### PR TITLE
Repair exact-main readiness failures and raise release parallelism

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 260
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 20
       matrix: ${{ fromJSON(needs.inventory.outputs.matrix) }}
     defaults:
       run:
@@ -84,7 +84,7 @@ jobs:
           rustup toolchain install "$nightly" --profile minimal
       - name: Prepare embedded targets
         if: matrix.group == 'embedded' || matrix.group == 'esp'
-        run: rustup target add riscv32imac-unknown-none-elf thumbv7em-none-eabihf
+        run: rustup target add --toolchain 1.96.0 riscv32imac-unknown-none-elf thumbv7em-none-eabihf
       - name: Prepare Linux native development packages
         if: runner.os == 'Linux' && matrix.platform != 'android-device'
         run: |

--- a/validation/integration/tests/runtime_persistence.rs
+++ b/validation/integration/tests/runtime_persistence.rs
@@ -17,8 +17,19 @@ use personal_rns::runtime::{
 };
 use personal_rns::storage::GrowableHeap;
 use personal_rns::tcp::{TcpClientInterface, TcpServer};
+use personal_rns::wire::DestinationHash;
+use tokio::sync::mpsc::UnboundedReceiver;
 
 const BITRATE: BitrateBps = BitrateBps::guess(1_000_000);
+const ANNOUNCE_DELIVERY_DEADLINE: Duration = Duration::from_secs(5);
+const ANNOUNCE_RETRY_INTERVAL: Duration = Duration::from_millis(200);
+
+#[derive(Debug)]
+enum AnnounceDeliveryFailure {
+    Deadline,
+    ChannelClosed,
+    UnsuccessfulSettlement,
+}
 
 fn secret(byte: u8) -> Zeroizing<[u8; IDENTITY_SECRET_KEY_LEN]> {
     Zeroizing::new([byte; IDENTITY_SECRET_KEY_LEN])
@@ -36,6 +47,47 @@ fn single(identity: Zeroizing<[u8; IDENTITY_SECRET_KEY_LEN]>) -> PreConfiguredDe
         ratchet: RatchetPolicy::NoRatchets,
         request_handlers: RequestHandlerRegistration::None,
     }
+}
+
+async fn hear_announced_destination(
+    commands: &PrnsNodeHandle,
+    heard_rx: &mut UnboundedReceiver<DestinationHash>,
+    announce: &AnnounceNow,
+) -> Result<(), AnnounceDeliveryFailure> {
+    let deadline = tokio::time::Instant::now() + ANNOUNCE_DELIVERY_DEADLINE;
+    let mut retry_at = tokio::time::Instant::now() + ANNOUNCE_RETRY_INTERVAL;
+    loop {
+        tokio::select! {
+            biased;
+            () = tokio::time::sleep_until(deadline) => {
+                return Err(AnnounceDeliveryFailure::Deadline);
+            }
+            heard = heard_rx.recv() => {
+                let Some(heard) = heard else {
+                    return Err(AnnounceDeliveryFailure::ChannelClosed);
+                };
+                if heard == announce.destination {
+                    break;
+                }
+            }
+            () = tokio::time::sleep_until(retry_at) => {
+                match tokio::time::timeout_at(
+                    deadline,
+                    commands.announce_now(announce.clone()),
+                )
+                .await
+                {
+                    Ok(Ok(())) => {}
+                    Ok(Err(_)) => {
+                        return Err(AnnounceDeliveryFailure::UnsuccessfulSettlement);
+                    }
+                    Err(_) => return Err(AnnounceDeliveryFailure::Deadline),
+                }
+                retry_at = tokio::time::Instant::now() + ANNOUNCE_RETRY_INTERVAL;
+            }
+        }
+    }
+    Ok(())
 }
 
 struct StoreDir {
@@ -456,36 +508,19 @@ async fn a_quiet_flush_skips_unchanged_regions_and_a_change_rewrites() {
     });
     let commands_b = node_b.handle();
 
-    let announce_first = commands_a.clone();
-    let announcer = tokio::spawn(async move {
-        let mut ticker = tokio::time::interval(Duration::from_millis(200));
-        loop {
-            ticker.tick().await;
-            if announce_first
-                .issue(EngineCommand::AnnounceNow(AnnounceNow {
-                    destination: dest_a1,
-                    target: AnnounceTarget::AllInterfaces,
-                    app_data: AnnounceAppData::Registered,
-                }))
-                .is_none()
-            {
-                break;
-            }
-        }
-    });
-
     let choreography = async {
-        loop {
-            let heard = tokio::time::timeout(Duration::from_secs(5), heard_rx.recv())
-                .await
-                .expect("B hears the first announce within 5s")
-                .expect("the announce channel stays open");
-            if heard == dest_a1 {
-                break;
-            }
-        }
-        announcer.abort();
-        tokio::time::sleep(Duration::from_millis(300)).await;
+        let first_announce = AnnounceNow {
+            destination: dest_a1,
+            target: AnnounceTarget::AllInterfaces,
+            app_data: AnnounceAppData::Registered,
+        };
+        commands_a
+            .announce_now(first_announce.clone())
+            .await
+            .expect("the first announce settles successfully");
+        hear_announced_destination(&commands_a, &mut heard_rx, &first_announce)
+            .await
+            .expect("B hears the first announce within 5s");
 
         let mut mark = FlushMark::default();
         let first = commands_b
@@ -509,55 +544,27 @@ async fn a_quiet_flush_skips_unchanged_regions_and_a_change_rewrites() {
         assert_eq!(quiet.destination_identities, RegionFlush::UnchangedSkipped);
         assert!(quiet.high_water >= first.high_water);
 
-        let second_announce = commands_a
-            .issue(EngineCommand::AnnounceNow(AnnounceNow {
-                destination: dest_a2,
-                target: AnnounceTarget::AllInterfaces,
-                app_data: AnnounceAppData::Registered,
-            }))
+        let second_announce = AnnounceNow {
+            destination: dest_a2,
+            target: AnnounceTarget::AllInterfaces,
+            app_data: AnnounceAppData::Registered,
+        };
+        let second_announce_id = commands_a
+            .issue(EngineCommand::AnnounceNow(second_announce.clone()))
             .expect("node A accepts the second announce");
         loop {
             let (id, settlement) = settled_rx
                 .recv()
                 .await
                 .expect("node A's settlement channel stays open");
-            if id == second_announce {
+            if id == second_announce_id {
                 assert_eq!(settlement, Settlement::AnnounceNow(Ok(())));
                 break;
             }
         }
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-        let mut retry = tokio::time::interval_at(
-            tokio::time::Instant::now() + Duration::from_millis(200),
-            Duration::from_millis(200),
-        );
-        loop {
-            tokio::select! {
-                biased;
-                () = tokio::time::sleep_until(deadline) => {
-                    panic!("B hears the second announce within 5s");
-                }
-                heard = heard_rx.recv() => {
-                    let heard = heard.expect("the announce channel stays open");
-                    if heard == dest_a2 {
-                        break;
-                    }
-                }
-                _ = retry.tick() => {
-                    tokio::time::timeout_at(
-                        deadline,
-                        commands_a.announce_now(AnnounceNow {
-                            destination: dest_a2,
-                            target: AnnounceTarget::AllInterfaces,
-                            app_data: AnnounceAppData::Registered,
-                        }),
-                    )
-                    .await
-                    .expect("the second announce retry settles within 5s")
-                    .expect("the second announce retry settles successfully");
-                }
-            }
-        }
+        hear_announced_destination(&commands_a, &mut heard_rx, &second_announce)
+            .await
+            .expect("B hears the second announce within 5s");
 
         let changed = commands_b
             .flush_changed_to_store(&mut store, &mut mark)

--- a/validation/release/workflow-contracts.py
+++ b/validation/release/workflow-contracts.py
@@ -24,6 +24,8 @@ AUTOMATIC_WORKFLOWS = frozenset(
         "napi.yml",
     }
 )
+STANDARD_MATRIX_PARALLELISM_LIMIT = 4
+MATRIX_PARALLELISM_LIMITS = {"release-readiness.yml": 20}
 
 
 def workflow_jobs(text: str) -> tuple[tuple[str, str], ...]:
@@ -47,6 +49,9 @@ def validate_resource_bounds(workflow: Path, text: str) -> list[str]:
     errors: list[str] = []
     relative = workflow.relative_to(ROOT)
     artifact_limit = 7 if workflow.name in AUTOMATIC_WORKFLOWS else 30
+    parallelism_limit = MATRIX_PARALLELISM_LIMITS.get(
+        workflow.name, STANDARD_MATRIX_PARALLELISM_LIMIT
+    )
     for job_name, block in workflow_jobs(text):
         if re.search(r"(?m)^    runs-on:", block):
             timeout = re.search(r"(?m)^    timeout-minutes:\s*(\d+)\s*$", block)
@@ -64,8 +69,18 @@ def validate_resource_bounds(workflow: Path, text: str) -> list[str]:
             )
             if parallel is None:
                 errors.append(f"{relative}: {job_name} has an unbounded matrix")
-            elif not 1 <= int(parallel.group(1)) <= 4:
-                errors.append(f"{relative}: {job_name} exceeds four parallel matrix jobs")
+            elif not 1 <= int(parallel.group(1)) <= parallelism_limit:
+                errors.append(
+                    f"{relative}: {job_name} exceeds {parallelism_limit} parallel matrix jobs"
+                )
+            elif (
+                workflow.name in MATRIX_PARALLELISM_LIMITS
+                and int(parallel.group(1)) != parallelism_limit
+            ):
+                errors.append(
+                    f"{relative}: {job_name} must use all {parallelism_limit} "
+                    "parallel matrix jobs"
+                )
 
         steps = re.split(r"(?m)(?=^      - )", block)
         for step in steps:
@@ -188,7 +203,8 @@ def validate() -> list[str]:
     embedded_target_step = re.search(
         r"name: Prepare embedded targets\n"
         r"        if: matrix\.group == 'embedded' \|\| matrix\.group == 'esp'\n"
-        r"        run: rustup target add riscv32imac-unknown-none-elf "
+        r"        run: rustup target add --toolchain 1\.96\.0 "
+        r"riscv32imac-unknown-none-elf "
         r"thumbv7em-none-eabihf",
         qualify,
     )


### PR DESCRIPTION
## What changed

- Reworked the persistence delivery choreography so both announce stages use settled typed retries on a fixed five-second deadline with non-burst 200 ms spacing.
- Pinned embedded target installation to Rust 1.96.0 so the T-Echo target is installed into the same toolchain used for its build.
- Raised only the exact-SHA release-readiness matrix from 4 to 20 concurrent jobs and updated the workflow contract to enforce that value while ordinary CI remains capped at 4.

## Why

Release-readiness run [30297465264](https://github.com/KenAKAFrosty/Prns/actions/runs/30297465264) had two substantive failures:

- `sanitizer-thread` timed out waiting for the second persistence announce after the first-stage unawaited interval producer could leave a burst backlog under TSAN scheduling.
- `shipping-firmware` built all three ESP artifacts but T-Echo failed because `thumbv7em-none-eabihf` had been installed into the repository-default `stable` toolchain rather than pinned Rust 1.96.0.

The aggregate failure was downstream of those two jobs.

## Impact

No engine, runtime, firmware, CLI, manifest, or consumer-facing API changes. The persistence edit is test choreography only. Embedded linker configuration remains owned by target configuration. The concurrency increase applies only to manually dispatched exact-SHA readiness runs.

## Local validation

- Persistence test normally: pass
- Persistence test under pinned TSAN: 10/10 pass
- Complete `sanitizers.sh thread`: pass (`SANITIZER_GATE_OK`)
- Workspace tests: pass
- Workspace clippy, all targets, `-D warnings`: pass
- `hopspot-flash`: 69 unit + 2 CLI tests pass
- Workflow contracts and `actionlint`: pass
- Validation self-tests: 32 pass
- Tools self-tests under Python 3.12: 122 pass
- `validation/run.py verify`: pass
- `./tools/prns verify`: pass
- Shipping firmware: Heltec V4, T-Beam Supreme, XIAO ESP32-C6, and T-Echo pass (`SHIPPING_FIRMWARE_GATE_OK`)
- Exact identities verified: Rust 1.96.0, ESP Rust 1.95.0.0, crosstool-NG 15.2.0_20250920, cargo-binstall 1.21.0, Dioxus 0.7.5
- Repository push hygiene gate: pass

Local coverage is Linux x86_64. Hosted PR CI remains authoritative for the configured Linux, Windows, macOS, WebAssembly, Android, and cross-target coverage.
