### PR TITLE
Restore framing performance and separate mutation audits

### DIFF
--- a/.github/workflows/deep-validation.yml
+++ b/.github/workflows/deep-validation.yml
@@ -31,7 +31,6 @@ jobs:
       oracles: ${{ steps.matrix.outputs.oracles }}
       interop: ${{ steps.matrix.outputs.interop }}
       hardening: ${{ steps.matrix.outputs.hardening }}
-      mutation: ${{ steps.matrix.outputs.mutation }}
       tier: ${{ steps.matrix.outputs.tier }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
@@ -46,7 +45,6 @@ jobs:
           echo "oracles=$(python3 validation/run.py matrix --domain oracles --tier "$VALIDATION_TIER")" >> "$GITHUB_OUTPUT"
           echo "interop=$(python3 validation/run.py matrix --domain interop --tier "$VALIDATION_TIER")" >> "$GITHUB_OUTPUT"
           echo "hardening=$(python3 validation/run.py matrix --domain hardening --tier "$VALIDATION_TIER")" >> "$GITHUB_OUTPUT"
-          echo "mutation=$(python3 validation/run.py matrix --domain mutation --tier "$VALIDATION_TIER")" >> "$GITHUB_OUTPUT"
 
   kani:
     needs: inventory
@@ -173,57 +171,10 @@ jobs:
           path: validation-artifacts/results/${{ matrix.id }}/**
           retention-days: 7
 
-  mutation:
-    needs: inventory
-    runs-on: ubuntu-24.04
-    timeout-minutes: 240
-    strategy:
-      fail-fast: false
-      max-parallel: 4
-      matrix: ${{ fromJSON(needs.inventory.outputs.mutation) }}
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
-        with:
-          shared-key: deep-${{ matrix.id }}
-      - run: cargo install cargo-mutants --version 27.1.0 --locked
-      - run: python3 validation/run.py run --suite "${{ matrix.id }}" --expected-sha "$GITHUB_SHA"
-      - if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: deep-${{ matrix.id }}-${{ github.run_id }}
-          path: |
-            validation-artifacts/results/${{ matrix.id }}/**
-            validation-artifacts/mutation/${{ matrix.id }}/**
-          retention-days: 7
-
-  mutation-aggregate:
-    if: always()
-    needs: [inventory, mutation]
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-        with:
-          pattern: deep-mutation-analysis-shard-*-${{ github.run_id }}
-          path: validation-artifacts
-          merge-multiple: true
-      - run: python3 validation/run.py aggregate --domain mutation --tier "${{ needs.inventory.outputs.tier }}" --expected-sha "$GITHUB_SHA"
-      - if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: deep-mutation-union-${{ github.run_id }}
-          path: |
-            validation-artifacts/mutation/union/**
-            validation-artifacts/release-manifest.json
-          retention-days: 7
-
   deep-validation:
     name: Deep validation
     if: always()
-    needs: [kani, fuzz, oracles, interop, hardening, mutation-aggregate]
+    needs: [kani, fuzz, oracles, interop, hardening]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     env:
@@ -232,9 +183,8 @@ jobs:
       ORACLES_RESULT: ${{ needs.oracles.result }}
       INTEROP_RESULT: ${{ needs.interop.result }}
       HARDENING_RESULT: ${{ needs.hardening.result }}
-      MUTATION_RESULT: ${{ needs.mutation-aggregate.result }}
     steps:
       - run: |
-          for result in "$KANI_RESULT" "$FUZZ_RESULT" "$ORACLES_RESULT" "$INTEROP_RESULT" "$HARDENING_RESULT" "$MUTATION_RESULT"; do
+          for result in "$KANI_RESULT" "$FUZZ_RESULT" "$ORACLES_RESULT" "$INTEROP_RESULT" "$HARDENING_RESULT"; do
             test "$result" = success
           done

--- a/.github/workflows/mutation-audit.yml
+++ b/.github/workflows/mutation-audit.yml
@@ -1,0 +1,80 @@
+name: Mutation audit
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "47 10 2 * *"
+
+concurrency:
+  group: mutation-audit
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings --cfg aes_armv8"
+
+jobs:
+  inventory:
+    name: Mutation audit inventory
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      mutation: ${{ steps.matrix.outputs.mutation }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - id: matrix
+        run: |
+          python3 validation/run.py verify
+          echo "mutation=$(python3 validation/run.py matrix --domain mutation --tier scheduled)" >> "$GITHUB_OUTPUT"
+
+  mutation:
+    name: Mutation audit ${{ matrix.id }}
+    needs: inventory
+    runs-on: ubuntu-24.04
+    timeout-minutes: 240
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix: ${{ fromJSON(needs.inventory.outputs.mutation) }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        with:
+          shared-key: mutation-audit-${{ matrix.id }}
+      - run: cargo install cargo-mutants --version 27.1.0 --locked
+      - run: python3 validation/run.py run --suite "${{ matrix.id }}" --expected-sha "$GITHUB_SHA"
+      - if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: mutation-audit-${{ matrix.id }}-${{ github.run_id }}
+          path: |
+            validation-artifacts/results/${{ matrix.id }}/**
+            validation-artifacts/mutation/${{ matrix.id }}/**
+          retention-days: 7
+
+  aggregate:
+    name: Mutation audit report
+    if: always()
+    needs: [inventory, mutation]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          pattern: mutation-audit-mutation-analysis-shard-*-${{ github.run_id }}
+          path: validation-artifacts
+          merge-multiple: true
+      - run: python3 validation/run.py aggregate --domain mutation --tier scheduled --expected-sha "$GITHUB_SHA"
+      - if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: mutation-audit-union-${{ github.run_id }}
+          path: |
+            validation-artifacts/mutation/union/**
+            validation-artifacts/release-manifest.json
+          retention-days: 7

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -142,9 +142,6 @@ jobs:
         run: |
           cargo install kani-verifier --version 0.67.0 --locked
           cargo kani setup
-      - name: Prepare pinned cargo-mutants
-        if: matrix.domain == 'mutation'
-        run: cargo install cargo-mutants --version 27.1.0 --locked
       - name: Prepare dependency audit tools
         if: matrix.id == 'dependency-audit'
         run: |
@@ -188,4 +185,3 @@ jobs:
           retention-days: 30
           path: |
             validation-artifacts/release-manifest.json
-            validation-artifacts/mutation/union/**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,12 @@ corroborated evidence.
   practical.
 - Avoid mutating process-global environment in tests when dependencies can be
   passed explicitly.
+- Treat mutation testing as diagnostic evidence that requires human triage, not
+  as a score or a reason by itself to rewrite production code. Prefer a stronger
+  behavioral test when a mutant exposes a real gap.
+- Require an independent correctness or design rationale for every production
+  change prompted by mutation analysis. Performance-shaped code also requires
+  comparative measurement against the exact prior implementation.
 - Follow the repository's [verification ladder](docs/testing.md); report the
   exact commands and host coverage instead of implying unrun platforms passed.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -101,6 +101,11 @@ energy, profiling, and interpretation rules.
 
 ## Contribution expectations
 
+When a change touches the configured mutation surface, run a focused mutation
+audit over the changed owner before submission and report the command, findings,
+and human triage. Mutation findings do not replace the normal correctness,
+performance, and platform evidence for the change.
+
 Before handing off a change:
 
 1. Format the languages you touched.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -54,7 +54,7 @@ opaque success token. Counts come from the live manifest and native source
 discovery, so the output also gives an operator a quick orientation:
 
 ```text
-[verify] Suite policy: 96 total suites (49 pull-request, 92 release, 93 scheduled); IDs, tiers, platforms, toolchains, commands, timeouts, and artifact paths are valid.
+[verify] Suite policy: 99 total suites (49 pull-request, 91 release, 96 scheduled); IDs, tiers, platforms, toolchains, commands, timeouts, and artifact paths are valid.
 [verify] Cargo ownership: 39 manifests are registered, valid, and repository-owned; 22 unique workspace roots own formatting.
 [verify] Native discovery: 18 Kani proofs and 8 fuzz targets exactly match their source owners.
 [verify] Asset ownership: 69 oracle/interop/smoke assets are registered; 1 documented exemption is current; nothing is orphaned.
@@ -91,16 +91,16 @@ integrity, normal tests and lints, release contracts, product build lanes,
 deterministic stock-RNS comparisons, and essential interop.
 
 The `release` tier adds every proof, every bounded fuzz target, full oracle and
-utility interop coverage, sanitizers, Miri, mutation analysis, and the remaining
-shipping-platform evidence. A release result is acceptable only when all
-required results are bound to the exact candidate commit.
+utility interop coverage, sanitizers, Miri, and the remaining shipping-platform
+evidence. A release result is acceptable only when all required results are
+bound to the exact candidate commit.
 
 The `scheduled` tier is allowed to spend longer on fuzzing, diagnostics,
-coverage, unsafe inventory, and hardware/network simulations. Scheduled evidence
-is useful for maintenance but cannot substitute for exact-SHA release evidence.
-The physical Android runtime suite remains registered here and requires its
-device-qualified runner, but it is separate from hosted release readiness unless
-an Android application release explicitly places it in scope.
+coverage, mutation analysis, unsafe inventory, and hardware/network simulations.
+Scheduled evidence is useful for maintenance but cannot substitute for exact-SHA
+release evidence. The physical Android runtime suite remains registered here and
+requires its device-qualified runner, but it is separate from hosted release
+readiness unless an Android application release explicitly places it in scope.
 
 ## Stock-RNS environments
 
@@ -167,9 +167,16 @@ runner emits cargo-mutants results, fingerprints each missed or timed-out mutant
 from stable semantic fields, and compares them with
 `validation/mutation/triage.toml`.
 
+Mutation analysis is a scheduled or manually dispatched audit, not a
+pull-request or release gate. Its findings require human classification. A
+useful mutant normally results in a stronger behavioral test. Mutation output
+alone is not a reason to rewrite production code; any production change needs
+an independent correctness or design rationale, and performance-shaped code
+requires comparative measurement before acceptance.
+
 Every accepted survivor must have a lowercase SHA-256 fingerprint, a concrete
 reason, a reviewer, and an expiry date. New, changed, timed-out, stale, or expired
-entries fail the lane. An accepted cargo-mutants nonzero exit is therefore never
+entries fail the audit. An accepted cargo-mutants nonzero exit is therefore never
 an unreviewed blanket waiver: the checked-in triage must exactly match the
 current unresolved set and the baseline must have succeeded.
 
@@ -180,7 +187,13 @@ fail-closed aggregate. Every shipping lane is a dependency of that aggregate;
 GitHub's `skipped` result is not green.
 
 `.github/workflows/deep-validation.yml` runs Kani, fuzzing, full oracle/interop,
-mutation, sanitizer, and Miri jobs independently with `fail-fast: false`.
+sanitizer, and Miri jobs independently with `fail-fast: false`.
+
+`.github/workflows/mutation-audit.yml` runs the sharded mutation audit monthly
+or by explicit dispatch. Its findings remain outside ordinary CI and exact-SHA
+release qualification, and the workflow must not be configured as a required
+status check. A red audit means its evidence needs operator triage; it does not
+mean the product build or candidate failed.
 
 `.github/workflows/release-readiness.yml` is manually dispatched with a full
 commit SHA. It checks out that exact object, records evidence in each platform

--- a/prns-core/src/engine/deadlines/mod.rs
+++ b/prns-core/src/engine/deadlines/mod.rs
@@ -65,8 +65,11 @@ impl<S: StorageLayout> EngineState<S> {
         interfaces: AttachedInterfaces<'_>,
         sink: &mut impl FnMut(EngineReaction<'_>),
     ) -> WakeSchedules {
-        self.tunnels.expire(now);
-        self.departed_interfaces.evict_expired(now);
+        let tunnels_changed = self.tunnels.expire(now) != 0;
+        let departures_changed = self.departed_interfaces.evict_expired(now) != 0;
+        if tunnels_changed || departures_changed {
+            self.routing_table.invalidate_route_expiries();
+        }
         let warmth = WarmestOf(&self.tunnels, &self.departed_interfaces);
         let dirty = &mut self.dirty_interfaces;
         let scheduled_announces = &mut self.scheduled_announces;
@@ -118,8 +121,9 @@ impl<S: StorageLayout> EngineState<S> {
                 };
                 let source = entry.source_interface;
                 let directed_to = entry.directed_to;
-                let crosses_local_boundary =
-                    directed_to.is_none() && source.kind() == Some(InterfaceKind::LocalClient);
+                let crosses_local_boundary = source.kind() == Some(InterfaceKind::LocalClient)
+                    && directed_to
+                        .is_none_or(|target| target.kind() != Some(InterfaceKind::LocalClient));
                 let emit_hops = self
                     .protocol
                     .local_hop_count_override

--- a/prns-core/src/interfaces/framing/rns_serial_framing.rs
+++ b/prns-core/src/interfaces/framing/rns_serial_framing.rs
@@ -14,23 +14,60 @@ pub const fn max_encoded_len(payload_len: usize) -> usize {
     2 + 2 * payload_len
 }
 
+#[cfg(target_pointer_width = "64")]
 fn find_special(haystack: &[u8]) -> Option<usize> {
-    haystack
+    const ONES: u128 = 0x0101_0101_0101_0101_0101_0101_0101_0101;
+    const HIGHS: u128 = 0x8080_8080_8080_8080_8080_8080_8080_8080;
+    const FLAG_REP: u128 = (FLAG as u128) * ONES;
+    const ESC_REP: u128 = (ESC as u128) * ONES;
+
+    let (chunks, _) = haystack.as_chunks::<16>();
+    for (chunk_index, chunk) in chunks.iter().enumerate() {
+        let word = u128::from_le_bytes(*chunk);
+        let f = word ^ FLAG_REP;
+        let e = word ^ ESC_REP;
+        let marks = ((f.wrapping_sub(ONES) & !f) | (e.wrapping_sub(ONES) & !e)) & HIGHS;
+        if marks != 0 {
+            return Some(chunk_index * 16 + (marks.trailing_zeros() / 8) as usize);
+        }
+    }
+    let scanned = chunks.len() * 16;
+    haystack[scanned..]
         .iter()
         .position(|&byte| byte == FLAG || byte == ESC)
+        .map(|offset| scanned + offset)
+}
+
+#[cfg(not(target_pointer_width = "64"))]
+fn find_special(haystack: &[u8]) -> Option<usize> {
+    const ONES: u64 = 0x0101_0101_0101_0101;
+    const HIGHS: u64 = 0x8080_8080_8080_8080;
+    const FLAG_REP: u64 = (FLAG as u64) * ONES;
+    const ESC_REP: u64 = (ESC as u64) * ONES;
+
+    let (chunks, _) = haystack.as_chunks::<8>();
+    for (chunk_index, chunk) in chunks.iter().enumerate() {
+        let word = u64::from_le_bytes(*chunk);
+        let f = word ^ FLAG_REP;
+        let e = word ^ ESC_REP;
+        let marks = ((f.wrapping_sub(ONES) & !f) | (e.wrapping_sub(ONES) & !e)) & HIGHS;
+        if marks != 0 {
+            return Some(chunk_index * 8 + (marks.trailing_zeros() / 8) as usize);
+        }
+    }
+    let scanned = chunks.len() * 8;
+    haystack[scanned..]
+        .iter()
+        .position(|&byte| byte == FLAG || byte == ESC)
+        .map(|offset| scanned + offset)
 }
 
 pub fn encode(input: &[u8], output: &mut [u8]) -> Result<usize, EncodeError> {
-    let required = input.len()
-        + 2
-        + input
-            .iter()
-            .filter(|&&byte| byte == FLAG || byte == ESC)
-            .count();
-    if output.len() < required {
+    let mut written = 0usize;
+
+    if output.is_empty() {
         return Err(EncodeError::OutputTooSmall);
     }
-    let mut written = 0usize;
     output[written] = FLAG;
     written += 1;
 
@@ -38,21 +75,27 @@ pub fn encode(input: &[u8], output: &mut [u8]) -> Result<usize, EncodeError> {
     loop {
         let split = find_special(rest);
         let run = &rest[..split.unwrap_or(rest.len())];
+        if written + run.len() > output.len() {
+            return Err(EncodeError::OutputTooSmall);
+        }
         output[written..written + run.len()].copy_from_slice(run);
         written += run.len();
 
         let Some(pos) = split else {
             break;
         };
+        if written + 2 > output.len() {
+            return Err(EncodeError::OutputTooSmall);
+        }
         output[written] = ESC;
         output[written + 1] = rest[pos] ^ ESC_MASK;
         written += 2;
-        let Some((_, tail)) = rest[pos..].split_first() else {
-            break;
-        };
-        rest = tail;
+        rest = &rest[pos + 1..];
     }
 
+    if written >= output.len() {
+        return Err(EncodeError::OutputTooSmall);
+    }
     output[written] = FLAG;
     written += 1;
 
@@ -97,8 +140,28 @@ impl RnsSerialScanner {
         offset: &mut usize,
         sink: &mut dyn FrameSink,
     ) -> Result<Option<usize>, DecodeError> {
-        let remaining = input.get(*offset..).unwrap_or_default();
-        for &byte in remaining {
+        while *offset < input.len() {
+            if self.in_frame && !self.saw_escape {
+                let run_end =
+                    find_special(&input[*offset..]).map_or(input.len(), |at| *offset + at);
+                let run_len = run_end - *offset;
+                if run_len != 0 {
+                    let free = sink.free_capacity();
+                    if run_len <= free {
+                        let run = &input[*offset..run_end];
+                        let _ = sink.extend_from_slice(run);
+                        *offset = run_end;
+                        continue;
+                    }
+
+                    *offset += free + 1;
+                    sink.clear();
+                    self.reset();
+                    return Err(DecodeError::FrameTooBig);
+                }
+            }
+
+            let byte = input[*offset];
             *offset += 1;
             if self.feed_one_into(byte, sink)? {
                 return Ok(Some(sink.frame_len()));
@@ -187,15 +250,11 @@ impl<const FRAME_CAP: usize> RnsSerialDecoder<FRAME_CAP> {
 
     pub fn feed_slice(&mut self, input: &[u8], mut on_frame: impl FnMut(&[u8])) {
         let mut offset = 0;
-        while input.get(offset).is_some() {
-            let previous = offset;
+        while offset < input.len() {
             match self.feed_slice_next(input, &mut offset) {
                 Ok(Some(frame)) => on_frame(frame),
                 Ok(None) => break,
                 Err(DecodeError::FrameTooBig) => {}
-            }
-            if offset == previous {
-                break;
             }
         }
     }
@@ -218,9 +277,43 @@ impl<const FRAME_CAP: usize> RnsSerialDecoder<FRAME_CAP> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::interfaces::framing::FrameSinkError;
     use proptest::prelude::*;
 
     const TEST_FRAME_CAP: usize = 1024;
+
+    #[derive(Default)]
+    struct RecordingSink {
+        bytes: std::vec::Vec<u8>,
+        push_calls: usize,
+        extend_calls: usize,
+    }
+
+    impl FrameSink for RecordingSink {
+        fn clear(&mut self) {
+            self.bytes.clear();
+        }
+
+        fn frame_len(&self) -> usize {
+            self.bytes.len()
+        }
+
+        fn free_capacity(&self) -> usize {
+            usize::MAX - self.bytes.len()
+        }
+
+        fn push(&mut self, byte: u8) -> Result<(), FrameSinkError> {
+            self.push_calls += 1;
+            self.bytes.push(byte);
+            Ok(())
+        }
+
+        fn extend_from_slice(&mut self, run: &[u8]) -> Result<(), FrameSinkError> {
+            self.extend_calls += 1;
+            self.bytes.extend_from_slice(run);
+            Ok(())
+        }
+    }
 
     fn decode_all(bytes: &[u8]) -> std::vec::Vec<std::vec::Vec<u8>> {
         let mut decoder: RnsSerialDecoder<TEST_FRAME_CAP> = RnsSerialDecoder::new();
@@ -272,9 +365,9 @@ mod tests {
         assert_eq!(find_special(&[0x01, 0x02, 0x03]), None);
         assert_eq!(find_special(&[0x01, FLAG, 0x03]), Some(1));
         assert_eq!(find_special(&[0x01, 0x02, ESC]), Some(2));
-        let mut in_second_word = [0x00u8; 20];
-        in_second_word[13] = FLAG;
-        assert_eq!(find_special(&in_second_word), Some(13));
+        let mut in_second_word = [0x00u8; 40];
+        in_second_word[21] = FLAG;
+        assert_eq!(find_special(&in_second_word), Some(21));
         let mut only_in_remainder = [0x11u8; 19];
         only_in_remainder[17] = ESC;
         assert_eq!(find_special(&only_in_remainder), Some(17));
@@ -317,11 +410,13 @@ mod tests {
             Err(EncodeError::OutputTooSmall)
         );
 
-        let mut escaped_tiny = [0u8; 3];
-        assert_eq!(
-            encode(&[FLAG], &mut escaped_tiny),
-            Err(EncodeError::OutputTooSmall),
-        );
+        for output_len in 0..max_encoded_len(1) {
+            let mut escaped_tiny = std::vec![0u8; output_len];
+            assert_eq!(
+                encode(&[FLAG], &mut escaped_tiny),
+                Err(EncodeError::OutputTooSmall),
+            );
+        }
     }
 
     #[test]
@@ -348,6 +443,33 @@ mod tests {
         let bytes = [FLAG, 0x01, 0x02, 0x03, FLAG];
         let frames = decode_all(&bytes);
         assert_eq!(frames, std::vec![std::vec![0x01, 0x02, 0x03]]);
+    }
+
+    #[test]
+    fn slice_scanner_bulk_copies_plain_runs() {
+        let payload = [0x35; 64];
+        let mut stream = [0u8; 66];
+        stream[0] = FLAG;
+        stream[1..65].copy_from_slice(&payload);
+        stream[65] = FLAG;
+
+        let mut scanner = RnsSerialScanner::new();
+        let mut sink = RecordingSink::default();
+        let mut offset = 0;
+        let frame_len = scanner
+            .next_frame_into(&stream, &mut offset, &mut sink)
+            .unwrap();
+
+        assert_eq!(
+            (
+                frame_len,
+                offset,
+                sink.bytes.as_slice(),
+                sink.push_calls,
+                sink.extend_calls,
+            ),
+            (Some(64), stream.len(), payload.as_slice(), 0, 1),
+        );
     }
 
     #[test]

--- a/prns-core/src/interfaces/packet/ifac.rs
+++ b/prns-core/src/interfaces/packet/ifac.rs
@@ -128,7 +128,7 @@ impl IfacContext {
         let ifac = &signature.0[SIGNATURE_BYTE_LEN - size..];
         let ifac_end = IFAC_START + size;
 
-        out[HEADER_FLAGS_INDEX] = clean[HEADER_FLAGS_INDEX];
+        out[HEADER_FLAGS_INDEX] = clean[HEADER_FLAGS_INDEX] | IFAC_FLAG;
         out[HEADER_HOPS_INDEX] = clean[HEADER_HOPS_INDEX];
         out[IFAC_START..ifac_end].copy_from_slice(ifac);
         out[ifac_end..total].copy_from_slice(&clean[IFAC_START..]);

--- a/prns-core/src/interfaces/shared_instance/rns_rpc/request.rs
+++ b/prns-core/src/interfaces/shared_instance/rns_rpc/request.rs
@@ -80,9 +80,15 @@ impl RnsNumber {
             Self::Float(seconds) if *seconds == 0.0 || seconds.is_nan() => {
                 BlackholeExpiry::Indefinite
             }
+            Self::Float(seconds) if *seconds < 0.0 => BlackholeExpiry::At(InstantMillis(0)),
             Self::Float(seconds) => {
                 let millis = *seconds * 1_000.0;
-                BlackholeExpiry::At(InstantMillis(millis as u64))
+                let deadline = if !millis.is_finite() || millis >= u64::MAX as f64 {
+                    u64::MAX
+                } else {
+                    millis as u64
+                };
+                BlackholeExpiry::At(InstantMillis(deadline))
             }
         }
     }
@@ -438,7 +444,7 @@ impl PickleRequestEncoder {
     }
 
     fn signed(&mut self, value: i64) {
-        self.long(value.to_le_bytes(), true);
+        self.long(value.to_le_bytes(), value < 0);
     }
 
     fn unsigned(&mut self, value: u64) {
@@ -447,12 +453,13 @@ impl PickleRequestEncoder {
 
     fn long(&mut self, raw: [u8; 8], negative: bool) {
         let extension = if negative { 0xff } else { 0x00 };
-        let length = (2..=raw.len())
-            .rev()
-            .find(|&length| {
-                raw[length - 1] != extension || (raw[length - 2] & 0x80 != 0) != negative
-            })
-            .unwrap_or(1);
+        let mut length = raw.len();
+        while length > 1
+            && raw[length - 1] == extension
+            && (raw[length - 2] & 0x80 != 0) == negative
+        {
+            length -= 1;
+        }
         let length_position = self.bytes.len() + 1;
         self.bytes.extend_from_slice(&[0x8a, length as u8]);
         self.bytes.extend_from_slice(&raw[..length]);

--- a/prns-core/src/routing/announce/held/impls/soa.rs
+++ b/prns-core/src/routing/announce/held/impls/soa.rs
@@ -170,14 +170,13 @@ impl<C: SoaColumns> HeldAnnounceTable for SoaHeldAnnounceTable<C> {
             return;
         };
         let iface_idx = idx as u16;
-        for i in (0..self.columns.len()).rev() {
+        let mut i = 0;
+        while i < self.columns.len() {
             if self.columns.probe()[i].iface_idx == iface_idx {
-                let handle = self.columns.cold()[i].entry.maybe_app_data_handle;
-                let before = self.columns.len();
+                on_removed(self.columns.cold()[i].entry.maybe_app_data_handle);
                 self.columns.swap_remove(i);
-                if self.columns.len() < before {
-                    on_removed(handle);
-                }
+            } else {
+                i += 1;
             }
         }
         self.columns.dir_mut()[idx] = None;

--- a/prns-core/src/routing/announce/schedule/impls/fixed.rs
+++ b/prns-core/src/routing/announce/schedule/impls/fixed.rs
@@ -167,17 +167,16 @@ impl<const MAX_PENDING: usize> FixedScheduledAnnounceQueue<MAX_PENDING> {
     }
 
     fn restore_orphaned_held(&mut self) {
-        let mut still_held = Vec::new();
-        while let Some(flood) = self.held.pop() {
-            let destination = flood.destination;
+        let mut j = 0;
+        while j < self.held.len() {
+            let destination = self.held[j].destination;
             if self.active_directed_index(destination).is_none() {
+                let flood = self.held.swap_remove(j);
                 let _ = self.push_row(flood);
             } else {
-                let _ = still_held.push(flood);
+                j += 1;
             }
         }
-        still_held.as_mut_slice().reverse();
-        self.held = still_held;
     }
 
     pub fn schedule(
@@ -275,10 +274,13 @@ impl<const MAX_PENDING: usize> FixedScheduledAnnounceQueue<MAX_PENDING> {
 
     pub fn drain_due(&mut self, now: InstantMillis) -> usize {
         let mut removed = 0;
-        for i in (0..self.due_at.len()).rev() {
+        let mut i = 0;
+        while i < self.due_at.len() {
             if self.due_at[i] <= now {
                 self.swap_remove_row(i);
                 removed += 1;
+            } else {
+                i += 1;
             }
         }
         self.refresh_earliest();
@@ -365,7 +367,8 @@ impl<const MAX_PENDING: usize> ScheduledAnnounceQueue for FixedScheduledAnnounce
         max_our_emission_count: u8,
     ) -> usize {
         let mut completed = 0;
-        for i in (0..self.due_at.len()).rev() {
+        let mut i = 0;
+        while i < self.due_at.len() {
             if self.due_at[i].0 <= now.0 {
                 if self.directed_to[i].is_some() && self.held_contains(self.destination[i]) {
                     self.swap_remove_row(i);
@@ -381,6 +384,7 @@ impl<const MAX_PENDING: usize> ScheduledAnnounceQueue for FixedScheduledAnnounce
                 }
                 self.due_at[i] = InstantMillis(now.0.saturating_add(interval_ms));
             }
+            i += 1;
         }
         self.restore_orphaned_held();
         self.refresh_earliest();

--- a/prns-core/src/routing/links/request.rs
+++ b/prns-core/src/routing/links/request.rs
@@ -21,12 +21,12 @@ use crate::routing::links::{LinkId, LinkKey};
 use crate::routing::request_handlers::RequestPathHash;
 use crate::storage::StorageLayout;
 use crate::units::RttMillis;
-#[cfg(test)]
-use crate::wire::DestinationHash;
 use crate::wire::{
     ContextFlag, DestinationType, IfacFlag, PacketType, PropagationType, WireContext,
-    WirePacketHeader, BROADCAST_MTU, TRUNCATED_HASH_BYTE_LEN,
+    WirePacketHeader, TRUNCATED_HASH_BYTE_LEN,
 };
+#[cfg(test)]
+use crate::wire::{DestinationHash, BROADCAST_MTU};
 
 /// RNS 1.4.0 `Resource.RESPONSE_MAX_GRACE_TIME` (10 s) × 1.125, the flat term in a request's default timeout: `rtt × traffic_timeout_factor + 11.25 s`.
 pub const REQUEST_RESPONSE_GRACE_MS: u64 = 11_250;
@@ -38,7 +38,15 @@ pub const REQUEST_WIRE_OVERHEAD: usize = 1 + 9 + 2 + TRUNCATED_HASH_BYTE_LEN;
 pub const RESPONSE_WIRE_OVERHEAD: usize = 1 + 2 + TRUNCATED_HASH_BYTE_LEN;
 
 /// Both verbs' data caps derive from the single-packet link MDU, so the two sides land on the same figure by construction.
-pub const WRAPPED_PLAINTEXT_CAP: usize = link_mdu(BROADCAST_MTU);
+pub const WRAPPED_PLAINTEXT_CAP: usize = {
+    let request = REQUEST_WIRE_OVERHEAD + MAX_SEND_REQUEST_DATA_LEN;
+    let response = RESPONSE_WIRE_OVERHEAD + MAX_RESPOND_DATA_LEN;
+    if request > response {
+        request
+    } else {
+        response
+    }
+};
 
 const FIXARRAY_3: u8 = 0x93;
 const FIXARRAY_2: u8 = 0x92;

--- a/validation/BASELINE.md
+++ b/validation/BASELINE.md
@@ -18,5 +18,6 @@ Post-sync product checks did not expose a Hopspot identity-custody regression:
 the Hopspot core suite, root workspace, configuration suite, daemon workspaces,
 release contracts, deterministic oracle suite, Kani matrix, and bounded fuzz
 matrix all passed locally. Linux live interop, Android hardware, sanitizer/Miri,
-fresh mutation triage, and hosted exact-SHA qualification remain evidence that
-must come from their registered qualified runners.
+and hosted exact-SHA qualification remain evidence that must come from their
+registered qualified runners. Fresh mutation triage remains separate scheduled
+audit evidence.

--- a/validation/manifest.toml
+++ b/validation/manifest.toml
@@ -422,7 +422,7 @@ artifacts = "validation-artifacts/results/fuzz-build"
 [[suite]]
 id = "mutation-analysis"
 domain = "mutation"
-tiers = ["release", "scheduled"]
+tiers = ["scheduled"]
 platform = "linux"
 toolchain = "stable"
 timeout_seconds = 14400

--- a/validation/release/workflow-contracts.py
+++ b/validation/release/workflow-contracts.py
@@ -15,7 +15,14 @@ ACTION_PATTERN = re.compile(r"^\s*(?:-\s*)?uses:\s*([^\s#]+)", re.MULTILINE)
 SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 JOB_PATTERN = re.compile(r"(?m)^  ([A-Za-z0-9_-]+):\n")
 AUTOMATIC_WORKFLOWS = frozenset(
-    {"ci.yml", "deep-validation.yml", "hardening.yml", "host-sdks.yml", "napi.yml"}
+    {
+        "ci.yml",
+        "deep-validation.yml",
+        "hardening.yml",
+        "host-sdks.yml",
+        "mutation-audit.yml",
+        "napi.yml",
+    }
 )
 
 
@@ -189,8 +196,21 @@ def validate() -> list[str]:
         errors.append(
             "release-readiness.yml does not provision embedded Rust targets for ESP suites"
         )
-    if "validation-artifacts/mutation/union/**" not in readiness:
-        errors.append("release-readiness.yml does not retain the merged mutation evidence")
+    for mutation_fragment in (
+        "matrix.domain == 'mutation'",
+        "cargo-mutants",
+        "validation-artifacts/mutation/union/**",
+    ):
+        if mutation_fragment in readiness:
+            errors.append(
+                "release-readiness.yml must not place mutation analysis on the release "
+                f"critical path: {mutation_fragment!r}"
+            )
+        if mutation_fragment in ci:
+            errors.append(
+                "ci.yml must leave mutation analysis to mutation-audit.yml: "
+                f"{mutation_fragment!r}"
+            )
     for native_package in ("libdbus-1-dev", "pkg-config"):
         if native_package not in readiness:
             errors.append(
@@ -282,19 +302,48 @@ def validate() -> list[str]:
     ):
         if resource_gate not in deep:
             errors.append(f"deep-validation.yml is missing resource gate {resource_gate!r}")
+    for mutation_fragment in (
+        "matrix --domain mutation",
+        "mutation-aggregate",
+        "MUTATION_RESULT",
+    ):
+        if mutation_fragment in deep:
+            errors.append(
+                "deep-validation.yml must leave mutation analysis to mutation-audit.yml: "
+                f"{mutation_fragment!r}"
+            )
+
+    mutation_audit = (
+        ROOT / ".github" / "workflows" / "mutation-audit.yml"
+    ).read_text(encoding="utf-8")
+    for resource_gate in (
+        "workflow_dispatch:",
+        'cron: "47 10 2 * *"',
+        "group: mutation-audit",
+        "cancel-in-progress: false",
+    ):
+        if resource_gate not in mutation_audit:
+            errors.append(
+                f"mutation-audit.yml is missing resource gate {resource_gate!r}"
+            )
+    for forbidden_trigger in ("\n  pull_request:", "\n  push:"):
+        if forbidden_trigger in mutation_audit:
+            errors.append(
+                "mutation-audit.yml must remain manual or scheduled: "
+                f"{forbidden_trigger.strip()!r}"
+            )
     for mutation_gate in (
         "mutation: ${{ steps.matrix.outputs.mutation }}",
-        'mutation=$(python3 validation/run.py matrix --domain mutation --tier "$VALIDATION_TIER")',
+        "mutation=$(python3 validation/run.py matrix --domain mutation --tier scheduled)",
         "matrix: ${{ fromJSON(needs.inventory.outputs.mutation) }}",
-        "name: deep-${{ matrix.id }}-${{ github.run_id }}",
+        "name: mutation-audit-${{ matrix.id }}-${{ github.run_id }}",
         "validation-artifacts/mutation/${{ matrix.id }}/**",
-        "pattern: deep-mutation-analysis-shard-*-${{ github.run_id }}",
-        'aggregate --domain mutation --tier "${{ needs.inventory.outputs.tier }}" --expected-sha "$GITHUB_SHA"',
-        "MUTATION_RESULT: ${{ needs.mutation-aggregate.result }}",
+        "pattern: mutation-audit-mutation-analysis-shard-*-${{ github.run_id }}",
+        'aggregate --domain mutation --tier scheduled --expected-sha "$GITHUB_SHA"',
     ):
-        if mutation_gate not in deep:
+        if mutation_gate not in mutation_audit:
             errors.append(
-                f"deep-validation.yml is missing mutation shard gate {mutation_gate!r}"
+                f"mutation-audit.yml is missing mutation evidence gate {mutation_gate!r}"
             )
 
     hardening = (ROOT / ".github" / "workflows" / "hardening.yml").read_text(

--- a/validation/tests/test_runner.py
+++ b/validation/tests/test_runner.py
@@ -168,7 +168,15 @@ class RegistryTests(unittest.TestCase):
         self.assertTrue(any("must derive shard arguments" in error for error in errors))
 
     def test_mutation_shards_are_round_robin_and_artifact_unique(self) -> None:
-        suites = runner.selected_suites(self.manifest, [], "mutation", "release")
+        self.assertEqual(
+            runner.selected_suites(self.manifest, [], "mutation", "release"),
+            [],
+        )
+        self.assertEqual(
+            runner.selected_suites(self.manifest, [], "mutation", "pr"),
+            [],
+        )
+        suites = runner.selected_suites(self.manifest, [], "mutation", "scheduled")
         self.assertEqual(len(suites), 4)
         self.assertEqual(len({suite["id"] for suite in suites}), 4)
         self.assertEqual(len({suite["artifacts"] for suite in suites}), 4)


### PR DESCRIPTION
## Summary

- restore the pre-mutation SWAR framing scanner, single-pass encoder, and bulk-copy decoder path
- restore other mutation-only production rewrites that lacked an independent correctness or design reason, while retaining the useful behavioral tests
- move mutation analysis out of pull-request, deep-validation, and exact-SHA release gates into a dedicated monthly/manual audit
- encode the human-triage and performance-measurement boundary in contribution guidance and workflow contracts

## Root cause

Mutation findings were placed on the release critical path. That turned a diagnostic tool into a completion objective and encouraged production rewrites whose only rationale was killing survivors. The framing rewrite replaced a vectorized scanner and bulk-copy decode path with repeated bytewise work and an encode preflight scan.

## Performance evidence

A pinned-core, fat-LTO, `target-cpu=native` A/B compared exact pre-mutation commit `7f3a98b352003016245d0ce1463806d7db556401`, current main `eaf7d675a8b7eae0c42a1a4e3ea57634954c65a2`, and the restored branch across seven payload shapes, encode/decode, eleven counterbalanced rounds, and approximately 100 ms per sample.

The current-main rewrite raised CPU cost by 2.52–4.44x for encode and 3.21–9.28x for decode on ordinary 64 B–128 KiB payloads. The restored implementation was within -0.83% to +0.92% of the exact pre-mutation baseline across all fourteen measurements with overlapping IQRs. The production portion of the framing owner is byte-identical to the pre-mutation implementation and hashes to `eb9f4f1bcc86469b791c34039e8afb88be3d4634616722b09aca87642027724c`.

## Mutation policy

Mutation analysis is now selected only by the `scheduled` tier. `.github/workflows/mutation-audit.yml` runs the four shards monthly or by manual dispatch and retains review evidence. Workflow contracts forbid adding pull-request or push triggers to that workflow and forbid mutation setup/results in ordinary CI, deep validation, or release readiness.

A focused framing diagnostic demonstrated why human classification is required: it produced cfg-disabled mutants, behaviorally equivalent mutants, performance-only mutants, progress violations reported as timeouts, and one real undersized-buffer test gap. The real gap received stronger behavioral coverage; no automatic survivor approvals were added.

## Validation

Linux x86_64, Rust/Cargo 1.96.0:

- `cargo test --workspace --locked`
- `cargo test --locked -p prns-core` (1,398 passed, 3 ignored)
- framing owner tests (22 passed)
- focused cargo-mutants rerun (2/2 caught)
- `cargo clippy --locked -p prns-core --all-targets -- -D warnings`
- `bash validation/hygiene/fmt-docs.sh`
- `python3 validation/release/workflow-contracts.py`
- `python3 -m unittest validation.tests.test_runner -v` (32 passed)
- tooling contract suite under Python 3.13 (122 passed)
- `python3 validation/run.py verify`
- `./tools/prns verify`
- `actionlint .github/workflows/*.yml`
- clean diff and tracked-worktree checks

No hosted readiness or release action from the prior main SHA is accepted as evidence for this branch. A new exact-main readiness run belongs after review, CI, and merge.
