### PR TITLE
Repair unsigned candidate reproducibility checks

### DIFF
--- a/docs/website/tools/test-web-flasher-production-boundary.sh
+++ b/docs/website/tools/test-web-flasher-production-boundary.sh
@@ -105,3 +105,39 @@ if find "$embedded" \( -name 'source.zip' -o -name 'source.zip.sha256' \) -print
     echo "embedded SoftAP site unexpectedly contains hosted source artifacts" >&2
     exit 1
 fi
+
+trust_test="$test_root/archive-aware-trust"
+trust_hosted="$trust_test/hosted"
+trust_embedded="$trust_test/embedded"
+trust_failure="$trust_test/failure.log"
+rm -rf -- "$trust_test"
+mkdir -p "$trust_hosted" "$trust_embedded"
+printf '%s\n' '<html></html>' > "$trust_hosted/index.html"
+printf '%s\n' '<html></html>' > "$trust_embedded/index.html"
+printf '%s\n' 'PRNS_BROWSER_TEST_FIXTURE_TRUST_ROOT_V1' > "$trust_hosted/source.zip"
+sed -n '2p' \
+    "$website/web-flasher/browser/fixtures/signed-candidate/minisign.pub" \
+    >> "$trust_hosted/source.zip"
+cp "$trust_hosted/source.zip" "$trust_embedded/source-capable.wasm"
+bash "$website/tools/verify-web-flasher-production-boundary.sh" \
+    "$trust_hosted" "$trust_embedded"
+
+printf '%s\n' 'PRNS_BROWSER_TEST_FIXTURE_TRUST_ROOT_V1' \
+    > "$trust_embedded/raw-marker.wasm"
+if bash "$website/tools/verify-web-flasher-production-boundary.sh" \
+    "$trust_hosted" "$trust_embedded" > "$trust_failure" 2>&1; then
+    echo "production boundary accepted a raw browser-test fixture marker" >&2
+    exit 1
+fi
+grep -qF 'a production output contains the browser-test fixture marker' "$trust_failure"
+rm "$trust_embedded/raw-marker.wasm"
+
+sed -n '2p' \
+    "$website/web-flasher/browser/fixtures/signed-candidate/minisign.pub" \
+    > "$trust_embedded/raw-key.wasm"
+if bash "$website/tools/verify-web-flasher-production-boundary.sh" \
+    "$trust_hosted" "$trust_embedded" > "$trust_failure" 2>&1; then
+    echo "production boundary accepted a raw browser-test Minisign public key" >&2
+    exit 1
+fi
+grep -qF 'a production output contains the browser-test Minisign public key' "$trust_failure"

--- a/docs/website/tools/verify-web-flasher-production-boundary.sh
+++ b/docs/website/tools/verify-web-flasher-production-boundary.sh
@@ -5,8 +5,7 @@ website="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 workspace="$(cd "$website/../.." && pwd)"
 hosted="${1:-}"
 embedded="${2:-}"
-marker='PRNS_BROWSER_TEST_FIXTURE_TRUST_ROOT_V1'
-fixture_key="$(sed -n '2p' "$website/web-flasher/browser/fixtures/signed-candidate/minisign.pub")"
+fixture_key="$website/web-flasher/browser/fixtures/signed-candidate/minisign.pub"
 
 if [[ -z "$hosted" || -z "$embedded" ]]; then
     echo "usage: tools/verify-web-flasher-production-boundary.sh HOSTED_DIST EMBEDDED_DIST" >&2
@@ -19,14 +18,17 @@ for directory in "$hosted" "$embedded"; do
     fi
 done
 
-if grep -R -a -l -F -- "$marker" "$hosted" "$embedded"; then
-    echo "a production output contains the browser-test fixture marker" >&2
-    exit 1
+trust_scan=(
+    python3
+    "$workspace/tools/release/flasher_browser_test_trust.py"
+    --fixture-key
+    "$fixture_key"
+)
+if [[ -f "$hosted/source.zip" ]]; then
+    trust_scan+=(--allow-exact-blob "$hosted/source.zip")
 fi
-if grep -R -a -l -F -- "$fixture_key" "$hosted" "$embedded"; then
-    echo "a production output contains the browser-test Minisign public key" >&2
-    exit 1
-fi
+trust_scan+=("$hosted" "$embedded")
+"${trust_scan[@]}"
 if grep -n '^default[[:space:]]*=.*browser-test-fixture' "$website/Cargo.toml"; then
     echo "browser-test-fixture cannot be a default website feature" >&2
     exit 1

--- a/tools/release/flasher_browser_test_trust.py
+++ b/tools/release/flasher_browser_test_trust.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+import sys
+from typing import Iterable
+
+
+BROWSER_TEST_FIXTURE_MARKER = b"PRNS_BROWSER_TEST_FIXTURE_TRUST_ROOT_V1"
+
+
+class BrowserTestTrustMaterial(Enum):
+    FIXTURE_MARKER = "browser-test fixture marker"
+    MINISIGN_PUBLIC_KEY = "browser-test Minisign public key"
+
+
+@dataclass(frozen=True)
+class BrowserTestTrustLeak:
+    path: Path
+    material: BrowserTestTrustMaterial
+
+
+def minisign_public_key_payload(path: Path) -> bytes:
+    lines = path.read_bytes().splitlines()
+    if len(lines) < 2 or not lines[1]:
+        raise ValueError(f"Minisign public key has no payload: {path}")
+    return lines[1]
+
+
+def find_browser_test_trust_leaks(
+    roots: Iterable[Path],
+    fixture_key: Path,
+    allowed_exact_blob: Path | None = None,
+) -> tuple[BrowserTestTrustLeak, ...]:
+    fixture_key_payload = minisign_public_key_payload(fixture_key)
+    allowed_blob = allowed_exact_blob.read_bytes() if allowed_exact_blob else None
+    if allowed_exact_blob and not allowed_blob:
+        raise ValueError(f"allowed exact blob is empty: {allowed_exact_blob}")
+    leaks = []
+    for root in roots:
+        if not root.is_dir():
+            raise ValueError(f"trust-scan root is not a directory: {root}")
+        for path in sorted(root.rglob("*")):
+            if not path.is_file():
+                continue
+            value = path.read_bytes()
+            if allowed_blob:
+                value = value.replace(allowed_blob, b"")
+            if BROWSER_TEST_FIXTURE_MARKER in value:
+                leaks.append(
+                    BrowserTestTrustLeak(
+                        path=path,
+                        material=BrowserTestTrustMaterial.FIXTURE_MARKER,
+                    )
+                )
+            if fixture_key_payload in value:
+                leaks.append(
+                    BrowserTestTrustLeak(
+                        path=path,
+                        material=BrowserTestTrustMaterial.MINISIGN_PUBLIC_KEY,
+                    )
+                )
+    return tuple(leaks)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--fixture-key", type=Path, required=True)
+    parser.add_argument("--allow-exact-blob", type=Path)
+    parser.add_argument("roots", type=Path, nargs="+")
+    arguments = parser.parse_args()
+    try:
+        leaks = find_browser_test_trust_leaks(
+            arguments.roots,
+            arguments.fixture_key,
+            arguments.allow_exact_blob,
+        )
+    except (OSError, ValueError) as error:
+        print(f"browser-test trust scan failed: {error}", file=sys.stderr)
+        return 2
+    for leak in leaks:
+        print(
+            f"a production output contains the {leak.material.value}: {leak.path}",
+            file=sys.stderr,
+        )
+    return 1 if leaks else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/release/validate-unsigned-flasher-candidate.py
+++ b/tools/release/validate-unsigned-flasher-candidate.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 
 from flasher_build_metadata import validate_metadata
+from flasher_browser_test_trust import find_browser_test_trust_leaks
 from flasher_reproducibility import validate_report as validate_reproducibility_report
 from flasher_sparse_sizes import build_report as build_sparse_size_report
 from flasher_website_history import allowed_historical_signatures, validate_candidate_history
@@ -62,9 +63,6 @@ FORBIDDEN_PRODUCTION_REFERENCES = (
     b"playwright",
     b"axe-core",
 )
-BROWSER_FIXTURE_MARKER = b"PRNS_BROWSER_TEST_FIXTURE_TRUST_ROOT_V1"
-
-
 def digest(path: Path) -> str:
     value = hashlib.sha256()
     with path.open("rb") as stream:
@@ -180,34 +178,17 @@ def verify_production_website(root: Path) -> None:
         / "signed-candidate"
         / "minisign.pub"
     )
-    fixture_key_payload = None
-    if fixture_key_path.is_file():
-        lines = fixture_key_path.read_bytes().splitlines()
-        fixture_key_payload = lines[1] if len(lines) > 1 else None
     source_archive_path = root / "website" / "source.zip"
-    source_archive = (
-        source_archive_path.read_bytes() if source_archive_path.is_file() else None
+    leaks = find_browser_test_trust_leaks(
+        (root / "website",),
+        fixture_key_path,
+        source_archive_path,
     )
-    for path in (root / "website").rglob("*"):
-        if not path.is_file():
-            continue
-        relative = path.relative_to(root / "website").as_posix()
-        if relative in {"source.zip", "source.zip.sha256"}:
-            # The exact commit-bound source archive legitimately contains browser
-            # test fixtures. verify_source_snapshot validates it separately.
-            continue
-        value = path.read_bytes()
-        if source_archive:
-            # Source-capable WASM and firmware contain this already-verified repository
-            # archive as inert data. Keep scanning every byte around that exact blob.
-            value = value.replace(source_archive, b"")
-        if BROWSER_FIXTURE_MARKER in value or (
-            fixture_key_payload and fixture_key_payload in value
-        ):
-            raise ValueError(
-                f"hosted website contains browser-test trust material: "
-                f"{path.relative_to(root).as_posix()}"
-            )
+    if leaks:
+        raise ValueError(
+            f"hosted website contains browser-test trust material: "
+            f"{leaks[0].path.relative_to(root).as_posix()}"
+        )
 
 
 def verify_sums(root: Path) -> None:

--- a/tools/release/write-release-audit-evidence.sh
+++ b/tools/release/write-release-audit-evidence.sh
@@ -11,6 +11,7 @@ fi
 notice_hash="$(shasum -a 256 "$root/THIRD_PARTY_NOTICES.md" | awk '{print $1}')"
 unsafe_hash="$(shasum -a 256 "$root/audits/unsafe-snapshot.json" | awk '{print $1}')"
 
+mkdir -p "$(dirname "$output")"
 {
     echo "# Release dependency audit evidence"
     echo

--- a/tools/tasks.toml
+++ b/tools/tasks.toml
@@ -684,6 +684,10 @@ path = "tools/release/flasher_build_metadata.py"
 reason = "Shared reproducible build metadata implementation."
 
 [[internal]]
+path = "tools/release/flasher_browser_test_trust.py"
+reason = "Shared production browser-test trust boundary implementation."
+
+[[internal]]
 path = "tools/release/flasher_candidate_output.py"
 reason = "Internal output-path safety helper invoked by candidate construction."
 

--- a/tools/tests/test_flasher_release_custody.py
+++ b/tools/tests/test_flasher_release_custody.py
@@ -139,6 +139,8 @@ class CandidateFixture:
         source_archive = (root / "website" / "source.zip").read_bytes()
         browser_wasm.write_bytes(
             b"fixture source-enabled wasm "
+            + source_archive
+            + b" "
             + source_metadata["sha256"].encode()
             + b" "
             + SOURCE_COMMIT[:12].encode()
@@ -514,6 +516,39 @@ class FlasherReleaseCustodyTests(unittest.TestCase):
         result = self.validate_unsigned()
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("checksum is malformed or stale", result.stderr)
+
+    def test_raw_browser_fixture_trust_is_rejected_outside_the_source_archive(self) -> None:
+        browser_wasm = (
+            self.fixture.root
+            / "website"
+            / "browser-node-playground-console"
+            / "pkg"
+            / "prns_wasm_bg.wasm"
+        )
+        original = browser_wasm.read_bytes()
+        fixture_key = (
+            ROOT
+            / "docs"
+            / "website"
+            / "web-flasher"
+            / "browser"
+            / "fixtures"
+            / "signed-candidate"
+            / "minisign.pub"
+        ).read_bytes().splitlines()[1]
+        for trust_material in (
+            b"PRNS_BROWSER_TEST_FIXTURE_TRUST_ROOT_V1",
+            fixture_key,
+        ):
+            with self.subTest(trust_material=trust_material):
+                browser_wasm.write_bytes(original + b" " + trust_material)
+                result = self.validate_unsigned()
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    "hosted website contains browser-test trust material",
+                    result.stderr,
+                )
+        browser_wasm.write_bytes(original)
 
     def test_fake_signer_injection_signs_documents_and_hosted_copies(self) -> None:
         result = self.sign_candidate()

--- a/tools/tests/test_release_audit_evidence.py
+++ b/tools/tests/test_release_audit_evidence.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import stat
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WRITER = ROOT / "tools" / "release" / "write-release-audit-evidence.sh"
+
+
+class ReleaseAuditEvidenceTests(unittest.TestCase):
+    def test_writer_creates_the_output_parent(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            workspace = Path(temporary)
+            tools = workspace / "bin"
+            tools.mkdir()
+            cargo = tools / "cargo"
+            cargo.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+    "deny --version") printf '%s\n' "cargo-deny 0.18.9" ;;
+    "about --version") printf '%s\n' "cargo-about 0.8.2" ;;
+    *) exit 2 ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            cargo.chmod(cargo.stat().st_mode | stat.S_IXUSR)
+            output = workspace / "absent" / "nested" / "release-audit-evidence.md"
+            environment = dict(os.environ)
+            environment["PATH"] = f"{tools}{os.pathsep}{environment['PATH']}"
+
+            result = subprocess.run(
+                (WRITER, output),
+                cwd=ROOT,
+                env=environment,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("cargo-deny 0.18.9", output.read_text(encoding="utf-8"))
+            self.assertIn("cargo-about 0.8.2", output.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Create the release-audit evidence output parent before writing the evidence document.
- Give browser-test trust scanning one shared release-tool owner.
- Permit browser fixture material only when it occurs inside byte-for-byte copies of the already verified `source.zip` payload.
- Continue scanning every byte outside those exact archive copies and reject either the fixture marker or Minisign public key.
- Add regressions for a missing nested audit directory, a top-level and embedded exact archive, and raw marker/key leaks.

## Root causes

The unsigned candidate run built both dependency-audit inputs successfully, but the audit writer assumed its clean-run `target/` parent already existed. Separately, the website build boundary used an older recursive byte scan that did not understand the intentional exact source archive embedded by source-capable WASM and firmware, while final candidate validation already had that semantic distinction.

## Impact

This changes release construction and validation only. It does not change runtime, protocol, framing, firmware payload generation, public APIs, or performance-sensitive production paths.

## Local verification

- `python3 tools/tests/test_release_audit_evidence.py`
- `python3 tools/tests/test_flasher_release_custody.py` (15/15)
- Python 3.13: `python3 -m unittest discover -s tools/tests -p 'test_*.py'` (125/125, loopback enabled)
- `bash docs/website/tools/test-web-flasher-production-boundary.sh` (both Dioxus builds and archive/raw-leak regressions)
- `python3 validation/release/workflow-contracts.py`
- `python3 validation/run.py verify`
- `./tools/prns verify`
- `cargo test --locked -p docs`
- `bash validation/hygiene/fmt-docs.sh`
- `git diff --check`

Host coverage: Linux x86_64 locally. Hosted PR CI remains authoritative for its configured Linux, macOS, and Windows coverage.
