### PR TITLE
Pin Windows release linker to Rust toolchain

### DIFF
--- a/.github/workflows/flasher-candidate.yml
+++ b/.github/workflows/flasher-candidate.yml
@@ -244,7 +244,7 @@ jobs:
           - os: windows-2025
             target: x86_64-pc-windows-msvc
             binary: target/x86_64-pc-windows-msvc/release/hopspot-flash.exe
-            rustflags: -D warnings -C link-arg=/Brepro
+            rustflags: -D warnings -C linker=rust-lld -C linker-flavor=lld-link -C link-arg=/Brepro
     runs-on: ${{ matrix.platform.os }}
     timeout-minutes: 180
     env:
@@ -257,6 +257,16 @@ jobs:
         with:
           toolchain: 1.96.0
           targets: ${{ matrix.platform.target }}
+      - name: Expose and prove the Rust-bundled Windows linker
+        if: matrix.platform.target == 'x86_64-pc-windows-msvc'
+        shell: bash
+        run: |
+          sysroot="$(cygpath --unix "$(rustc --print sysroot)")"
+          host="$(rustc --print host-tuple)"
+          rust_lld="${sysroot}/lib/rustlib/${host}/bin/rust-lld.exe"
+          test -x "$rust_lld"
+          "$rust_lld" -flavor link --version | grep -E '^LLD 22\.1\.2 '
+          dirname "$rust_lld" >> "$GITHUB_PATH"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           shared-key: flasher-cli-${{ matrix.build_pass }}-${{ matrix.platform.target }}

--- a/.github/workflows/prnsd-candidate.yml
+++ b/.github/workflows/prnsd-candidate.yml
@@ -43,7 +43,7 @@ jobs:
           - os: windows-2025
             target: x86_64-pc-windows-msvc
             binary: prnsd/target/x86_64-pc-windows-msvc/release/prnsd.exe
-            rustflags: -D warnings -C link-arg=/Brepro
+            rustflags: -D warnings -C linker=rust-lld -C linker-flavor=lld-link -C link-arg=/Brepro
     runs-on: ${{ matrix.platform.os }}
     timeout-minutes: 180
     env:
@@ -70,6 +70,16 @@ jobs:
           toolchain: 1.96.0
           targets: ${{ matrix.platform.target }}
           components: llvm-tools-preview
+      - name: Expose and prove the Rust-bundled Windows linker
+        if: matrix.platform.target == 'x86_64-pc-windows-msvc'
+        shell: bash
+        run: |
+          sysroot="$(cygpath --unix "$(rustc --print sysroot)")"
+          host="$(rustc --print host-tuple)"
+          rust_lld="${sysroot}/lib/rustlib/${host}/bin/rust-lld.exe"
+          test -x "$rust_lld"
+          "$rust_lld" -flavor link --version | grep -E '^LLD 22\.1\.2 '
+          dirname "$rust_lld" >> "$GITHUB_PATH"
       - name: Build the complete native daemon
         shell: bash
         run: |
@@ -105,9 +115,12 @@ jobs:
               sysroot="$(cygpath --unix "$(rustc --print sysroot)")"
               host="$(rustc --print host-tuple)"
               llvm_readobj="${sysroot}/lib/rustlib/${host}/bin/llvm-readobj.exe"
+              rust_lld="${sysroot}/lib/rustlib/${host}/bin/rust-lld.exe"
               test -x "$llvm_readobj"
+              test -x "$rust_lld"
               {
                 file "${{ matrix.platform.binary }}"
+                "$rust_lld" -flavor link --version
                 "$llvm_readobj" --coff-imports "${{ matrix.platform.binary }}"
               } > "$evidence"
               ;;

--- a/tools/tests/test_flasher_reproducibility.py
+++ b/tools/tests/test_flasher_reproducibility.py
@@ -697,12 +697,25 @@ class FlasherReproducibilityTests(unittest.TestCase):
             ROOT / "validation" / "release" / "workflow-contracts.py"
         )
         self.assertEqual(result.returncode, 0, result.stderr)
-        candidate_workflow = (
-            ROOT / ".github" / "workflows" / "flasher-candidate.yml"
-        ).read_text(encoding="utf-8")
-        windows_start = candidate_workflow.index("target: x86_64-pc-windows-msvc")
-        windows_end = candidate_workflow.index("runs-on:", windows_start)
-        self.assertIn("link-arg=/Brepro", candidate_workflow[windows_start:windows_end])
+        for workflow_name in ("flasher-candidate.yml", "prnsd-candidate.yml"):
+            workflow = (
+                ROOT / ".github" / "workflows" / workflow_name
+            ).read_text(encoding="utf-8")
+            windows_start = workflow.index("target: x86_64-pc-windows-msvc")
+            windows_end = workflow.index("runs-on:", windows_start)
+            windows_matrix = workflow[windows_start:windows_end]
+            self.assertIn("linker=rust-lld", windows_matrix)
+            self.assertIn("linker-flavor=lld-link", windows_matrix)
+            self.assertIn("link-arg=/Brepro", windows_matrix)
+            self.assertIn(
+                "Expose and prove the Rust-bundled Windows linker",
+                workflow,
+            )
+            self.assertIn(
+                "${sysroot}/lib/rustlib/${host}/bin/rust-lld.exe",
+                workflow,
+            )
+            self.assertIn(r"grep -E '^LLD 22\.1\.2 '", workflow)
 
     def test_shipping_firmware_reuses_one_embedded_site_build(self) -> None:
         shipping = (


### PR DESCRIPTION
## Summary

- link Windows prnsd and hopspot-flash release binaries with the rust-lld bundled in pinned Rust 1.96
- retain the PE reproducibility flag and verify LLD 22.1.2 before each Windows build
- record the linker version in native linkage evidence and guard both workflows with release-contract tests

## Root cause

Primary and reproduction jobs received different windows-2025 runner image revisions. Their MSVC linkers emitted different PE Rich records and CodeView identities despite identical source and Rust versions. Binding the linker to the Rust toolchain removes the mutable runner linker from the release input set.

## Validation

- full release-contract suite: 164 tests passed on synchronized trunk
- protected-main focused workflow contract passed
- repository verifier and pre-push formatting/documentation gate passed