### PR TITLE
Pin release-readiness qualification to Rust 1.96

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -53,6 +53,8 @@ jobs:
     name: ${{ matrix.id }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 260
+    env:
+      RUSTUP_TOOLCHAIN: 1.96.0
     strategy:
       fail-fast: false
       max-parallel: 20

--- a/validation/release/workflow-contracts.py
+++ b/validation/release/workflow-contracts.py
@@ -200,6 +200,15 @@ def validate() -> list[str]:
             "release-readiness.yml does not provision exact cargo-binstall and Dioxus "
             "tools for both web and ESP suites"
         )
+    qualify_toolchain = re.search(
+        r"(?m)^    env:\n      RUSTUP_TOOLCHAIN: 1\.96\.0$",
+        qualify,
+    )
+    if qualify_toolchain is None:
+        errors.append(
+            "release-readiness.yml does not force the exact Rust toolchain for "
+            "qualification suites"
+        )
     embedded_target_step = re.search(
         r"name: Prepare embedded targets\n"
         r"        if: matrix\.group == 'embedded' \|\| matrix\.group == 'esp'\n"


### PR DESCRIPTION
## Failure

Readiness run 30312468574 installed embedded targets into Rust 1.96.0 but ran qualification Cargo commands with stable Rust 1.97.1, so embedded-builds could not find core for thumbv7em-none-eabihf.

## Fix

- force RUSTUP_TOOLCHAIN 1.96.0 at the qualification-job boundary
- fail closed in workflow contracts if that exact pin is removed
- no production or firmware source changes

## Verification

- exact Rust 1.96 embedded gate: pass
- release workflow contracts: 122 tests pass
- validation self-tests: 32 tests pass
- validation registry and tooling registry verification: pass
- formatting and documentation gate: pass