### PR TITLE
Validate flasher headroom from shipped partitions

### DIFF
--- a/tools/release/validate-unsigned-flasher-candidate.py
+++ b/tools/release/validate-unsigned-flasher-candidate.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 from pathlib import Path, PurePosixPath
 import subprocess
+import struct
 import sys
 
 from flasher_build_metadata import validate_metadata
@@ -26,10 +27,12 @@ CLI_TARGETS = {
     "x86_64-pc-windows-msvc": ".zip",
 }
 SHIPPING_BOARDS = {"heltec-v4", "t-beam-supreme", "xiao-esp32-c6", "t-echo"}
-SOURCE_APPLICATION_CAPACITIES = {
-    "heltec-v4": 0x670000,
-    "t-beam-supreme": 0x670000,
-}
+ESP_PARTITION_ENTRY = struct.Struct("<HBBII16sI")
+ESP_PARTITION_MAGIC = 0x50AA
+ESP_PARTITION_MD5_MAGIC = 0xEBEB
+ESP_APPLICATION_TYPE = 0x00
+ESP_FACTORY_APPLICATION_SUBTYPE = 0x00
+SOURCE_APPLICATION_HEADROOM = 1024 * 1024
 REQUIRED_RELEASE_FILES = (
     "VERSION",
     "flash-manifest.json",
@@ -67,6 +70,8 @@ FORBIDDEN_PRODUCTION_REFERENCES = (
     b"playwright",
     b"axe-core",
 )
+
+
 def digest(path: Path) -> str:
     value = hashlib.sha256()
     with path.open("rb") as stream:
@@ -89,6 +94,44 @@ def safe_path(root: Path, relative: str) -> Path:
     ):
         raise ValueError(f"unsafe candidate path {relative!r}")
     return root.joinpath(*pure.parts)
+
+
+def factory_application_partition(partition_table: Path) -> tuple[int, int]:
+    payload = partition_table.read_bytes()
+    if not payload or len(payload) % ESP_PARTITION_ENTRY.size != 0:
+        raise ValueError("ESP partition table has a truncated entry")
+    factories: list[tuple[int, int]] = []
+    for entry_index in range(0, len(payload), ESP_PARTITION_ENTRY.size):
+        entry = payload[entry_index : entry_index + ESP_PARTITION_ENTRY.size]
+        magic = int.from_bytes(entry[:2], "little")
+        if magic in {0xFFFF, ESP_PARTITION_MD5_MAGIC}:
+            break
+        if magic != ESP_PARTITION_MAGIC:
+            raise ValueError(
+                f"ESP partition table entry {entry_index // ESP_PARTITION_ENTRY.size} "
+                f"has invalid magic 0x{magic:04x}"
+            )
+        (
+            _magic,
+            partition_type,
+            subtype,
+            offset,
+            size,
+            _label,
+            _flags,
+        ) = ESP_PARTITION_ENTRY.unpack(entry)
+        if (
+            partition_type == ESP_APPLICATION_TYPE
+            and subtype == ESP_FACTORY_APPLICATION_SUBTYPE
+        ):
+            if offset <= 0 or size <= 0:
+                raise ValueError("ESP factory application partition has an invalid extent")
+            factories.append((offset, size))
+    if len(factories) != 1:
+        raise ValueError(
+            "ESP partition table must contain exactly one factory application partition"
+        )
+    return factories[0]
 
 
 def payload_files(root: Path) -> set[str]:
@@ -350,25 +393,26 @@ def verify(arguments: argparse.Namespace) -> dict:
         ):
             raise ValueError(f"target {board_slug} has the wrong embedded source identity")
         if source is not None:
-            application = next(
-                (
-                    part
-                    for part in parts
-                    if isinstance(part, dict) and part.get("kind") == "application"
-                ),
-                None,
-            )
-            if (
-                application is None
-                or not isinstance(application.get("size"), int)
-                or application["size"] + 1024 * 1024
-                > SOURCE_APPLICATION_CAPACITIES[board_slug]
-            ):
+            applications = [
+                part
+                for part in parts
+                if isinstance(part, dict) and part.get("kind") == "application"
+            ]
+            partition_tables = [
+                part
+                for part in parts
+                if isinstance(part, dict) and part.get("kind") == "partition-table"
+            ]
+            if len(applications) != 1 or len(partition_tables) != 1:
                 raise ValueError(
-                    f"target {board_slug} does not retain 1 MiB application headroom"
+                    f"source-enabled target {board_slug} must carry exactly one "
+                    "application and partition table"
                 )
+            application = applications[0]
+            partition_table = partition_tables[0]
         else:
             application = None
+            partition_table = None
         for part in parts:
             if not isinstance(part, dict):
                 raise ValueError("candidate manifest contains a malformed firmware part")
@@ -389,6 +433,29 @@ def verify(arguments: argparse.Namespace) -> dict:
             if not hosted.is_file() or hosted.read_bytes() != artifact.read_bytes():
                 raise ValueError(f"hosted firmware part differs from candidate payload: {relative}")
         if application is not None:
+            partition_offset, partition_capacity = factory_application_partition(
+                safe_path(root, partition_table["path"])
+            )
+            application_offset = application.get("offset")
+            application_size = application.get("size")
+            if (
+                not isinstance(application_offset, int)
+                or isinstance(application_offset, bool)
+                or application_offset != partition_offset
+            ):
+                raise ValueError(
+                    f"target {board_slug} application offset disagrees with its "
+                    "factory partition"
+                )
+            if (
+                not isinstance(application_size, int)
+                or isinstance(application_size, bool)
+                or application_size + SOURCE_APPLICATION_HEADROOM
+                > partition_capacity
+            ):
+                raise ValueError(
+                    f"target {board_slug} does not retain 1 MiB application headroom"
+                )
             application_bytes = safe_path(root, application["path"]).read_bytes()
             if application_bytes.count(source_archive) != 1:
                 raise ValueError(
@@ -452,9 +519,15 @@ def verify(arguments: argparse.Namespace) -> dict:
         if status == "serving":
             if target_by_board[board_slug].get("source") != source_identity:
                 raise ValueError(f"{board_slug} serving claim disagrees with its target metadata")
+            if capability.get("reserve_bytes") != SOURCE_APPLICATION_HEADROOM:
+                raise ValueError(
+                    f"{board_slug} serving claim does not record the required reserve"
+                )
         elif status == "capacity-downgrade":
             if target_by_board[board_slug].get("source") is not None:
                 raise ValueError(f"{board_slug} downgrade still claims an embedded archive")
+            if capability.get("reserve_bytes") is not None:
+                raise ValueError(f"{board_slug} downgrade must not claim reserved bytes")
         else:
             raise ValueError(f"{board_slug} has an invalid source capability status")
     for board_slug in {"xiao-esp32-c6", "t-echo"}:

--- a/tools/tests/test_flasher_release_custody.py
+++ b/tools/tests/test_flasher_release_custody.py
@@ -10,6 +10,7 @@ import os
 from pathlib import Path
 import shutil
 import stat
+import struct
 import subprocess
 import sys
 import tempfile
@@ -45,10 +46,32 @@ CLI_TARGETS = {
     "aarch64-unknown-linux-gnu": ".tar.gz",
     "x86_64-pc-windows-msvc": ".zip",
 }
+ESP_PARTITION_ENTRY = struct.Struct("<HBBII16sI")
+SOURCE_APPLICATION_HEADROOM = 1024 * 1024
 
 
 def sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def esp_partition_table(
+    factory_size: int,
+    *,
+    factory_offset: int = 0x10000,
+    partition_type: int = 0x00,
+    subtype: int = 0x00,
+) -> bytes:
+    entry = ESP_PARTITION_ENTRY.pack(
+        0x50AA,
+        partition_type,
+        subtype,
+        factory_offset,
+        factory_size,
+        b"factory".ljust(16, b"\0"),
+        0,
+    )
+    md5_marker = b"\xeb\xeb" + b"\xff" * 30
+    return (entry + md5_marker).ljust(0xC00, b"\xff")
 
 
 def run_script(script: str, *arguments: object, environment: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
@@ -185,21 +208,41 @@ class CandidateFixture:
             hosted = root / "website" / "releases" / VERSION / relative
             hosted.parent.mkdir(parents=True, exist_ok=True)
             hosted.write_bytes(artifact.read_bytes())
+            application_part = {
+                "kind": "uf2" if board == "t-echo" else "application",
+                "path": relative,
+                "size": artifact.stat().st_size,
+                "sha256": sha256(artifact),
+            }
+            if board != "t-echo":
+                application_part["offset"] = 0x10000
+            parts = [application_part]
+            if board in {"heltec-v4", "t-beam-supreme"}:
+                partition_relative = f"firmware/{board}/partition-table.bin"
+                partition_artifact = root / partition_relative
+                partition_artifact.write_bytes(esp_partition_table(0xFF0000))
+                self.firmware_paths.append(partition_artifact)
+                partition_hosted = (
+                    root / "website" / "releases" / VERSION / partition_relative
+                )
+                partition_hosted.parent.mkdir(parents=True, exist_ok=True)
+                partition_hosted.write_bytes(partition_artifact.read_bytes())
+                parts.insert(
+                    0,
+                    {
+                        "kind": "partition-table",
+                        "path": partition_relative,
+                        "offset": 0x8000,
+                        "size": partition_artifact.stat().st_size,
+                        "sha256": sha256(partition_artifact),
+                    },
+                )
             target = {
                 "board_slug": board,
                 "transport": (
                     "uf2-mass-storage" if board == "t-echo" else "esp-serial"
                 ),
-                "parts": [
-                    {
-                        "kind": (
-                            "uf2" if board == "t-echo" else "application"
-                        ),
-                        "path": relative,
-                        "size": artifact.stat().st_size,
-                        "sha256": sha256(artifact),
-                    }
-                ],
+                "parts": parts,
             }
             if board in {"heltec-v4", "t-beam-supreme"}:
                 target["source"] = source_identity
@@ -223,6 +266,11 @@ class CandidateFixture:
                         ),
                         "source": (
                             source_identity
+                            if board in {"heltec-v4", "t-beam-supreme"}
+                            else None
+                        ),
+                        "reserve_bytes": (
+                            SOURCE_APPLICATION_HEADROOM
                             if board in {"heltec-v4", "t-beam-supreme"}
                             else None
                         ),
@@ -600,6 +648,84 @@ class FlasherReleaseCustodyTests(unittest.TestCase):
         result = self.validate_unsigned()
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("SHA-256 mismatch", result.stderr)
+
+    def test_source_headroom_uses_the_shipped_partition_table(self) -> None:
+        result = self.validate_unsigned()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        target = next(
+            target
+            for target in self.fixture.manifest["targets"]
+            if target["board_slug"] == "heltec-v4"
+        )
+        application = next(
+            part for part in target["parts"] if part["kind"] == "application"
+        )
+        partition = next(
+            part for part in target["parts"] if part["kind"] == "partition-table"
+        )
+        partition_path = self.fixture.root / partition["path"]
+        partition_path.write_bytes(
+            esp_partition_table(
+                application["size"] + SOURCE_APPLICATION_HEADROOM - 1
+            )
+        )
+        partition["sha256"] = sha256(partition_path)
+        hosted = self.fixture.root / "website" / "releases" / VERSION / partition["path"]
+        hosted.write_bytes(partition_path.read_bytes())
+        write_json(self.fixture.manifest_path, self.fixture.manifest)
+
+        result = self.validate_unsigned()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("does not retain 1 MiB application headroom", result.stderr)
+
+    def test_source_headroom_rejects_missing_factory_partition(self) -> None:
+        target = next(
+            target
+            for target in self.fixture.manifest["targets"]
+            if target["board_slug"] == "heltec-v4"
+        )
+        partition = next(
+            part for part in target["parts"] if part["kind"] == "partition-table"
+        )
+        partition_path = self.fixture.root / partition["path"]
+        partition_path.write_bytes(
+            esp_partition_table(
+                0xFF0000,
+                partition_type=0x01,
+                subtype=0x02,
+            )
+        )
+        partition["sha256"] = sha256(partition_path)
+        hosted = self.fixture.root / "website" / "releases" / VERSION / partition["path"]
+        hosted.write_bytes(partition_path.read_bytes())
+        write_json(self.fixture.manifest_path, self.fixture.manifest)
+
+        result = self.validate_unsigned()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "exactly one factory application partition",
+            result.stderr,
+        )
+
+    def test_source_headroom_binds_application_offset(self) -> None:
+        target = next(
+            target
+            for target in self.fixture.manifest["targets"]
+            if target["board_slug"] == "heltec-v4"
+        )
+        application = next(
+            part for part in target["parts"] if part["kind"] == "application"
+        )
+        application["offset"] += 0x10000
+        write_json(self.fixture.manifest_path, self.fixture.manifest)
+
+        result = self.validate_unsigned()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "application offset disagrees with its factory partition",
+            result.stderr,
+        )
 
     def test_hosted_source_snapshot_is_bound_to_the_exact_commit(self) -> None:
         archive = self.fixture.root / "website" / "source.zip"


### PR DESCRIPTION
## Summary

- remove the stale per-board application-capacity map from unsigned flasher validation
- parse the exact ESP partition table shipped in each source-enabled candidate
- bind application offset and 1 MiB reserve checks to the factory application partition
- fail closed on malformed, missing, or ambiguous factory partitions
- bind source-capability reserve metadata to the enforced policy

## Release exercise finding

The v0.3.1 candidate correctly built Heltec V4 with its reviewed 16 MiB layout:

- factory application partition: `0xff0000` (16,711,680 bytes)
- source-enabled application: 7,831,696 bytes
- remaining headroom: 8,879,984 bytes

The previous validator compared that application against Heltec's obsolete `0x670000`
capacity even though the builder already used the shipped partition table.

## Validation

- 20/20 flasher custody tests
- 147/147 release-contract tests
- release workflow contracts
- repository tooling verification
- focused malformed-partition, insufficient-capacity, and offset-mismatch tests
- full local pre-push gate
