### PR TITLE
Fix cargo-binstall release version probe

### DIFF
--- a/tools/release/flasher_build_metadata.py
+++ b/tools/release/flasher_build_metadata.py
@@ -67,7 +67,7 @@ def resolved_tools(output=command_output) -> dict[str, str]:
         "node": output("node", "--version"),
         "npm": output("npm", "--version"),
         "dioxus": output("dx", "--version"),
-        "cargo_binstall": output("cargo-binstall", "--version"),
+        "cargo_binstall": output("cargo-binstall", "-V"),
         "espup": output("espup", "--version"),
         "esp_rustc": output("rustc", "+esp", "--version"),
         "xtensa_gcc": output("xtensa-esp-elf-gcc", "--version"),

--- a/tools/tests/test_flasher_reproducibility.py
+++ b/tools/tests/test_flasher_reproducibility.py
@@ -10,6 +10,7 @@ import sys
 import tarfile
 import tempfile
 import unittest
+from unittest.mock import patch
 import zipfile
 
 
@@ -21,6 +22,7 @@ from flasher_build_metadata import (
     EXPECTED_TOOLS,
     EXPECTED_WEB_PACKAGES,
     build_metadata,
+    resolved_tools,
     validate_metadata,
 )
 from flasher_candidate_output import resolve_output
@@ -322,6 +324,36 @@ class FlasherReproducibilityTests(unittest.TestCase):
             value["tools"]["node"] = "v24.18.1"
             with self.assertRaisesRegex(ValueError, "exact pins"):
                 validate_metadata(value, commit=COMMIT)
+
+    def test_build_metadata_uses_each_tools_version_report_flag(self) -> None:
+        commands: list[tuple[str, ...]] = []
+
+        def output(*command: str) -> str:
+            commands.append(command)
+            return command[0]
+
+        with patch(
+            "flasher_build_metadata.resolved_llvm_objcopy",
+            return_value="llvm-objcopy version 20.1.8",
+        ):
+            resolved_tools(output=output)
+
+        self.assertEqual(
+            commands,
+            [
+                ("rustc", "--version"),
+                ("cargo", "--version"),
+                ("node", "--version"),
+                ("npm", "--version"),
+                ("dx", "--version"),
+                ("cargo-binstall", "-V"),
+                ("espup", "--version"),
+                ("rustc", "+esp", "--version"),
+                ("xtensa-esp-elf-gcc", "--version"),
+                ("python3", "--version"),
+                ("git", "--version"),
+            ],
+        )
 
     def test_sparse_report_covers_all_boards_and_enforces_sixty_percent(self) -> None:
         report = build_report(manifest())


### PR DESCRIPTION
## What changed

- use cargo-binstall's `-V` version-report flag when recording release build metadata
- exercise `resolved_tools()` in its owner test and assert the complete external-command contract

## Root cause

Unsigned candidate run https://github.com/KenAKAFrosty/Prns/actions/runs/30321132350 installed and proved cargo-binstall 1.21.0 successfully, but both independent sparse-firmware/hosted-site builds failed while collecting metadata. `cargo-binstall --version` treats `--version` as an installation-version option and requires a value; `cargo-binstall -V` reports the tool version.

No candidate archive, signature, or GitHub Release was produced.

## Impact

Release candidate construction can record the already-pinned cargo-binstall identity. There are no runtime, firmware, CLI, manifest, or consumer-facing API changes.

## Verification

- `python3 -m unittest tools.tests.test_flasher_reproducibility` — 17 passed
- Python 3.13: `python -m unittest discover -s tools/tests -p 'test_*.py'` — 123 passed
- `python3 validation/release/workflow-contracts.py`
- Python 3.13: `python validation/run.py verify`
- `./tools/prns verify`
- `git diff --check`
- live owner probe: `command_output("cargo-binstall", "-V")` returned `1.21.0`
- pre-push validation, tooling-registry, Cargo formatting, and intra-doc gates passed
