### PR TITLE
Fix Windows release linkage evidence

### DIFF
--- a/.github/workflows/prnsd-candidate.yml
+++ b/.github/workflows/prnsd-candidate.yml
@@ -102,9 +102,13 @@ jobs:
               } > "$evidence"
               ;;
             Windows)
+              sysroot="$(cygpath --unix "$(rustc --print sysroot)")"
+              host="$(rustc --print host-tuple)"
+              llvm_readobj="${sysroot}/lib/rustlib/${host}/bin/llvm-readobj.exe"
+              test -x "$llvm_readobj"
               {
                 file "${{ matrix.platform.binary }}"
-                "$(rustup which llvm-readobj)" --coff-imports "${{ matrix.platform.binary }}"
+                "$llvm_readobj" --coff-imports "${{ matrix.platform.binary }}"
               } > "$evidence"
               ;;
             *)

--- a/release/acceptance/rosters/0.3.1.json
+++ b/release/acceptance/rosters/0.3.1.json
@@ -1,0 +1,185 @@
+{
+  "schema": 2,
+  "release": {
+    "version": "0.3.1"
+  },
+  "release_owner": "github:KenAKAFrosty",
+  "confirmed_on": "2026-07-30",
+  "physical_assignments": [
+    {
+      "board": "heltec-v4",
+      "surface": "web",
+      "os": "linux",
+      "architecture": "x86_64",
+      "browser": {
+        "name": "chrome",
+        "channel": "stable"
+      },
+      "tester": "github:KenAKAFrosty",
+      "cables_ready": true,
+      "device_permissions_ready": true,
+      "recovery_instructions_reviewed": true
+    },
+    {
+      "board": "heltec-v4",
+      "surface": "cli",
+      "os": "linux",
+      "architecture": "x86_64",
+      "tester": "github:KenAKAFrosty",
+      "cables_ready": true,
+      "device_permissions_ready": true,
+      "recovery_instructions_reviewed": true
+    },
+    {
+      "board": "t-beam-supreme",
+      "surface": "web",
+      "os": "macos",
+      "architecture": "aarch64",
+      "browser": {
+        "name": "chrome",
+        "channel": "stable"
+      },
+      "tester": "github:KenAKAFrosty",
+      "cables_ready": true,
+      "device_permissions_ready": true,
+      "recovery_instructions_reviewed": true
+    },
+    {
+      "board": "t-beam-supreme",
+      "surface": "cli",
+      "os": "macos",
+      "architecture": "aarch64",
+      "tester": "github:KenAKAFrosty",
+      "cables_ready": true,
+      "device_permissions_ready": true,
+      "recovery_instructions_reviewed": true
+    },
+    {
+      "board": "xiao-esp32-c6",
+      "surface": "web",
+      "os": "windows",
+      "architecture": "x86_64",
+      "browser": {
+        "name": "edge",
+        "channel": "stable"
+      },
+      "tester": "github:KenAKAFrosty",
+      "cables_ready": true,
+      "device_permissions_ready": true,
+      "recovery_instructions_reviewed": true
+    },
+    {
+      "board": "xiao-esp32-c6",
+      "surface": "cli",
+      "os": "windows",
+      "architecture": "x86_64",
+      "tester": "github:KenAKAFrosty",
+      "cables_ready": true,
+      "device_permissions_ready": true,
+      "recovery_instructions_reviewed": true
+    },
+    {
+      "board": "t-echo",
+      "surface": "web",
+      "os": "linux",
+      "architecture": "x86_64",
+      "browser": {
+        "name": "chrome",
+        "channel": "stable"
+      },
+      "tester": "github:KenAKAFrosty",
+      "cables_ready": true,
+      "device_permissions_ready": true,
+      "recovery_instructions_reviewed": true
+    },
+    {
+      "board": "t-echo",
+      "surface": "cli",
+      "os": "linux",
+      "architecture": "x86_64",
+      "tester": "github:KenAKAFrosty",
+      "cables_ready": true,
+      "device_permissions_ready": true,
+      "recovery_instructions_reviewed": true
+    }
+  ],
+  "fallback_assignments": [
+    {
+      "browser": {
+        "name": "firefox",
+        "channel": "stable"
+      },
+      "os": "linux",
+      "architecture": "x86_64",
+      "tester": "github:KenAKAFrosty",
+      "browser_ready": true
+    },
+    {
+      "browser": {
+        "name": "firefox",
+        "channel": "stable"
+      },
+      "os": "macos",
+      "architecture": "aarch64",
+      "tester": "github:KenAKAFrosty",
+      "browser_ready": true
+    },
+    {
+      "browser": {
+        "name": "firefox",
+        "channel": "stable"
+      },
+      "os": "windows",
+      "architecture": "x86_64",
+      "tester": "github:KenAKAFrosty",
+      "browser_ready": true
+    },
+    {
+      "browser": {
+        "name": "safari",
+        "channel": "stable"
+      },
+      "os": "macos",
+      "architecture": "aarch64",
+      "tester": "github:KenAKAFrosty",
+      "browser_ready": true
+    }
+  ],
+  "installation_assignments": [
+    {
+      "target": "aarch64-apple-darwin",
+      "os": "macos",
+      "architecture": "aarch64",
+      "tester": "github:KenAKAFrosty",
+      "archive_ready": true
+    },
+    {
+      "target": "x86_64-apple-darwin",
+      "os": "macos",
+      "architecture": "x86_64",
+      "tester": "github:KenAKAFrosty",
+      "archive_ready": true
+    },
+    {
+      "target": "x86_64-unknown-linux-gnu",
+      "os": "linux",
+      "architecture": "x86_64",
+      "tester": "github:KenAKAFrosty",
+      "archive_ready": true
+    },
+    {
+      "target": "aarch64-unknown-linux-gnu",
+      "os": "linux",
+      "architecture": "aarch64",
+      "tester": "github:KenAKAFrosty",
+      "archive_ready": true
+    },
+    {
+      "target": "x86_64-pc-windows-msvc",
+      "os": "windows",
+      "architecture": "x86_64",
+      "tester": "github:KenAKAFrosty",
+      "archive_ready": true
+    }
+  ]
+}

--- a/validation/release/workflow-contracts.py
+++ b/validation/release/workflow-contracts.py
@@ -174,6 +174,27 @@ def validate() -> list[str]:
         if mutable in candidate:
             errors.append(f"flasher-candidate.yml contains mutable production input {mutable!r}")
 
+    daemon_candidate = (
+        ROOT / ".github" / "workflows" / "prnsd-candidate.yml"
+    ).read_text(encoding="utf-8")
+    for linkage_gate in (
+        "components: llvm-tools-preview",
+        'sysroot="$(cygpath --unix "$(rustc --print sysroot)")"',
+        'host="$(rustc --print host-tuple)"',
+        'llvm_readobj="${sysroot}/lib/rustlib/${host}/bin/llvm-readobj.exe"',
+        'test -x "$llvm_readobj"',
+        '"$llvm_readobj" --coff-imports',
+    ):
+        if linkage_gate not in daemon_candidate:
+            errors.append(
+                "prnsd-candidate.yml is missing deterministic Windows linkage gate "
+                f"{linkage_gate!r}"
+            )
+    if "rustup which llvm-readobj" in daemon_candidate:
+        errors.append(
+            "prnsd-candidate.yml must resolve llvm-readobj from the pinned Rust sysroot"
+        )
+
     ci = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
     readiness = (
         ROOT / ".github" / "workflows" / "release-readiness.yml"


### PR DESCRIPTION
## Summary

- Resolve Windows `llvm-readobj` from the pinned Rust 1.96 sysroot and host tuple instead of asking
  rustup for a proxy it does not provide.
- Fail closed when the expected installed tool is absent.
- Add release-workflow contracts for the exact lookup and reject the broken `rustup which` form.
- Commit the reconfirmed `v0.3.1` tester roster with the existing public assignments.

## Release evidence

Native candidate run `30520481050` built the complete Windows release binary successfully, then
failed only while recording PE linkage because `rustup which llvm-readobj` is not a supported
lookup. `llvm-tools-preview` installs the binary under
`lib/rustlib/<host>/bin/llvm-readobj.exe` in the exact toolchain sysroot.

The roster differs from `0.3.0` only in its release version and confirmation date.

## Validation

- Exact Rust 1.96 sysroot tool layout exercised locally.
- `python3 validation/release/workflow-contracts.py`
- `./tools/prns release tester-roster validate -- --roster release/acceptance/rosters/0.3.1.json --version 0.3.1`
- `python3 validation/run.py run --suite release-contracts --expected-sha 58eceae4f156ea2af417a139adf3fc39b4cc207e` (144 tests)
- Ruff 0.15.22 and Python bytecode checks.
- Repository pre-push gate.
