### PR TITLE
Provision wasm-bindgen for release candidates

### DIFF
--- a/.github/workflows/flasher-candidate.yml
+++ b/.github/workflows/flasher-candidate.yml
@@ -334,6 +334,8 @@ jobs:
           version: "1.21.0"
       - name: Install exact Dioxus CLI
         run: cargo binstall --locked --no-confirm --force dioxus-cli@0.7.5
+      - name: Install exact WASM binding CLI
+        run: cargo install wasm-bindgen-cli --version 0.2.126 --locked
       - name: Prove exact release tools and source epoch
         run: |
           rustc --version | grep -E '^rustc 1\.96\.0 '
@@ -341,6 +343,7 @@ jobs:
           test "$(node --version)" = "v24.18.0"
           cargo-binstall -V | grep -E '(^| )1\.21\.0($| )'
           dx --version | grep -E '(^| )0\.7\.5($| )'
+          wasm-bindgen --version | grep -E '^wasm-bindgen 0\.2\.126$'
           ./tools/prns release toolchain esp verify
           host_triple="$(rustc -vV | sed -n 's/^host: //p')"
           llvm_objcopy="$(rustc --print sysroot)/lib/rustlib/$host_triple/bin/llvm-objcopy"

--- a/tools/tests/test_task_runner.py
+++ b/tools/tests/test_task_runner.py
@@ -115,7 +115,7 @@ class TaskRegistryTests(unittest.TestCase):
             any("implementation must live in its domain directory" in error for error in errors)
         )
 
-    def test_wasm_bindgen_setup_matches_lockfile_and_release_workflow(self) -> None:
+    def test_wasm_bindgen_setup_matches_lockfile_and_release_workflows(self) -> None:
         task = runner.task_map(self.manifest)["build.wasm-docs.stage"]
         lock = tomllib.loads((ROOT / "prns-wasm" / "Cargo.lock").read_text(encoding="utf-8"))
         version = next(
@@ -125,10 +125,19 @@ class TaskRegistryTests(unittest.TestCase):
         )
         setup = task["setup"]
         self.assertIn(f"--version {version} --locked", setup)
-        workflow = (ROOT / ".github" / "workflows" / "release-readiness.yml").read_text(
-            encoding="utf-8"
+        for workflow_name in ("release-readiness.yml", "flasher-candidate.yml"):
+            workflow = (
+                ROOT / ".github" / "workflows" / workflow_name
+            ).read_text(encoding="utf-8")
+            self.assertIn(setup, workflow)
+        candidate = (
+            ROOT / ".github" / "workflows" / "flasher-candidate.yml"
+        ).read_text(encoding="utf-8")
+        version_pattern = re.escape(version)
+        self.assertIn(
+            f"wasm-bindgen --version | grep -E '^wasm-bindgen {version_pattern}$'",
+            candidate,
         )
-        self.assertIn(setup, workflow)
 
     def test_retired_script_callers_are_rejected(self) -> None:
         self.assertIsNotNone(runner.LEGACY_CALL_PATTERN.search("run: bash scripts/legacy.sh"))


### PR DESCRIPTION
## What changed

- install the lockfile-matched `wasm-bindgen-cli` in both sparse firmware and hosted-site candidate builds
- prove the installed `wasm-bindgen` identity before candidate construction
- extend the task-registry owner test to require the same exact setup in release readiness and candidate workflows

## Root cause

Candidate run 30328366031 reached the source-archive browser-playground staging path, which invokes `wasm-bindgen` directly. Release readiness provisioned the exact CLI, but the candidate workflow did not, so both primary and reproduction jobs failed with `wasm-bindgen: command not found`.

## Impact

This changes release tooling only. It does not change runtime behavior, public APIs, firmware sources, manifests, or performance-sensitive code.

## Validation

- exact owner test passed
- 123 release-tool tests passed on Linux with Python 3.13
- `python3 validation/release/workflow-contracts.py` passed
- `python3 validation/run.py verify` passed
- `./tools/prns verify` passed
- pre-push formatting and documentation gate passed
- `git diff --check` passed
