### PR TITLE
Run candidate critical path before readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,10 +245,9 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           persist-credentials: false
-      - name: Immutable actions and exact production tools
-        run: python3 validation/release/workflow-contracts.py
-      - name: Release custody, reproducibility, and acceptance tests
-        run: PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tools/tests -p 'test_*.py' -v
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86
+      - name: Release critical-path preflight
+        run: python3 validation/run.py run --suite release-contracts --expected-sha "$GITHUB_SHA"
       - name: Tool task registry and implementation syntax
         run: ./tools/prns verify
 

--- a/tools/release/finalize-flasher-candidate.py
+++ b/tools/release/finalize-flasher-candidate.py
@@ -234,7 +234,13 @@ def main() -> int:
             raise ValueError("--key-id is required")
         require_unsigned(candidate)
         version = read_version(candidate)
-        validate_manifest(candidate, version, arguments.channel, arguments.commit, arguments.key_id)
+        manifest = validate_manifest(
+            candidate,
+            version,
+            arguments.channel,
+            arguments.commit,
+            arguments.key_id,
+        )
         archives = require_cli_archives(candidate, version)
         render_installers(candidate, version, archives)
 

--- a/tools/tests/test_flasher_release_custody.py
+++ b/tools/tests/test_flasher_release_custody.py
@@ -63,6 +63,16 @@ def run_script(script: str, *arguments: object, environment: dict[str, str] | No
     )
 
 
+def run_task(*arguments: object) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(ROOT / "tools" / "prns"), *(str(argument) for argument in arguments)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
 def write_json(path: Path, value: object) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -470,6 +480,107 @@ class FlasherReleaseCustodyTests(unittest.TestCase):
             self.secret,
             environment=self.environment,
         )
+
+    def test_unsigned_candidate_preflight_executes_every_downstream_stage(self) -> None:
+        reproduction = CandidateFixture(self.workspace / "reproduction")
+
+        for fixture in (self.fixture, reproduction):
+            (fixture.root / "SHA256SUMS.txt").unlink()
+            (fixture.root / "channels" / "stable.json").unlink()
+            shutil.rmtree(fixture.root / "website" / "releases" / VERSION)
+            (
+                fixture.root
+                / "website"
+                / "releases"
+                / "channels"
+                / "stable.json"
+            ).unlink()
+            (fixture.root / "metadata" / "sparse-sizes.json").unlink()
+            (fixture.root / "metadata" / "reproducibility.json").unlink()
+
+            finalized = run_task(
+                "release",
+                "candidate",
+                "finalize",
+                "--",
+                fixture.root,
+                "--channel",
+                "stable",
+                "--commit",
+                SOURCE_COMMIT,
+                "--key-id",
+                KEY_ID,
+            )
+            self.assertEqual(finalized.returncode, 0, finalized.stderr)
+            self.assertEqual(
+                json.loads(
+                    (
+                        fixture.root / "metadata" / "sparse-sizes.json"
+                    ).read_text(encoding="utf-8")
+                ),
+                build_sparse_size_report(fixture.manifest),
+            )
+
+        primary_archive = self.workspace / "primary.tar.gz"
+        reproduction_archive = self.workspace / "reproduction.tar.gz"
+        for fixture, archive in (
+            (self.fixture, primary_archive),
+            (reproduction, reproduction_archive),
+        ):
+            packaged = run_task(
+                "release",
+                "candidate",
+                "package",
+                "--",
+                fixture.root,
+                archive,
+            )
+            self.assertEqual(packaged.returncode, 0, packaged.stderr)
+
+        unsigned_archive = self.workspace / "unsigned.tar.gz"
+        report = self.workspace / "reproducibility.json"
+        compared = run_task(
+            "release",
+            "candidate",
+            "compare",
+            "--",
+            "--primary",
+            primary_archive,
+            "--reproduction",
+            reproduction_archive,
+            "--output",
+            unsigned_archive,
+            "--report",
+            report,
+        )
+        self.assertEqual(compared.returncode, 0, compared.stderr)
+
+        verified = self.workspace / "verified"
+        extracted = run_task(
+            "release",
+            "candidate",
+            "extract",
+            "--",
+            unsigned_archive,
+            verified,
+        )
+        self.assertEqual(extracted.returncode, 0, extracted.stderr)
+        validated = run_task(
+            "release",
+            "candidate",
+            "validate-unsigned",
+            "--",
+            verified,
+            "--expected-commit",
+            SOURCE_COMMIT,
+            "--repository-version",
+            self.fixture.repository_version,
+            "--pinned-key",
+            self.fixture.key,
+            "--tester-roster",
+            self.fixture.tester_roster,
+        )
+        self.assertEqual(validated.returncode, 0, validated.stderr)
 
     def test_unsigned_candidate_is_fully_bound_before_signing(self) -> None:
         result = self.validate_unsigned()

--- a/validation/manifest.toml
+++ b/validation/manifest.toml
@@ -402,8 +402,8 @@ tiers = ["pr", "release", "scheduled"]
 platform = "any"
 toolchain = "python"
 timeout_seconds = 600
-command = ["python3", "-m", "unittest", "discover", "-s", "tools/tests", "-p", "test_*.py", "-v"]
-inputs = ["tools/tests", "tools/release", "validation/release/workflow-contracts.py"]
+command = ["bash", "validation/release/contracts.sh"]
+inputs = ["tools/tests", "tools/release", "validation/release/contracts.sh", "validation/release/workflow-contracts.py"]
 artifacts = "validation-artifacts/results/release-contracts"
 
 [[suite]]

--- a/validation/release/contracts.sh
+++ b/validation/release/contracts.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$root"
+validation_python="${VALIDATION_PYTHON:-python3}"
+
+uvx --from ruff==0.15.22 ruff check \
+    --select F821 \
+    tools/release \
+    tools/tests \
+    validation/release
+"$validation_python" validation/release/workflow-contracts.py
+PYTHONDONTWRITEBYTECODE=1 "$validation_python" -m unittest discover \
+    -s tools/tests \
+    -p 'test_*.py' \
+    -v

--- a/validation/release/workflow-contracts.py
+++ b/validation/release/workflow-contracts.py
@@ -143,7 +143,11 @@ def validate() -> list[str]:
         'version: "1.21.0"',
         "cargo binstall --locked --no-confirm --force dioxus-cli@0.7.5",
         "link-arg=/Brepro",
+        "./tools/prns release candidate finalize --",
+        "./tools/prns release candidate package --",
         "./tools/prns release candidate compare --",
+        "./tools/prns release candidate extract --",
+        "./tools/prns release candidate validate-unsigned --",
         "default: retain",
         "bootstrap is forbidden after any signed schema-v2 custody asset exists",
         "./tools/prns release website-history -- probe-stable",
@@ -173,6 +177,30 @@ def validate() -> list[str]:
     readiness = (
         ROOT / ".github" / "workflows" / "release-readiness.yml"
     ).read_text(encoding="utf-8")
+    for preflight_fragment in (
+        "astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86",
+        'python3 validation/run.py run --suite release-contracts --expected-sha "$GITHUB_SHA"',
+    ):
+        if preflight_fragment not in ci:
+            errors.append(
+                f"ci.yml is missing release critical-path preflight {preflight_fragment!r}"
+            )
+    release_contracts = (
+        ROOT / "validation" / "release" / "contracts.sh"
+    ).read_text(encoding="utf-8")
+    for preflight_fragment in (
+        "uvx --from ruff==0.15.22 ruff check",
+        "--select F821",
+        "tools/release",
+        "tools/tests",
+        "validation/release",
+        "-m unittest discover",
+    ):
+        if preflight_fragment not in release_contracts:
+            errors.append(
+                "release contracts are missing critical-path preflight "
+                f"{preflight_fragment!r}"
+            )
     locked_dioxus = "cargo binstall --locked --no-confirm --force dioxus-cli@0.7.5"
     for name, workflow in (
         ("ci.yml", ci),


### PR DESCRIPTION
## What changed

- retain the validated flasher manifest in the candidate finalizer before generating sparse-size evidence
- add a fixture-backed preflight that executes the exact public finalize, package, compare, extract, and unsigned-validation commands for both independent candidate passes
- add pinned Ruff 0.15.22 undefined-name checking for release Python
- make the registered `release-contracts` suite own static checks, workflow contracts, and all release custody tests
- invoke that suite from ordinary PR CI before any manually dispatched release-readiness run

## Root cause

Unsigned candidate run 30366779583 reached assembly only after earlier upstream defects were repaired. Both assembly passes failed because `validate_manifest()` returned the parsed manifest but the finalizer discarded it and later referenced an undefined `manifest` name. Existing tests constructed already-finalized fixtures and release-readiness never executed the finalizer, so expensive breadth ran before this cheap critical path.

## Impact

The release finalizer now uses its validated source of truth. A seven-second fixture rehearsal covers every stage that had remained unreachable in hosted candidate runs, and static analysis independently rejects this exact class of failure. There are no runtime, firmware payload, API, framing, or performance-sensitive changes.

## Verification

- pinned Ruff `F821`: clean; confirmed it rejects current `main` at the original undefined reference
- registered `release-contracts` suite: 126/126 tests passed
- exact-SHA evidence for `ed00813351e2fabceff9e2ac8380d6934ae03ca8`: passed, clean tracked worktree, exit 0, no timeout
- validation self-tests: 32/32 passed
- `python3 validation/run.py verify`
- `./tools/prns verify`
- `bash validation/hygiene/fmt-docs.sh`
- workflow contracts, shell syntax, and `git diff --check`

Nothing in this PR signs, publishes, promotes, or announces a release.
