### PR TITLE
Fix Windows flasher release gate

### DIFF
--- a/personal-hopspot/flasher/src/techo.rs
+++ b/personal-hopspot/flasher/src/techo.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
@@ -132,7 +132,7 @@ fn select_mount(
 
 #[cfg(unix)]
 fn sync_mount_directory(mount: &Path) -> Result<(), AppError> {
-    File::open(mount)
+    std::fs::File::open(mount)
         .and_then(|directory| directory.sync_all())
         .map_err(|error| {
             AppError::uf2_delivery(format!("TECHOBOOT directory sync failed: {error}"))

--- a/validation/platforms/windows.py
+++ b/validation/platforms/windows.py
@@ -20,6 +20,17 @@ COMMANDS = (
     (
         "cargo",
         "clippy",
+        "--package",
+        "hopspot-flash",
+        "--all-targets",
+        "--locked",
+        "--",
+        "-D",
+        "warnings",
+    ),
+    (
+        "cargo",
+        "clippy",
         "--manifest-path",
         "personal-hopspot/desktop/Cargo.toml",
         "--all-targets",


### PR DESCRIPTION
## Failure → cause → fix

Unsigned flasher candidate run [30324555315](https://github.com/KenAKAFrosty/Prns/actions/runs/30324555315) failed in `CLI primary x86_64-pc-windows-msvc` because strict warnings rejected the unconditional `std::fs::File` import in `personal-hopspot/flasher/src/techo.rs`. The type is only used by the Unix-only mount-directory synchronization path.

This change qualifies `std::fs::File` at its existing `#[cfg(unix)]` use site, so Windows no longer sees the unused import. It also adds standalone `hopspot-flash --all-targets` strict clippy to the owned Windows platform gate so this exact class of failure is caught before candidate construction.

There is no runtime behavior, public-interface, manifest, firmware, or performance-path change.

## Scope

- Base exact `main`: `036767918353021b336c26410316e217fe6e3771`
- Repair commit: `864415e1`
- 2 files, 13 insertions, 2 deletions

## Local proof

- `cargo clippy --locked -p hopspot-flash --all-targets -- -D warnings`
- `cargo test --locked -p hopspot-flash` — 71 passed
- `cargo fmt --all -- --check`
- Python 3.13 validation self-tests — 32 passed
- Python 3.13 release-tool contract tests — 123 passed
- `python3.13 validation/release/workflow-contracts.py`
- `python3.13 validation/run.py verify`
- `./tools/prns verify`
- `git diff --check`
- repository pre-push gate

The hosted Windows platform job is the required cross-platform proof.
