### PR TITLE
Fix prnsd Windows release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,13 +394,13 @@ jobs:
           retention-days: 7
 
   windows-desktop:
-    # The Hopspot desktop face is the cross-platform proving ground, and nothing else in CI builds on
-    # Windows, so a Windows-only break (a path assumption, an OS cfg gate, the SDL2 link) reaches main
-    # unseen. This lane builds and lints personal-hopspot/desktop on windows-latest. It
-    # is a plain-std crate on stable (its own rust-toolchain.toml pins stable; RUSTUP_TOOLCHAIN below
-    # reasserts it belt-and-suspenders). It links SDL2 statically from source on Windows (sdl2
-    # `bundled` + `static-link`, see its Cargo.toml + .cargo/config.toml); that build needs CMake + the
-    # MSVC toolchain, both preinstalled on windows-latest.
+    # Windows-only cfg and lint failures must be caught before a release candidate is assembled.
+    # This lane checks the complete prnsd release feature set and builds/lints the Hopspot desktop
+    # face on windows-latest. Hopspot is a plain-std crate on stable (its own rust-toolchain.toml
+    # pins stable; RUSTUP_TOOLCHAIN below reasserts it belt-and-suspenders). It links SDL2 statically
+    # from source on Windows (sdl2 `bundled` + `static-link`, see its Cargo.toml +
+    # .cargo/config.toml); that build needs CMake + the MSVC toolchain, both preinstalled on
+    # windows-latest.
     runs-on: windows-latest
     timeout-minutes: 90
     env:
@@ -420,6 +420,9 @@ jobs:
       - name: clippy — native FFI boundary (Windows)
         run: cargo clippy --all-targets --locked -- -D warnings
         working-directory: prns-ffi
+      - name: check — complete prnsd release profile (Windows)
+        run: cargo check --locked --no-default-features --features tokio-host,observability,tray
+        working-directory: prnsd
       # Lint + compile parity with the Linux desktop-face step in feature-configs: this is what would
       # have caught the snapshot-refactor type mismatch that left main non-compiling.
       - name: clippy — hopspot desktop face (Windows)

--- a/audits/unsafe-snapshot.json
+++ b/audits/unsafe-snapshot.json
@@ -13176,11 +13176,11 @@
       "name": "prnsd",
       "source": "prnsd",
       "unsafe": {
-        "blocks": 1,
-        "externs": 1,
+        "blocks": 0,
+        "externs": 0,
         "functions": 0,
         "impls": 0,
-        "tokens": 2
+        "tokens": 0
       },
       "version": "0.3.1"
     },

--- a/prnsd/Cargo.toml
+++ b/prnsd/Cargo.toml
@@ -127,6 +127,9 @@ rustix = { version = "1.1.4", features = ["fs"] }
 tray-icon = { version = "0.24.1", optional = true, default-features = false }
 winit = { version = "0.30.12", optional = true, default-features = false }
 
+[target.'cfg(windows)'.dependencies]
+tempfile = "3"
+
 [dev-dependencies]
 tempfile = "3"
 

--- a/prnsd/src/interface_discovery/publication/advertisement.rs
+++ b/prnsd/src/interface_discovery/publication/advertisement.rs
@@ -1,6 +1,5 @@
 #[cfg(unix)]
-use std::path::Path;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use personal_rns::config::{
     DiscoveryAdvertisementPlan, DiscoveryAnnouncementPlan, DiscoveryEncryption,
@@ -226,17 +225,21 @@ pub(super) enum DiscoveryAdvertisementResolutionError {
     UnknownInterface {
         interface: InterfaceId,
     },
+    #[cfg(unix)]
     HomeUnavailable {
         path: PathBuf,
     },
+    #[cfg(unix)]
     Execute {
         path: PathBuf,
         source: std::io::Error,
     },
+    #[cfg(unix)]
     Exit {
         path: PathBuf,
         status: std::process::ExitStatus,
     },
+    #[cfg(unix)]
     OutputNotUtf8 {
         path: PathBuf,
         source: std::string::FromUtf8Error,
@@ -249,17 +252,21 @@ impl core::fmt::Display for DiscoveryAdvertisementResolutionError {
             Self::UnknownInterface { interface } => {
                 write!(formatter, "unknown discovery interface {interface:?}")
             }
+            #[cfg(unix)]
             Self::HomeUnavailable { path } => write!(
                 formatter,
                 "reachable_on path {} needs a home directory, but HOME is unavailable",
                 path.display()
             ),
+            #[cfg(unix)]
             Self::Execute { path, source } => {
                 write!(formatter, "could not execute {}: {source}", path.display())
             }
+            #[cfg(unix)]
             Self::Exit { path, status } => {
                 write!(formatter, "{} exited with {status}", path.display())
             }
+            #[cfg(unix)]
             Self::OutputNotUtf8 { path, source } => {
                 write!(
                     formatter,
@@ -274,11 +281,13 @@ impl core::fmt::Display for DiscoveryAdvertisementResolutionError {
 impl std::error::Error for DiscoveryAdvertisementResolutionError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
+            #[cfg(unix)]
             Self::Execute { source, .. } => Some(source),
+            #[cfg(unix)]
             Self::OutputNotUtf8 { source, .. } => Some(source),
-            Self::UnknownInterface { .. } | Self::HomeUnavailable { .. } | Self::Exit { .. } => {
-                None
-            }
+            Self::UnknownInterface { .. } => None,
+            #[cfg(unix)]
+            Self::HomeUnavailable { .. } | Self::Exit { .. } => None,
         }
     }
 }

--- a/prnsd/src/nnpages.rs
+++ b/prnsd/src/nnpages.rs
@@ -835,50 +835,9 @@ pub(crate) fn replace_file(temporary: &Path, destination: &Path) -> io::Result<(
 
 #[cfg(windows)]
 pub(crate) fn replace_file(temporary: &Path, destination: &Path) -> io::Result<()> {
-    use std::ffi::c_void;
-    use std::os::windows::ffi::OsStrExt as _;
-
-    if !destination.exists() {
-        return fs::rename(temporary, destination);
-    }
-    #[link(name = "kernel32")]
-    unsafe extern "system" {
-        fn ReplaceFileW(
-            replaced: *const u16,
-            replacement: *const u16,
-            backup: *const u16,
-            flags: u32,
-            exclude: *mut c_void,
-            reserved: *mut c_void,
-        ) -> i32;
-    }
-    let replaced = destination
-        .as_os_str()
-        .encode_wide()
-        .chain(Some(0))
-        .collect::<Vec<_>>();
-    let replacement = temporary
-        .as_os_str()
-        .encode_wide()
-        .chain(Some(0))
-        .collect::<Vec<_>>();
-    // SAFETY: both paths are valid, NUL-terminated UTF-16 buffers for the duration of
-    // the call; the optional backup and extension arguments are deliberately null.
-    let succeeded = unsafe {
-        ReplaceFileW(
-            replaced.as_ptr(),
-            replacement.as_ptr(),
-            std::ptr::null(),
-            1, // REPLACEFILE_WRITE_THROUGH
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-        )
-    };
-    if succeeded != 0 {
-        Ok(())
-    } else {
-        Err(io::Error::last_os_error())
-    }
+    tempfile::TempPath::try_from_path(temporary.to_path_buf())?
+        .persist(destination)
+        .map_err(|error| error.error)
 }
 
 fn decode_request(path: &Path) -> Option<PendingNnPagesRefresh> {

--- a/prnsd/src/tray/actions.rs
+++ b/prnsd/src/tray/actions.rs
@@ -119,6 +119,7 @@ pub(crate) enum TrayActionError {
     ForegroundSession,
     TemporaryScript(io::Error),
     ScriptWrite(io::Error),
+    #[cfg(unix)]
     ScriptPermissions(io::Error),
     Launch {
         program: &'static str,
@@ -154,6 +155,7 @@ impl fmt::Display for TrayActionError {
             Self::ScriptWrite(error) => {
                 write!(formatter, "could not write the terminal launcher: {error}")
             }
+            #[cfg(unix)]
             Self::ScriptPermissions(error) => {
                 write!(
                     formatter,

--- a/prnsd/src/utilities/rnid/io.rs
+++ b/prnsd/src/utilities/rnid/io.rs
@@ -92,6 +92,9 @@ impl AtomicOutput {
         overwrite: OverwritePolicy,
         sensitivity: OutputSensitivity,
     ) -> Result<Self, IdentityIoError> {
+        #[cfg(not(unix))]
+        let _ = sensitivity;
+
         let final_path = expand_user_path(path)?;
         if overwrite == OverwritePolicy::Refuse && final_path.exists() {
             return Err(IdentityIoError::AlreadyExists(final_path));


### PR DESCRIPTION
## Summary

- Replace Prnsd's direct Windows FFI with the safe, atomic `tempfile` persistence boundary.
- Cfg-gate Unix-only error cases and values so the complete Windows profile is warning-clean.
- Add the complete Prnsd Windows release profile to required PR CI.

## Release evidence

The first `v0.3.1` native candidate exposed five Windows-only compile failures. This change passes
the exact release feature set locally for `x86_64-pc-windows-msvc` with `-D warnings` and makes
the same profile a required Windows CI step.

## Validation

- `RUSTFLAGS='-D warnings' cargo check --manifest-path prnsd/Cargo.toml --locked --target x86_64-pc-windows-msvc --no-default-features --features tokio-host,observability,tray`
- `cargo test --manifest-path prnsd/Cargo.toml --workspace --all-features --locked`
- `cargo test --manifest-path prnsd/Cargo.toml --locked --no-default-features --features tokio-cloud-host,observability nnpages`
- `python3 validation/run.py run --suite release-contracts --expected-sha 1b0cc84ae344bb0ebba9c799d32a650195e28f67` (144 tests)
- `./tools/prns verify`
- Repository pre-push gate
