### PR TITLE
Make release candidates reproducible across hosts

### DIFF
--- a/tools/release/build-flasher-candidate.sh
+++ b/tools/release/build-flasher-candidate.sh
@@ -210,7 +210,10 @@ bash "$root/docs/website/tools/verify-web-flasher-production-boundary.sh" \
     "$candidate/website" \
     "$boundary_root/embedded"
 cd "$root"
-cargo doc --locked --no-deps --workspace
+cargo doc --locked --no-deps --workspace --jobs 1
+python3 "$root/tools/release/flasher_rustdoc.py" \
+    "$root/target/doc" \
+    --current-crate docs
 mkdir -p "$candidate/website/api"
 cp -R "$root/target/doc/." "$candidate/website/api/"
 cp "$root/release/website/api-index.html" "$candidate/website/api/index.html"

--- a/tools/release/flasher_rustdoc.py
+++ b/tools/release/flasher_rustdoc.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+GENERIC_PAGES = ("help.html", "settings.html")
+CURRENT_CRATE = re.compile(rb'data-current-crate="[^"]+"')
+CRATE_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def normalize_generic_pages(output: Path, current_crate: str) -> None:
+    if not output.is_dir():
+        raise ValueError("Rustdoc output directory is unavailable")
+    if CRATE_NAME.fullmatch(current_crate) is None:
+        raise ValueError("Rustdoc current crate is invalid")
+    if not (output / current_crate / "index.html").is_file():
+        raise ValueError("Rustdoc current crate is absent from the output")
+
+    replacement = f'data-current-crate="{current_crate}"'.encode()
+    normalized: dict[Path, bytes] = {}
+    for relative in GENERIC_PAGES:
+        path = output / relative
+        if not path.is_file():
+            raise ValueError(f"Rustdoc generic page is unavailable: {relative}")
+        value, replacements = CURRENT_CRATE.subn(replacement, path.read_bytes())
+        if replacements != 1:
+            raise ValueError(
+                f"Rustdoc generic page has {replacements} current-crate fields: {relative}"
+            )
+        normalized[path] = value
+
+    for path, value in normalized.items():
+        path.write_bytes(value)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--current-crate", required=True)
+    arguments = parser.parse_args()
+    try:
+        normalize_generic_pages(arguments.output, arguments.current_crate)
+    except (OSError, ValueError) as error:
+        print(f"Rustdoc normalization failed: {error}", file=sys.stderr)
+        return 1
+    print(f"normalized Rustdoc generic pages to {arguments.current_crate}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/release/source_snapshot.py
+++ b/tools/release/source_snapshot.py
@@ -5,15 +5,16 @@ from __future__ import annotations
 import hashlib
 import io
 import json
-from pathlib import Path, PurePosixPath
+import os
 import stat
 import subprocess
 import tempfile
 import zipfile
-
+from pathlib import Path, PurePosixPath
 
 MAX_ARCHIVE_FILES = 100_000
 MAX_UNCOMPRESSED_BYTES = 2 * 1024 * 1024 * 1024
+ARCHIVE_TIMEZONE = "UTC"
 REQUIRED_SOURCE_FILES = (
     "Cargo.lock",
     "Cargo.toml",
@@ -73,6 +74,8 @@ def resolve_commit(repository: Path, commit: str) -> str:
 
 def git_archive(repository: Path, *, commit: str, version: str) -> bytes:
     resolved = resolve_commit(repository, commit)
+    environment = os.environ.copy()
+    environment["TZ"] = ARCHIVE_TIMEZONE
     result = subprocess.run(
         (
             "git",
@@ -85,6 +88,7 @@ def git_archive(repository: Path, *, commit: str, version: str) -> bytes:
         ),
         capture_output=True,
         check=False,
+        env=environment,
     )
     if result.returncode != 0:
         detail = result.stderr.decode("utf-8", errors="replace").strip()

--- a/tools/tasks.toml
+++ b/tools/tasks.toml
@@ -704,6 +704,10 @@ path = "tools/release/flasher_reproducibility.py"
 reason = "Shared deterministic candidate comparison implementation."
 
 [[internal]]
+path = "tools/release/flasher_rustdoc.py"
+reason = "Shared deterministic Rustdoc normalization implementation."
+
+[[internal]]
 path = "tools/release/release-esp-toolchain-identity.sh"
 reason = "Shared exact ESP compiler identity used by installation and verification."
 

--- a/tools/tests/test_flasher_reproducibility.py
+++ b/tools/tests/test_flasher_reproducibility.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
 import hashlib
-import json
 import importlib.util
 import io
-from pathlib import Path
+import json
+import os
 import subprocess
 import sys
 import tarfile
 import tempfile
 import unittest
-from unittest.mock import patch
 import zipfile
-
+from pathlib import Path
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS = ROOT / "tools" / "release"
@@ -27,13 +27,13 @@ from flasher_build_metadata import (
 )
 from flasher_candidate_output import resolve_output
 from flasher_reproducibility import validate_report
+from flasher_rustdoc import normalize_generic_pages
 from flasher_sparse_sizes import MERGED_BASELINES, SPARSE_BASELINES, build_report
 from source_snapshot import (
     REQUIRED_SOURCE_FILES,
     package_source_snapshot,
     validate_archive_members,
 )
-
 
 VERSION = (ROOT / "VERSION").read_text(encoding="utf-8").strip()
 COMMIT = "a" * 40
@@ -214,6 +214,51 @@ class FlasherReproducibilityTests(unittest.TestCase):
                 names,
             )
 
+    def test_source_snapshot_is_timezone_independent(self) -> None:
+        commit = subprocess.run(
+            ("git", "rev-parse", "HEAD"),
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=True,
+        ).stdout.strip()
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            outputs = []
+            for name, timezone in (("utc", "UTC0"), ("est", "EST5")):
+                output = root / name
+                environment = os.environ.copy()
+                environment["TZ"] = timezone
+                subprocess.run(
+                    (
+                        sys.executable,
+                        str(SCRIPTS / "package-source-snapshot.py"),
+                        "--repository",
+                        str(ROOT),
+                        "--commit",
+                        commit,
+                        "--version",
+                        VERSION,
+                        "--output",
+                        str(output / "source.zip"),
+                        "--metadata",
+                        str(output / "source.json"),
+                    ),
+                    cwd=ROOT,
+                    env=environment,
+                    text=True,
+                    capture_output=True,
+                    check=True,
+                )
+                outputs.append(
+                    (
+                        (output / "source.zip").read_bytes(),
+                        (output / "source.zip.sha256").read_bytes(),
+                        (output / "source.json").read_bytes(),
+                    )
+                )
+            self.assertEqual(outputs[0], outputs[1])
+
     def test_source_snapshot_rejects_missing_nomadnet_page_source(self) -> None:
         commit = subprocess.run(
             ("git", "rev-parse", "HEAD"),
@@ -290,6 +335,59 @@ class FlasherReproducibilityTests(unittest.TestCase):
             candidate_build.index("package-source-snapshot.py"),
             candidate_build.index('cp -R "$hosted_dist/." "$candidate/website/"'),
         )
+
+    def test_candidate_rustdoc_is_serial_and_normalized_before_staging(self) -> None:
+        candidate_build = (SCRIPTS / "build-flasher-candidate.sh").read_text(
+            encoding="utf-8"
+        )
+        documentation = "cargo doc --locked --no-deps --workspace --jobs 1"
+        normalization = 'flasher_rustdoc.py" \\\n    "$root/target/doc"'
+        staging = 'cp -R "$root/target/doc/." "$candidate/website/api/"'
+        self.assertIn(documentation, candidate_build)
+        self.assertIn(normalization, candidate_build)
+        self.assertLess(
+            candidate_build.index(documentation),
+            candidate_build.index(normalization),
+        )
+        self.assertLess(
+            candidate_build.index(normalization),
+            candidate_build.index(staging),
+        )
+
+    def test_rustdoc_generic_page_normalization_is_atomic(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary)
+            (output / "docs").mkdir()
+            (output / "docs" / "index.html").write_text("docs", encoding="utf-8")
+            help_page = output / "help.html"
+            settings_page = output / "settings.html"
+            help_page.write_text(
+                '<meta data-current-crate="first"><main>help</main>',
+                encoding="utf-8",
+            )
+            settings_page.write_text(
+                '<meta data-current-crate="second"><main>settings</main>',
+                encoding="utf-8",
+            )
+
+            normalize_generic_pages(output, "docs")
+
+            self.assertEqual(
+                {
+                    "help": help_page.read_text(encoding="utf-8"),
+                    "settings": settings_page.read_text(encoding="utf-8"),
+                },
+                {
+                    "help": '<meta data-current-crate="docs"><main>help</main>',
+                    "settings": '<meta data-current-crate="docs"><main>settings</main>',
+                },
+            )
+
+            original_help = help_page.read_bytes()
+            settings_page.write_text("<main>settings</main>", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "0 current-crate fields"):
+                normalize_generic_pages(output, "docs")
+            self.assertEqual(help_page.read_bytes(), original_help)
 
     def test_build_metadata_is_source_derived_and_exact_pinned(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Failure → cause → fix

The unsigned-candidate run reached the final independent-byte comparison, then found 76 Rustdoc differences. Parallel workspace documentation let the last crate to finish select Rustdoc's generic-page state, so independent builds emitted different search shards and data-current-crate values. The same investigation found that git archive timestamps depended on the runner timezone.

This change:

- builds candidate Rustdoc serially and normalizes the two generic Rustdoc pages to the docs crate before staging;
- makes that normalization fail closed and owns it in one internal release helper;
- runs source-snapshot git archive with UTC inside the snapshot owner;
- adds atomic Rustdoc, build-order, and cross-timezone source-snapshot tests.

No engine, runtime, firmware, CLI, manifest, consumer API, or mutation-gate behavior changes.

## Local verification

Linux x86_64, America/Chicago:

- ./tools/prns verify
- python3.13 validation/run.py verify
- python3.13 -m unittest -v tools.tests.test_flasher_reproducibility — 20/20
- VALIDATION_PYTHON=python3.13 bash validation/release/contracts.sh — 129/129
- python3.13 -m unittest discover -s validation/tests -p test_*.py -v — 32/32
- cargo test --locked -p docs
- Ruff lint/new-file format, bash -n, and git diff --check
- two cold serial Rustdoc builds at the same target path — 69.24s and 69.79s; all 9,912 files matched after production normalization
- reconstructed independent hosted candidates — identical precomparison archive SHA-256 3b43816a7aca683eef56d9b30185563c12b5bad80f78b7ce52ee2963aef987d0
- public candidate comparison — 10,063 files / 203,628,890 bytes matched
- unsigned-candidate validation passed without an external timezone override

The serial Rustdoc cost is isolated to independent release-candidate construction; it does not affect runtime throughput or firmware behavior.