### PR TITLE
Remove host-sensitive Windows PDB identity

### DIFF
--- a/.github/workflows/flasher-candidate.yml
+++ b/.github/workflows/flasher-candidate.yml
@@ -244,7 +244,7 @@ jobs:
           - os: windows-2025
             target: x86_64-pc-windows-msvc
             binary: target/x86_64-pc-windows-msvc/release/hopspot-flash.exe
-            rustflags: -D warnings -C linker=rust-lld -C linker-flavor=lld-link -C link-arg=/Brepro
+            rustflags: -D warnings -C linker=rust-lld -C linker-flavor=lld-link -C link-arg=/Brepro -C link-arg=/debug:none
     runs-on: ${{ matrix.platform.os }}
     timeout-minutes: 180
     env:
@@ -257,6 +257,7 @@ jobs:
         with:
           toolchain: 1.96.0
           targets: ${{ matrix.platform.target }}
+          components: llvm-tools-preview
       - name: Expose and prove the Rust-bundled Windows linker
         if: matrix.platform.target == 'x86_64-pc-windows-msvc'
         shell: bash
@@ -279,6 +280,20 @@ jobs:
           echo "SOURCE_DATE_EPOCH=$(git show -s --format=%ct "$GITHUB_SHA")" >> "$GITHUB_ENV"
       - name: Build standalone CLI from locked dependencies
         run: cargo build --release --locked -p hopspot-flash --target ${{ matrix.platform.target }}
+      - name: Reject unshipped Windows PDB identity
+        if: matrix.platform.target == 'x86_64-pc-windows-msvc'
+        shell: bash
+        run: |
+          sysroot="$(cygpath --unix "$(rustc --print sysroot)")"
+          host="$(rustc --print host-tuple)"
+          llvm_readobj="${sysroot}/lib/rustlib/${host}/bin/llvm-readobj.exe"
+          test -x "$llvm_readobj"
+          debug_directory="$("$llvm_readobj" --coff-debug-directory "${{ matrix.platform.binary }}")"
+          printf '%s\n' "$debug_directory"
+          if grep -Eiq 'PDBFileName:|\.pdb([[:space:]]|$)' <<< "$debug_directory"; then
+            echo "release binary contains an unshipped PDB identity" >&2
+            exit 1
+          fi
       - name: Package deterministic archive
         run: ./tools/prns release cli package -- --binary "${{ matrix.platform.binary }}" --target "${{ matrix.platform.target }}" --out-dir target/flasher-cli
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/.github/workflows/prnsd-candidate.yml
+++ b/.github/workflows/prnsd-candidate.yml
@@ -43,7 +43,7 @@ jobs:
           - os: windows-2025
             target: x86_64-pc-windows-msvc
             binary: prnsd/target/x86_64-pc-windows-msvc/release/prnsd.exe
-            rustflags: -D warnings -C linker=rust-lld -C linker-flavor=lld-link -C link-arg=/Brepro
+            rustflags: -D warnings -C linker=rust-lld -C linker-flavor=lld-link -C link-arg=/Brepro -C link-arg=/debug:none
     runs-on: ${{ matrix.platform.os }}
     timeout-minutes: 180
     env:
@@ -91,6 +91,20 @@ jobs:
             --target "${{ matrix.platform.target }}" \
             --no-default-features \
             --features tokio-host,observability,tray
+      - name: Reject unshipped Windows PDB identity
+        if: matrix.platform.target == 'x86_64-pc-windows-msvc'
+        shell: bash
+        run: |
+          sysroot="$(cygpath --unix "$(rustc --print sysroot)")"
+          host="$(rustc --print host-tuple)"
+          llvm_readobj="${sysroot}/lib/rustlib/${host}/bin/llvm-readobj.exe"
+          test -x "$llvm_readobj"
+          debug_directory="$("$llvm_readobj" --coff-debug-directory "${{ matrix.platform.binary }}")"
+          printf '%s\n' "$debug_directory"
+          if grep -Eiq 'PDBFileName:|\.pdb([[:space:]]|$)' <<< "$debug_directory"; then
+            echo "release binary contains an unshipped PDB identity" >&2
+            exit 1
+          fi
       - name: Record native linkage
         shell: bash
         run: |
@@ -122,6 +136,7 @@ jobs:
                 file "${{ matrix.platform.binary }}"
                 "$rust_lld" -flavor link --version
                 "$llvm_readobj" --coff-imports "${{ matrix.platform.binary }}"
+                "$llvm_readobj" --coff-debug-directory "${{ matrix.platform.binary }}"
               } > "$evidence"
               ;;
             *)

--- a/tools/tests/test_flasher_reproducibility.py
+++ b/tools/tests/test_flasher_reproducibility.py
@@ -707,6 +707,7 @@ class FlasherReproducibilityTests(unittest.TestCase):
             self.assertIn("linker=rust-lld", windows_matrix)
             self.assertIn("linker-flavor=lld-link", windows_matrix)
             self.assertIn("link-arg=/Brepro", windows_matrix)
+            self.assertIn("link-arg=/debug:none", windows_matrix)
             self.assertIn(
                 "Expose and prove the Rust-bundled Windows linker",
                 workflow,
@@ -716,6 +717,9 @@ class FlasherReproducibilityTests(unittest.TestCase):
                 workflow,
             )
             self.assertIn(r"grep -E '^LLD 22\.1\.2 '", workflow)
+            self.assertIn("Reject unshipped Windows PDB identity", workflow)
+            self.assertIn("--coff-debug-directory", workflow)
+            self.assertIn("PDBFileName:", workflow)
 
     def test_shipping_firmware_reuses_one_embedded_site_build(self) -> None:
         shipping = (


### PR DESCRIPTION
## Summary
- suppress the unshipped Windows PDB/CodeView identity after enabling reproducible LLD linking
- reject any packaged Windows binary that still names a PDB
- record the PE debug directory in native linkage evidence
- extend the workflow regression contract across both native and flasher producers

## Evidence
- focused workflow contract: passed
- release workflow contracts: passed
- full tooling/release suite: 164/164 passed
- `./tools/prns verify`: passed
- `cargo fmt --all --check`: passed
- trunk pre-push repository/format/docs gates: passed

This removes the final 20 host-sensitive metadata bytes observed in both Windows reproduction failures without weakening byte-for-byte custody.