### PR TITLE
Add Heltec V4-R8 as a separate shipping board from S3R2 V4

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -23,6 +23,7 @@ Entries are deduplicated by SPDX identifier and canonical notice text; line endi
 - nRF52840: `personal-hopspot/embedded/nrf52840/Cargo.toml` (`thumbv7em-none-eabihf`, locked resolution)
 - ESP32-C6: `personal-hopspot/embedded/esp32/boards/xiao-esp32-c6/Cargo.toml` (`riscv32imac-unknown-none-elf`, locked resolution)
 - ESP32-S3 Heltec: `personal-hopspot/embedded/esp32/boards/heltec-v4/Cargo.toml` (`xtensa-esp32s3-none-elf`, locked resolution)
+- ESP32-S3 Heltec R8: `personal-hopspot/embedded/esp32/boards/heltec-v4-r8/Cargo.toml` (`xtensa-esp32s3-none-elf`, locked resolution)
 - ESP32-S3 T-Beam: `personal-hopspot/embedded/esp32/boards/t-beam-supreme/Cargo.toml` (`xtensa-esp32s3-none-elf`, locked resolution)
 - WASM: `prns-wasm/Cargo.toml` (`wasm32-unknown-unknown`, locked resolution)
 - website Rust/WASM: `docs/website/Cargo.toml` (`wasm32-unknown-unknown`, locked resolution)
@@ -84,7 +85,7 @@ License: BSD Zero Clause License
 
 Used by: `managed 0.8.0`
 
-Release graphs: ESP32-S3 Heltec, ESP32-S3 T-Beam
+Release graphs: ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam
 
 ```text
 Copyright (C) 2017 whitequark@whitequark.org
@@ -107,7 +108,7 @@ License: BSD Zero Clause License
 
 Used by: `smoltcp 0.13.1`
 
-Release graphs: ESP32-S3 Heltec, ESP32-S3 T-Beam
+Release graphs: ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam
 
 ```text
 Copyright (C) smoltcp contributors
@@ -1411,7 +1412,7 @@ License: Apache License 2.0
 
 Used by: `dunce 1.0.5`, `ryu 1.0.23`, `serial2 0.2.37`, `serial2-tokio 0.1.24`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, website Rust/WASM
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, website Rust/WASM
 
 ```text
 Apache License
@@ -1727,7 +1728,7 @@ License: BSD 3-Clause "New" or "Revised" License
 
 Used by: `subtle 2.6.1`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840
 
 ```text
 Copyright (c) 2016-2017 Isis Agora Lovecruft, Henry de Valence. All rights reserved.
@@ -1767,7 +1768,7 @@ License: BSD 3-Clause "New" or "Revised" License
 
 Used by: `curve25519-dalek 4.1.3`, `nrf-pac 0.3.0`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
 
 ```text
 Copyright (c) <year> <owner>.
@@ -1789,7 +1790,7 @@ License: BSD 3-Clause "New" or "Revised" License
 
 Used by: `ed25519-dalek 2.2.0`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
 
 ```text
 Copyright (c) 2017-2019 isis agora lovecruft. All rights reserved.
@@ -1828,7 +1829,7 @@ License: BSD 3-Clause "New" or "Revised" License
 
 Used by: `x25519-dalek 2.0.1`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
 
 ```text
 Copyright (c) 2017-2021 isis agora lovecruft. All rights reserved.
@@ -2264,7 +2265,7 @@ License: MIT License
 
 Used by: `gimli 0.32.3`, `heck 0.4.1`, `heck 0.5.0`, `unicode-segmentation 1.13.2`, `unicode-segmentation 1.13.3`, `unicode-width 0.1.14`, `unicode-width 0.2.2`, `unicode-xid 0.2.6`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, website Rust/WASM
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, website Rust/WASM
 
 ```text
 Copyright (c) 2015 The Rust Project Developers
@@ -2300,7 +2301,7 @@ License: MIT License
 
 Used by: `unicase 2.9.0`
 
-Release graphs: ESP32-S3 Heltec, ESP32-S3 T-Beam, website Rust/WASM
+Release graphs: ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, website Rust/WASM
 
 ```text
 Copyright (c) 2014-2026 Sean McArthur
@@ -2360,9 +2361,9 @@ SOFTWARE.
 
 License: MIT License
 
-Used by: `bitfield-macros 0.19.4`, `block2 0.5.1`, `block2 0.6.2`, `bluez-async 0.8.2`, `bluez-generated 0.4.0`, `btleplug 0.12.0`, `btuuid 0.1.1`, `cesu8 1.1.0`, `const-serialize 0.7.2`, `const-serialize 0.8.0-alpha.0`, `const-serialize-macro 0.7.2`, `const-serialize-macro 0.8.0-alpha.0`, `cortex-m-rt 0.7.5`, `cortex-m-rt-macros 0.7.5`, `custom_debug 0.6.2`, `custom_debug_derive 0.6.2`, `deku_derive 0.18.1`, `delegate 0.13.5`, `dioxus 0.7.5`, `dioxus-asset-resolver 0.7.9`, `dioxus-cli-config 0.7.9`, `dioxus-config-macro 0.7.9`, `dioxus-config-macros 0.7.9`, `dioxus-core 0.7.9`, `dioxus-core-macro 0.7.9`, `dioxus-core-types 0.7.9`, `dioxus-devtools 0.7.9`, `dioxus-devtools-types 0.7.9`, `dioxus-document 0.7.9`, `dioxus-history 0.7.9`, `dioxus-hooks 0.7.9`, `dioxus-html 0.7.9`, `dioxus-html-internal-macro 0.7.9`, `dioxus-interpreter-js 0.7.9`, `dioxus-logger 0.7.9`, `dioxus-router 0.7.9`, `dioxus-router-macro 0.7.9`, `dioxus-rsx 0.7.9`, `dioxus-signals 0.7.9`, `dioxus-stores 0.7.9`, `dioxus-stores-macro 0.7.9`, `dioxus-web 0.7.9`, `dispatch 0.2.0`, `dispatch2 0.3.1`, `dlopen2 0.8.2`, `docs 0.1.0`, `docsplay-macros 0.1.2`, `dpi 0.1.2`, `embassy-embedded-hal 0.6.0`, `embassy-executor 0.10.0`, `embassy-executor-macros 0.8.0`, `embassy-executor-timer-queue 0.1.0`, `embassy-futures 0.1.2`, `embassy-hal-internal 0.4.0`, `embassy-hal-internal 0.5.0`, `embassy-net 0.9.1`, `embassy-net-driver 0.2.0`, `embassy-net-driver-channel 0.4.0`, `embassy-nrf 0.10.0`, `embassy-sync 0.6.2`, `embassy-sync 0.7.2`, `embassy-sync 0.8.0`, `embassy-time 0.5.1`, `embassy-time-driver 0.2.2`, `embassy-time-queue-utils 0.3.2`, `embassy-usb 0.6.0`, `embassy-usb-driver 0.2.2`, `embassy-usb-synopsys-otg 0.3.3`, `embedded-graphics-core 0.4.1`, `embedded-nal-async 0.9.0`, `esp-alloc 0.10.0`, `esp-backtrace 0.19.0`, `esp-bootloader-esp-idf 0.5.0`, `esp-config 0.7.0`, `esp-hal 1.1.1`, `esp-hal-procmacros 0.22.0`, `esp-metadata-generated 0.4.0`, `esp-phy 0.2.0`, `esp-println 0.17.0`, `esp-radio 0.18.0`, `esp-radio-rtos-driver 0.3.0`, `esp-riscv-rt 0.14.0`, `esp-rom-sys 0.1.4`, `esp-rtos 0.3.0`, `esp-sync 0.2.1`, `esp-wifi-sys-esp32c6 0.2.0`, `esp-wifi-sys-esp32s3 0.2.0`, `esp32c6 0.23.2`, `esp32s3 0.35.2`, `fluent-langneg 0.13.1`, `generational-box 0.7.9`, `gloo-timers 0.3.0`, `hopspot-flash 0.3.2`, `hopspot-heltec-v4 0.1.0`, `hopspot-t-beam-supreme 0.1.0`, `hopspot-xiao-esp32-c6 0.1.0`, `intl_pluralrules 7.0.2`, `jni-sys-macros 0.4.1`, `lazy-js-bundle 0.7.9`, `macaddr 1.0.1`, `manganis 0.7.9`, `manganis-core 0.7.9`, `manganis-macro 0.7.9`, `minisign-verify 0.2.5`, `napi 3.11.0`, `napi-build 2.3.2`, `napi-derive 3.6.0`, `napi-derive-backend 6.0.0`, `napi-sys 3.3.0`, `ndk-context 0.1.1`, `netlink-packet-core 0.8.1`, `netlink-sys 0.8.8`, `nrf-softdevice 0.1.0`, `nrf-softdevice-macro 0.1.0`, `objc-sys 0.3.5`, `objc2 0.5.2`, `objc2 0.6.4`, `objc2-app-kit 0.2.2`, `objc2-app-kit 0.3.2`, `objc2-core-bluetooth 0.2.2`, `objc2-core-bluetooth 0.3.2`, `objc2-core-foundation 0.3.2`, `objc2-core-graphics 0.3.2`, `objc2-core-wlan 0.3.2`, `objc2-encode 4.1.0`, `objc2-foundation 0.2.2`, `objc2-foundation 0.3.2`, `objc2-io-kit 0.3.2`, `objc2-security 0.3.2`, `objc2-security-foundation 0.3.2`, `objc2-system-configuration 0.3.2`, `ouroboros 0.18.5`, `ouroboros_macro 0.18.5`, `parse_int 0.9.0`, `personal-hopspot-android 0.1.0`, `personal-hopspot-core 0.1.0`, `personal-hopspot-desktop 0.1.0`, `personal-hopspot-esp32 0.1.0`, `personal-hopspot-ios 0.1.0`, `personal-rns 0.3.2`, `portable_atomic_enum 0.3.1`, `portable_atomic_enum_macros 0.2.1`, `prns-config 0.3.2`, `prns-core 0.3.2`, `prns-ffi 0.3.2`, `prns-flash-manifest 0.1.0`, `prns-host 0.3.2`, `prns-host-cooperative 0.3.2`, `prns-host-native 0.3.2`, `prns-interfaces-embassy 0.3.2`, `prns-interfaces-tokio 0.3.2`, `prns-runtime 0.3.2`, `prns-runtime-embassy 0.3.2`, `prns-runtime-tokio 0.3.2`, `prns-tools-command 0.1.0`, `prns-wasm 0.3.2`, `prnsd 0.3.2`, `prnsd-control 0.1.0`, `reticulum-site 0.1.0`, `riscv-macros 0.3.0`, `riscv-rt-macros 0.6.1`, `rlsf 0.2.2`, `sledgehammer_bindgen 0.6.0`, `sledgehammer_bindgen_macro 0.6.5`, `sledgehammer_utils 0.3.1`, `subsecond 0.7.9`, `subsecond-types 0.7.9`, `t-echo 0.1.0`, `tokio-udev 0.9.1`, `trouble-host 0.6.0`, `trouble-host-macros 0.4.0`, `type-map 0.5.1`, `ufmt-write 0.1.0`, `usbd-hid-descriptors 0.10.0`, `usbd-hid-macros 0.10.0`, `void 1.0.2`, `warnings 0.2.1`, `warnings-macro 0.2.0`, `windows 0.58.0`, `windows 0.62.2`, `windows-collections 0.3.2`, `windows-core 0.58.0`, `windows-core 0.62.2`, `windows-future 0.3.2`, `windows-implement 0.58.0`, `windows-implement 0.60.2`, `windows-interface 0.58.0`, `windows-interface 0.59.3`, `windows-link 0.2.1`, `windows-numerics 0.3.1`, `windows-result 0.2.0`, `windows-result 0.4.1`, `windows-strings 0.1.0`, `windows-strings 0.5.1`, `windows-sys 0.52.0`, `windows-sys 0.59.0`, `windows-sys 0.61.2`, `windows-targets 0.52.6`, `windows-threading 0.2.1`, `windows_x86_64_msvc 0.52.6`, `xtensa-lx 0.13.0`, `xtensa-lx-rt 0.22.0`, `xtensa-lx-rt-proc-macros 0.5.0`
+Used by: `bitfield-macros 0.19.4`, `block2 0.5.1`, `block2 0.6.2`, `bluez-async 0.8.2`, `bluez-generated 0.4.0`, `btleplug 0.12.0`, `btuuid 0.1.1`, `cesu8 1.1.0`, `const-serialize 0.7.2`, `const-serialize 0.8.0-alpha.0`, `const-serialize-macro 0.7.2`, `const-serialize-macro 0.8.0-alpha.0`, `cortex-m-rt 0.7.5`, `cortex-m-rt-macros 0.7.5`, `custom_debug 0.6.2`, `custom_debug_derive 0.6.2`, `deku_derive 0.18.1`, `delegate 0.13.5`, `dioxus 0.7.5`, `dioxus-asset-resolver 0.7.9`, `dioxus-cli-config 0.7.9`, `dioxus-config-macro 0.7.9`, `dioxus-config-macros 0.7.9`, `dioxus-core 0.7.9`, `dioxus-core-macro 0.7.9`, `dioxus-core-types 0.7.9`, `dioxus-devtools 0.7.9`, `dioxus-devtools-types 0.7.9`, `dioxus-document 0.7.9`, `dioxus-history 0.7.9`, `dioxus-hooks 0.7.9`, `dioxus-html 0.7.9`, `dioxus-html-internal-macro 0.7.9`, `dioxus-interpreter-js 0.7.9`, `dioxus-logger 0.7.9`, `dioxus-router 0.7.9`, `dioxus-router-macro 0.7.9`, `dioxus-rsx 0.7.9`, `dioxus-signals 0.7.9`, `dioxus-stores 0.7.9`, `dioxus-stores-macro 0.7.9`, `dioxus-web 0.7.9`, `dispatch 0.2.0`, `dispatch2 0.3.1`, `dlopen2 0.8.2`, `docs 0.1.0`, `docsplay-macros 0.1.2`, `dpi 0.1.2`, `embassy-embedded-hal 0.6.0`, `embassy-executor 0.10.0`, `embassy-executor-macros 0.8.0`, `embassy-executor-timer-queue 0.1.0`, `embassy-futures 0.1.2`, `embassy-hal-internal 0.4.0`, `embassy-hal-internal 0.5.0`, `embassy-net 0.9.1`, `embassy-net-driver 0.2.0`, `embassy-net-driver-channel 0.4.0`, `embassy-nrf 0.10.0`, `embassy-sync 0.6.2`, `embassy-sync 0.7.2`, `embassy-sync 0.8.0`, `embassy-time 0.5.1`, `embassy-time-driver 0.2.2`, `embassy-time-queue-utils 0.3.2`, `embassy-usb 0.6.0`, `embassy-usb-driver 0.2.2`, `embassy-usb-synopsys-otg 0.3.3`, `embedded-graphics-core 0.4.1`, `embedded-nal-async 0.9.0`, `esp-alloc 0.10.0`, `esp-backtrace 0.19.0`, `esp-bootloader-esp-idf 0.5.0`, `esp-config 0.7.0`, `esp-hal 1.1.1`, `esp-hal-procmacros 0.22.0`, `esp-metadata-generated 0.4.0`, `esp-phy 0.2.0`, `esp-println 0.17.0`, `esp-radio 0.18.0`, `esp-radio-rtos-driver 0.3.0`, `esp-riscv-rt 0.14.0`, `esp-rom-sys 0.1.4`, `esp-rtos 0.3.0`, `esp-sync 0.2.1`, `esp-wifi-sys-esp32c6 0.2.0`, `esp-wifi-sys-esp32s3 0.2.0`, `esp32c6 0.23.2`, `esp32s3 0.35.2`, `fluent-langneg 0.13.1`, `generational-box 0.7.9`, `gloo-timers 0.3.0`, `hopspot-flash 0.3.2`, `hopspot-heltec-v4 0.1.0`, `hopspot-heltec-v4-r8 0.1.0`, `hopspot-t-beam-supreme 0.1.0`, `hopspot-xiao-esp32-c6 0.1.0`, `intl_pluralrules 7.0.2`, `jni-sys-macros 0.4.1`, `lazy-js-bundle 0.7.9`, `macaddr 1.0.1`, `manganis 0.7.9`, `manganis-core 0.7.9`, `manganis-macro 0.7.9`, `minisign-verify 0.2.5`, `napi 3.11.0`, `napi-build 2.3.2`, `napi-derive 3.6.0`, `napi-derive-backend 6.0.0`, `napi-sys 3.3.0`, `ndk-context 0.1.1`, `netlink-packet-core 0.8.1`, `netlink-sys 0.8.8`, `nrf-softdevice 0.1.0`, `nrf-softdevice-macro 0.1.0`, `objc-sys 0.3.5`, `objc2 0.5.2`, `objc2 0.6.4`, `objc2-app-kit 0.2.2`, `objc2-app-kit 0.3.2`, `objc2-core-bluetooth 0.2.2`, `objc2-core-bluetooth 0.3.2`, `objc2-core-foundation 0.3.2`, `objc2-core-graphics 0.3.2`, `objc2-core-wlan 0.3.2`, `objc2-encode 4.1.0`, `objc2-foundation 0.2.2`, `objc2-foundation 0.3.2`, `objc2-io-kit 0.3.2`, `objc2-security 0.3.2`, `objc2-security-foundation 0.3.2`, `objc2-system-configuration 0.3.2`, `ouroboros 0.18.5`, `ouroboros_macro 0.18.5`, `parse_int 0.9.0`, `personal-hopspot-android 0.1.0`, `personal-hopspot-core 0.1.0`, `personal-hopspot-desktop 0.1.0`, `personal-hopspot-esp32 0.1.0`, `personal-hopspot-ios 0.1.0`, `personal-rns 0.3.2`, `portable_atomic_enum 0.3.1`, `portable_atomic_enum_macros 0.2.1`, `prns-config 0.3.2`, `prns-core 0.3.2`, `prns-ffi 0.3.2`, `prns-flash-manifest 0.1.0`, `prns-host 0.3.2`, `prns-host-cooperative 0.3.2`, `prns-host-native 0.3.2`, `prns-interfaces-embassy 0.3.2`, `prns-interfaces-tokio 0.3.2`, `prns-runtime 0.3.2`, `prns-runtime-embassy 0.3.2`, `prns-runtime-tokio 0.3.2`, `prns-tools-command 0.1.0`, `prns-wasm 0.3.2`, `prnsd 0.3.2`, `prnsd-control 0.1.0`, `reticulum-site 0.1.0`, `riscv-macros 0.3.0`, `riscv-rt-macros 0.6.1`, `rlsf 0.2.2`, `sledgehammer_bindgen 0.6.0`, `sledgehammer_bindgen_macro 0.6.5`, `sledgehammer_utils 0.3.1`, `subsecond 0.7.9`, `subsecond-types 0.7.9`, `t-echo 0.1.0`, `tokio-udev 0.9.1`, `trouble-host 0.6.0`, `trouble-host-macros 0.4.0`, `type-map 0.5.1`, `ufmt-write 0.1.0`, `usbd-hid-descriptors 0.10.0`, `usbd-hid-macros 0.10.0`, `void 1.0.2`, `warnings 0.2.1`, `warnings-macro 0.2.0`, `windows 0.58.0`, `windows 0.62.2`, `windows-collections 0.3.2`, `windows-core 0.58.0`, `windows-core 0.62.2`, `windows-future 0.3.2`, `windows-implement 0.58.0`, `windows-implement 0.60.2`, `windows-interface 0.58.0`, `windows-interface 0.59.3`, `windows-link 0.2.1`, `windows-numerics 0.3.1`, `windows-result 0.2.0`, `windows-result 0.4.1`, `windows-strings 0.1.0`, `windows-strings 0.5.1`, `windows-sys 0.52.0`, `windows-sys 0.59.0`, `windows-sys 0.61.2`, `windows-targets 0.52.6`, `windows-threading 0.2.1`, `windows_x86_64_msvc 0.52.6`, `xtensa-lx 0.13.0`, `xtensa-lx-rt 0.22.0`, `xtensa-lx-rt-proc-macros 0.5.0`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
 
 ```text
 MIT License
@@ -2623,7 +2624,7 @@ License: MIT License
 
 Used by: `uuid 1.23.3`, `uuid 1.23.4`, `uuid 1.23.5`, `uuid 1.24.0`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, daemon Linux, daemon Windows, daemon macOS, desktop Linux, nRF52840
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, daemon Linux, daemon Windows, daemon macOS, desktop Linux, nRF52840
 
 ```text
 Copyright (c) 2014 The Rust Project Developers
@@ -2732,7 +2733,7 @@ License: MIT License
 
 Used by: `bitflags 1.3.2`, `bitflags 2.11.1`, `bitflags 2.12.1`, `bitflags 2.13.0`, `bitflags 2.13.1`, `log 0.4.30`, `log 0.4.31`, `log 0.4.32`, `log 0.4.33`, `num-bigint 0.4.8`, `num-derive 0.4.2`, `num-integer 0.1.46`, `num-traits 0.2.19`, `regex 1.12.3`, `regex 1.13.1`, `regex-automata 0.4.14`, `regex-automata 0.4.15`, `regex-automata 0.4.16`, `regex-syntax 0.8.10`, `regex-syntax 0.8.11`, `semver 0.9.0`, `serde-pickle 1.2.0`, `serde_plain 1.0.2`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
 
 ```text
 Copyright (c) 2014 The Rust Project Developers
@@ -2786,7 +2787,7 @@ License: MIT License
 
 Used by: `aho-corasick 1.1.4`, `byteorder 1.5.0`, `byteorder-lite 0.1.0`, `csv 1.4.0`, `csv-core 0.1.13`, `jiff 0.2.28`, `memchr 2.8.0`, `memchr 2.8.1`, `memchr 2.8.2`, `memchr 2.8.3`, `termcolor 1.4.1`, `walkdir 2.5.0`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
 
 ```text
 The MIT License (MIT)
@@ -2818,7 +2819,7 @@ License: MIT License
 
 Used by: `half 2.7.1`, `ident_case 1.0.1`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, daemon Linux, desktop Linux, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, nRF52840, website Rust/WASM
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, daemon Linux, desktop Linux, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, nRF52840, website Rust/WASM
 
 ```text
 MIT License
@@ -2848,7 +2849,7 @@ License: MIT License
 
 Used by: `scopeguard 1.2.0`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, daemon Linux, daemon Windows, daemon macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, website Rust/WASM
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, daemon Linux, daemon Windows, daemon macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, website Rust/WASM
 
 ```text
 Copyright (c) 2016-2019 Ulrik Sverdrup "bluss" and scopeguard developers
@@ -2946,7 +2947,7 @@ License: MIT License
 
 Used by: `flate2 1.1.9`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
 
 ```text
 Copyright (c) 2014-2026 Alex Crichton
@@ -3014,7 +3015,7 @@ License: MIT License
 
 Used by: `az 1.2.1`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, WASM, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, WASM, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
 
 ```text
 Copyright © 2019–2021 Trevor Spiteri
@@ -3080,7 +3081,7 @@ License: MIT License
 
 Used by: `strum 0.26.3`, `strum 0.27.2`, `strum 0.28.0`, `strum_macros 0.26.4`, `strum_macros 0.27.2`, `strum_macros 0.28.0`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, daemon Linux, desktop Linux, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, daemon Linux, desktop Linux, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
 
 ```text
 MIT License
@@ -3206,7 +3207,7 @@ License: MIT License
 
 Used by: `hkdf 0.13.0`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
 
 ```text
 Copyright (c) 2015-2018 Vlad Filippov
@@ -3400,7 +3401,7 @@ License: MIT License
 
 Used by: `adler2 2.0.1`, `allocator-api2 0.3.1`, `anyhow 1.0.102`, `async-recursion 1.1.1`, `async-trait 0.1.89`, `async-trait 0.1.91`, `concurrent-queue 2.5.0`, `ctrlc 3.5.2`, `curve25519-dalek-derive 0.1.1`, `deku 0.18.1`, `displaydoc 0.2.6`, `displaydoc 0.2.7`, `docsplay 0.1.3`, `endi 1.1.1`, `event-listener 5.4.1`, `event-listener-strategy 0.5.4`, `fastrand 2.4.1`, `fastrand 2.5.0`, `flume 0.12.0`, `futures-lite 2.6.1`, `home 0.5.12`, `indoc 2.0.7`, `iter-read 1.1.0`, `itoa 1.0.18`, `linux-raw-sys 0.12.1`, `macro-string 0.1.4`, `num_enum 0.7.6`, `num_enum_derive 0.7.6`, `nusb 0.2.4`, `once_cell 1.21.4`, `ordered-stream 0.2.0`, `parking 2.2.1`, `paste 1.0.15`, `pastey 0.2.3`, `pin-project 1.1.13`, `pin-project-internal 1.1.13`, `pin-project-lite 0.2.17`, `portable-atomic 1.13.1`, `proc-macro-crate 3.5.0`, `proc-macro2 1.0.106`, `proc-macro2 1.0.107`, `quote 1.0.45`, `quote 1.0.46`, `quote 1.0.47`, `rtrb 0.3.4`, `rustc-hash 1.1.0`, `rustc-hash 2.1.2`, `rustc-hash 2.1.3`, `rustix 1.1.4`, `rustversion 1.0.22`, `rustversion 1.0.23`, `semver 1.0.28`, `send_wrapper 0.6.0`, `serde 1.0.228`, `serde 1.0.229`, `serde_core 1.0.228`, `serde_core 1.0.229`, `serde_derive 1.0.228`, `serde_derive 1.0.229`, `serde_json 1.0.150`, `serde_json 1.0.151`, `serde_repr 0.1.21`, `serde_yaml 0.9.34+deprecated`, `smol_str 0.2.2`, `syn 1.0.109`, `syn 2.0.117`, `syn 2.0.118`, `syn 2.0.119`, `syn 3.0.2`, `syn 3.0.3`, `thiserror 1.0.69`, `thiserror 2.0.18`, `thiserror 2.0.19`, `thiserror-impl 1.0.69`, `thiserror-impl 2.0.18`, `thiserror-impl 2.0.19`, `unic-langid 0.9.6`, `unic-langid-impl 0.9.6`, `unic-langid-macros 0.9.6`, `unic-langid-macros-impl 0.9.6`, `unicode-ident 1.0.24`, `unsafe-libyaml 0.2.11`, `utf-8 0.7.6`, `utf8-zero 0.8.1`, `wasm-streams 0.4.2`, `zmij 1.0.21`, `zmij 1.0.23`, `zvariant_utils 3.5.0`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
 
 ```text
 Permission is hereby granted, free of charge, to any
@@ -3496,7 +3497,7 @@ License: MIT License
 
 Used by: `aes 0.8.4`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
 
 ```text
 Copyright (c) 2018 Artyom Pavlov
@@ -3599,7 +3600,7 @@ License: MIT License
 
 Used by: `object 0.37.3`, `object 0.39.1`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
 
 ```text
 Copyright (c) 2015 The Gimli Developers
@@ -3635,7 +3636,7 @@ License: MIT License
 
 Used by: `critical-section 1.2.0`, `static_cell 2.1.1`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, nRF52840
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, nRF52840
 
 ```text
 Copyright (c) 2022 The critical-section authors
@@ -3671,7 +3672,7 @@ License: MIT License
 
 Used by: `bt-hci 0.8.1`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam
 
 ```text
 Copyright (c) Embassy project contributors
@@ -3981,7 +3982,7 @@ License: MIT License
 
 Used by: `md-5 0.10.6`, `sha1 0.10.7`, `sha2 0.10.9`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
 
 ```text
 Copyright (c) 2006-2009 Graydon Hoare
@@ -4019,7 +4020,7 @@ License: MIT License
 
 Used by: `hash32 0.3.1`, `panic-halt 1.0.0`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
 
 ```text
 Copyright (c) 2018 Jorge Aparicio
@@ -4091,7 +4092,7 @@ License: MIT License
 
 Used by: `document-features 0.2.12`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, nRF52840
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, nRF52840
 
 ```text
 Copyright (c) 2020 Olivier Goffart <ogoffart@sixtyfps.io>
@@ -4121,7 +4122,7 @@ License: MIT License
 
 Used by: `equivalent 1.0.2`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Node addon macOS, daemon Linux, daemon macOS, desktop Linux, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Node addon macOS, daemon Linux, daemon macOS, desktop Linux, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
 
 ```text
 Copyright (c) 2016--2023
@@ -4157,7 +4158,7 @@ License: MIT License
 
 Used by: `ctutils 0.4.2`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
 
 ```text
 Copyright (c) 2025-2026 The RustCrypto Project Developers
@@ -4193,7 +4194,7 @@ License: MIT License
 
 Used by: `anstream 1.0.0`, `anstyle 1.0.14`, `anstyle-parse 1.0.0`, `anstyle-query 1.1.5`, `anstyle-wincon 3.0.11`, `clap 4.6.1`, `clap_builder 4.6.0`, `clap_derive 4.6.1`, `clap_lex 1.1.0`, `colorchoice 1.0.5`, `env_filter 0.1.4`, `is_terminal_polyfill 1.70.2`, `once_cell_polyfill 1.70.2`, `serde_spanned 1.1.1`, `toml 1.1.3+spec-1.1.0`, `toml 1.1.4+spec-1.1.0`, `toml_datetime 1.1.1+spec-1.1.0`, `toml_edit 0.25.12+spec-1.1.0`, `toml_edit 0.25.13+spec-1.1.0`, `toml_parser 1.1.2+spec-1.1.0`, `toml_parser 1.1.3+spec-1.1.0`, `toml_writer 1.1.2+spec-1.1.0`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, daemon Linux, daemon Windows, daemon macOS, desktop Linux, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, daemon Linux, daemon Windows, daemon macOS, desktop Linux, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
 
 ```text
 Copyright (c) Individual contributors
@@ -4260,7 +4261,7 @@ License: MIT License
 
 Used by: `embedded-storage-async 0.4.1`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, WASM, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, WASM, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
 
 ```text
 Copyright (c) 2022 Diego Barrios Romero
@@ -4383,7 +4384,7 @@ License: MIT License
 
 Used by: `zeroize_derive 1.4.3`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, daemon Linux, daemon Windows, daemon macOS, engine, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, daemon Linux, daemon Windows, daemon macOS, engine, iOS, nRF52840
 
 ```text
 MIT License
@@ -4473,7 +4474,7 @@ License: MIT License
 
 Used by: `indexmap 2.14.0`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Node addon macOS, daemon Linux, daemon macOS, desktop Linux, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Node addon macOS, daemon Linux, daemon macOS, desktop Linux, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
 
 ```text
 Copyright (c) 2016--2017
@@ -4545,7 +4546,7 @@ License: MIT License
 
 Used by: `md-5 0.11.0`, `sha2 0.11.0`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840
 
 ```text
 Copyright (c) 2016-2026 The RustCrypto Project Developers
@@ -4584,7 +4585,7 @@ License: MIT License
 
 Used by: `futures-intrusive 0.5.0`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam
 
 ```text
 Copyright (c) 2019 Matthias Einwag
@@ -4820,7 +4821,7 @@ License: MIT License
 
 Used by: `stable_deref_trait 1.2.1`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
 
 ```text
 Copyright (c) 2017 Robert Grosse
@@ -4892,7 +4893,7 @@ License: MIT License
 
 Used by: `block-buffer 0.10.4`, `block-padding 0.3.3`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
 
 ```text
 Copyright (c) 2018-2019 The RustCrypto Project Developers
@@ -4928,7 +4929,7 @@ License: MIT License
 
 Used by: `simd-adler32 0.3.10`, `simd-adler32 0.3.9`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
 
 ```text
 MIT License
@@ -5059,7 +5060,7 @@ License: MIT License
 
 Used by: `crypto-common 0.1.7`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
 
 ```text
 Copyright (c) 2021 RustCrypto Developers
@@ -5095,7 +5096,7 @@ License: MIT License
 
 Used by: `svgbobdoc 0.3.0`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam
 
 ```text
 Copyright 2017 yvt
@@ -5113,7 +5114,7 @@ License: MIT License
 
 Used by: `base64 0.13.1`, `base64 0.22.1`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
 
 ```text
 The MIT License (MIT)
@@ -5239,7 +5240,7 @@ License: MIT License
 
 Used by: `rand_core 0.10.1`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam
 
 ```text
 Copyright (c) 2018-2026 The Rand Project Developers
@@ -5275,7 +5276,7 @@ License: MIT License
 
 Used by: `inout 0.1.4`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
 
 ```text
 Copyright (c) 2022 The RustCrypto Project Developers
@@ -5413,7 +5414,7 @@ License: MIT License
 
 Used by: `block-buffer 0.12.1`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840
 
 ```text
 Copyright (c) 2018-2025 The RustCrypto Project Developers
@@ -5589,7 +5590,7 @@ License: MIT License
 
 Used by: `ed25519 2.2.3`, `signature 2.2.0`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
 
 ```text
 Copyright (c) 2018-2023 RustCrypto Developers
@@ -5661,7 +5662,7 @@ License: MIT License
 
 Used by: `ral-registers 0.1.3`
 
-Release graphs: ESP32-S3 Heltec, ESP32-S3 T-Beam
+Release graphs: ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam
 
 ```text
 Copyright (c) 2018-2021 Adam Greig
@@ -5697,7 +5698,7 @@ License: MIT License
 
 Used by: `smallvec 1.15.1`, `smallvec 1.15.2`
 
-Release graphs: ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, daemon Linux, daemon Windows, daemon macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, website Rust/WASM
+Release graphs: ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, daemon Linux, daemon Windows, daemon macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, website Rust/WASM
 
 ```text
 Copyright (c) 2018 The Servo Project Developers
@@ -5907,7 +5908,7 @@ License: MIT License
 
 Used by: `cc 1.2.65`, `cc 1.2.67`, `cc 1.3.0`, `cc 1.4.0`, `cfg-if 1.0.4`, `cmake 0.1.58`, `find-msvc-tools 0.1.9`, `js-sys 0.3.103`, `js-sys 0.3.99`, `longest-increasing-subsequence 0.1.0`, `pkg-config 0.3.33`, `socket2 0.6.4`, `socket2 0.6.5`, `wasm-bindgen 0.2.122`, `wasm-bindgen 0.2.126`, `wasm-bindgen-futures 0.4.72`, `wasm-bindgen-macro 0.2.122`, `wasm-bindgen-macro 0.2.126`, `wasm-bindgen-macro-support 0.2.122`, `wasm-bindgen-macro-support 0.2.126`, `wasm-bindgen-shared 0.2.122`, `wasm-bindgen-shared 0.2.126`, `web-sys 0.3.99`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
 
 ```text
 Copyright (c) 2014 Alex Crichton
@@ -6005,7 +6006,7 @@ License: MIT License
 
 Used by: `manyhow 0.11.4`, `proc-macro-utils 0.10.0`
 
-Release graphs: ESP32-S3 Heltec, ESP32-S3 T-Beam
+Release graphs: ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam
 
 ```text
 MIT License
@@ -6037,7 +6038,7 @@ License: MIT License
 
 Used by: `winnow 0.7.15`, `winnow 1.0.3`, `winnow 1.0.4`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, daemon Linux, daemon Windows, daemon macOS, desktop Linux, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, website Rust/WASM
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, daemon Linux, daemon Windows, daemon macOS, desktop Linux, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, website Rust/WASM
 
 ```text
 Permission is hereby granted, free of charge, to any person obtaining
@@ -6066,7 +6067,7 @@ License: MIT License
 
 Used by: `typenum 1.20.0`, `typenum 1.20.1`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
 
 ```text
 The MIT License (MIT)
@@ -6098,7 +6099,7 @@ License: MIT License
 
 Used by: `maybe-async-cfg 0.2.5`
 
-Release graphs: ESP32-S3 Heltec, ESP32-S3 T-Beam
+Release graphs: ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam
 
 ```text
 Copyright (c) 2020 Guoli Lyu
@@ -6128,7 +6129,7 @@ License: MIT License
 
 Used by: `bare-metal 0.2.5`, `fugit 0.3.9`, `heapless 0.8.0`, `heapless 0.9.3`, `nb 0.1.3`, `nb 1.1.0`, `vcell 0.1.3`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
 
 ```text
 Copyright (c) 2017 Jorge Aparicio
@@ -6262,7 +6263,7 @@ License: MIT License
 
 Used by: `lock_api 0.4.14`, `parking_lot 0.12.5`, `parking_lot_core 0.9.12`, `rustc_version 0.2.3`, `rustc_version 0.4.1`, `thread_local 1.1.10`, `thread_local 1.1.9`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840, website Rust/WASM
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840, website Rust/WASM
 
 ```text
 Copyright (c) 2016 The Rust Project Developers
@@ -6330,7 +6331,7 @@ License: MIT License
 
 Used by: `strsim 0.10.0`, `strsim 0.11.1`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, daemon Linux, daemon Windows, daemon macOS, desktop Linux, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, nRF52840
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, daemon Linux, daemon Windows, daemon macOS, desktop Linux, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, nRF52840
 
 ```text
 The MIT License (MIT)
@@ -6364,7 +6365,7 @@ License: MIT License
 
 Used by: `instability 0.3.12`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam
 
 ```text
 # MIT License
@@ -6433,7 +6434,7 @@ License: MIT License
 
 Used by: `cipher 0.4.4`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
 
 ```text
 Copyright (c) 2016-2020 RustCrypto Developers
@@ -6574,7 +6575,7 @@ License: MIT License
 
 Used by: `crc32fast 1.5.0`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS
 
 ```text
 MIT License
@@ -6670,7 +6671,7 @@ License: MIT License
 
 Used by: `autocfg 1.5.1`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
 
 ```text
 Copyright (c) 2018 Josh Stone
@@ -6738,7 +6739,7 @@ License: MIT License
 
 Used by: `digest 0.10.7`, `hmac 0.13.0`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
 
 ```text
 Copyright (c) 2017 Artyom Pavlov
@@ -6905,7 +6906,7 @@ License: MIT License
 
 Used by: `embedded-nal 0.9.0`, `embedded-storage 0.3.1`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, WASM, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, WASM, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
 
 ```text
 Copyright (c) 2020 Jonathan 'theJPster' Pallant
@@ -6943,7 +6944,7 @@ License: MIT License
 
 Used by: `zerocopy 0.8.50`, `zerocopy 0.8.52`, `zerocopy 0.8.54`, `zerocopy 0.8.55`, `zerocopy-derive 0.8.50`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, daemon Linux, daemon Windows, daemon macOS, nRF52840
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, daemon Linux, daemon Windows, daemon macOS, nRF52840
 
 ```text
 Copyright 2023 The Fuchsia Authors
@@ -7015,7 +7016,7 @@ License: MIT License
 
 Used by: `cmov 0.5.4`, `hybrid-array 0.4.12`, `hybrid-array 0.4.13`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840
 
 ```text
 Copyright (c) 2022-2026 The RustCrypto Project Developers
@@ -7148,7 +7149,7 @@ License: MIT License
 
 Used by: `linked_list_allocator 0.10.6`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam
 
 ```text
 Copyright (c) 2016 Philipp Oppermann
@@ -7328,7 +7329,7 @@ License: MIT License
 
 Used by: `miniz_oxide 0.8.9`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
 
 ```text
 MIT License
@@ -7363,7 +7364,7 @@ License: MIT License
 
 Used by: `generic-array 0.14.7`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
 
 ```text
 The MIT License (MIT)
@@ -7395,7 +7396,7 @@ License: MIT License
 
 Used by: `hashbrown 0.13.2`, `hashbrown 0.14.5`, `hashbrown 0.17.1`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, nRF52840
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, nRF52840
 
 ```text
 Copyright (c) 2016 Amanieu d'Antras
@@ -7431,7 +7432,7 @@ License: MIT License
 
 Used by: `convert_case 0.11.0`, `convert_case 0.8.0`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Node addon Linux, Node addon Windows, Node addon macOS, website Rust/WASM
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Node addon Linux, Node addon Windows, Node addon macOS, website Rust/WASM
 
 ```text
 MIT License
@@ -7463,7 +7464,7 @@ License: MIT License
 
 Used by: `usb-device 0.3.2`
 
-Release graphs: ESP32-S3 Heltec, ESP32-S3 T-Beam, nRF52840
+Release graphs: ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, nRF52840
 
 ```text
 MIT License
@@ -7630,7 +7631,7 @@ License: MIT License
 
 Used by: `futures 0.3.32`, `futures 0.3.33`, `futures-channel 0.3.32`, `futures-channel 0.3.33`, `futures-core 0.3.32`, `futures-core 0.3.33`, `futures-executor 0.3.32`, `futures-executor 0.3.33`, `futures-io 0.3.32`, `futures-io 0.3.33`, `futures-macro 0.3.32`, `futures-macro 0.3.33`, `futures-sink 0.3.32`, `futures-sink 0.3.33`, `futures-task 0.3.32`, `futures-task 0.3.33`, `futures-util 0.3.32`, `futures-util 0.3.33`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, iOS, nRF52840, website Rust/WASM
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, iOS, nRF52840, website Rust/WASM
 
 ```text
 Copyright (c) 2016 Alex Crichton
@@ -7667,7 +7668,7 @@ License: MIT License
 
 Used by: `micromath 2.1.0`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, WASM, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, WASM, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
 
 ```text
 MIT License
@@ -7814,7 +7815,7 @@ License: MIT License
 
 Used by: `pulldown-cmark 0.11.3`, `pulldown-cmark 0.13.4`, `pulldown-cmark-escape 0.11.0`
 
-Release graphs: ESP32-S3 Heltec, ESP32-S3 T-Beam, website Rust/WASM
+Release graphs: ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, website Rust/WASM
 
 ```text
 The MIT License
@@ -7846,7 +7847,7 @@ License: MIT License
 
 Used by: `bitfield 0.13.2`, `bitfield 0.14.0`, `bitfield 0.19.4`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, nRF52840
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, nRF52840
 
 ```text
 Copyright (c) 2017 Loïc Damien
@@ -8049,7 +8050,7 @@ License: MIT License
 
 Used by: `manyhow-macros 0.11.4`
 
-Release graphs: ESP32-S3 Heltec, ESP32-S3 T-Beam
+Release graphs: ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam
 
 ```text
 MIT License
@@ -8099,7 +8100,7 @@ License: MIT License
 
 Used by: `fnv 1.0.7`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, daemon Linux, desktop Linux, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, nRF52840, website Rust/WASM
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, daemon Linux, desktop Linux, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, nRF52840, website Rust/WASM
 
 ```text
 Copyright (c) 2017 Contributors
@@ -8203,7 +8204,7 @@ License: MIT License
 
 Used by: `byte-slice-cast 1.2.3`
 
-Release graphs: ESP32-S3 Heltec, ESP32-S3 T-Beam
+Release graphs: ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam
 
 ```text
 The MIT License (MIT)
@@ -8265,7 +8266,7 @@ License: MIT License
 
 Used by: `digest 0.11.3`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840
 
 ```text
 Copyright (c) 2017-2025 RustCrypto Developers
@@ -8386,7 +8387,7 @@ License: MIT License
 
 Used by: `gcd 2.3.0`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam
 
 ```text
 Copyright (c) 2016 Corey Farwell
@@ -8422,7 +8423,7 @@ License: MIT License
 
 Used by: `rand 0.9.5`, `rand_chacha 0.9.0`, `rand_core 0.6.4`, `rand_core 0.9.5`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
 
 ```text
 Copyright 2018 Developers of the Rand project
@@ -8491,7 +8492,7 @@ License: MIT License
 
 Used by: `darling 0.13.4`, `darling 0.20.11`, `darling 0.21.3`, `darling 0.23.0`, `darling_core 0.13.4`, `darling_core 0.20.11`, `darling_core 0.21.3`, `darling_core 0.23.0`, `darling_macro 0.13.4`, `darling_macro 0.20.11`, `darling_macro 0.21.3`, `darling_macro 0.23.0`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, daemon Linux, desktop Linux, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, nRF52840, website Rust/WASM
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, daemon Linux, desktop Linux, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, nRF52840, website Rust/WASM
 
 ```text
 MIT License
@@ -8523,7 +8524,7 @@ License: MIT License
 
 Used by: `embedded-io 0.6.1`, `embedded-io 0.7.1`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, nRF52840
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, nRF52840
 
 ```text
 Copyright (c) 2023 The embedded-io authors
@@ -8559,7 +8560,7 @@ License: MIT License
 
 Used by: `somni-expr 0.2.0`, `somni-parser 0.2.2`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam
 
 ```text
 Copyright 2025 danielb
@@ -8631,7 +8632,7 @@ License: MIT License
 
 Used by: `cordyceps 0.3.4`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, nRF52840
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, nRF52840
 
 ```text
 MIT License
@@ -8663,7 +8664,7 @@ License: MIT License
 
 Used by: `esp-synopsys-usb-otg 0.4.2`
 
-Release graphs: ESP32-S3 Heltec, ESP32-S3 T-Beam
+Release graphs: ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam
 
 ```text
 MIT License
@@ -8695,7 +8696,7 @@ License: MIT License
 
 Used by: `embedded-can 0.4.1`, `embedded-hal-async 1.0.0`, `embedded-hal-bus 0.3.0`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, nRF52840
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, nRF52840
 
 ```text
 Copyright (c) 2021-2022 The Rust embedded HAL team and contributors.
@@ -8725,7 +8726,7 @@ License: MIT License
 
 Used by: `embedded-graphics 0.8.2`, `embedded-graphics-simulator 0.8.0`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, WASM, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, WASM, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
 
 ```text
 Copyright (c) 2020 James Waples
@@ -8761,7 +8762,7 @@ License: MIT License
 
 Used by: `litrs 1.0.0`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, nRF52840
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, nRF52840
 
 ```text
 Copyright (c) 2020 Project Developers
@@ -8833,7 +8834,7 @@ License: MIT License
 
 Used by: `const-default 1.0.0`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam
 
 ```text
 MIT License
@@ -8931,7 +8932,7 @@ License: MIT License
 
 Used by: `crypto-common 0.2.2`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840
 
 ```text
 Copyright (c) 2021-2026 RustCrypto Developers
@@ -8967,7 +8968,7 @@ License: MIT License
 
 Used by: `zeroize 1.8.2`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, daemon Linux, daemon Windows, daemon macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, daemon Linux, daemon Windows, daemon macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840
 
 ```text
 MIT License
@@ -8999,7 +9000,7 @@ License: MIT License
 
 Used by: `bytemuck 1.25.0`, `bytemuck 1.25.2`, `bytemuck_derive 1.11.0`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, nRF52840
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, nRF52840
 
 ```text
 MIT License
@@ -9051,7 +9052,7 @@ License: MIT License
 
 Used by: `display-interface 0.5.0`, `display-interface-i2c 0.5.0`, `display-interface-spi 0.5.0`, `ssd1306 0.9.0`
 
-Release graphs: ESP32-S3 Heltec, ESP32-S3 T-Beam
+Release graphs: ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam
 
 ```text
 Copyright (c) 2018 James Waples
@@ -9087,7 +9088,7 @@ License: MIT License
 
 Used by: `embedded-hal 0.2.7`, `embedded-hal 1.0.0`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, nRF52840
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, nRF52840
 
 ```text
 Copyright (c) 2017-2018 Jorge Aparicio
@@ -9159,7 +9160,7 @@ License: MIT License
 
 Used by: `version_check 0.9.5`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
 
 ```text
 The MIT License (MIT)
@@ -9189,7 +9190,7 @@ License: MIT License
 
 Used by: `enumset 1.1.13`, `enumset_derive 0.15.0`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, website Rust/WASM
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, website Rust/WASM
 
 ```text
 Copyright (c) 2017-2025 Alissa Rao <aura@aura.moe>
@@ -9225,7 +9226,7 @@ License: MIT License
 
 Used by: `float-cmp 0.9.0`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, WASM, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, WASM, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
 
 ```text
 Copyright (c) 2014-2020 Optimal Computing (NZ) Ltd
@@ -9255,7 +9256,7 @@ License: MIT License
 
 Used by: `cbc 0.1.2`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, iOS, nRF52840
 
 ```text
 Copyright (c) 2018-2022 RustCrypto Developers
@@ -9328,7 +9329,7 @@ License: MIT License
 
 Used by: `embedded-io-async 0.6.1`, `embedded-io-async 0.7.0`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, nRF52840
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, nRF52840
 
 ```text
 Copyright (c) 2023 The embedded-io-async authors
@@ -9816,7 +9817,7 @@ License: Unicode License v3
 
 Used by: `unicode-ident 1.0.24`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
+Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
 
 ```text
 UNICODE LICENSE V3

--- a/audits/unsafe-snapshot.json
+++ b/audits/unsafe-snapshot.json
@@ -77,6 +77,11 @@
       "target": "xtensa-esp32s3-none-elf"
     },
     {
+      "manifest": "personal-hopspot/embedded/esp32/boards/heltec-v4-r8/Cargo.toml",
+      "name": "esp32-s3-heltec-r8",
+      "target": "xtensa-esp32s3-none-elf"
+    },
+    {
       "manifest": "personal-hopspot/embedded/esp32/boards/t-beam-supreme/Cargo.toml",
       "name": "esp32-s3-tbeam",
       "target": "xtensa-esp32s3-none-elf"
@@ -111,6 +116,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "adler2",
@@ -136,6 +142,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -238,6 +245,9 @@
           "alloc"
         ],
         "esp32-s3-heltec": [
+          "alloc"
+        ],
+        "esp32-s3-heltec-r8": [
           "alloc"
         ],
         "esp32-s3-tbeam": [
@@ -480,6 +490,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -508,6 +519,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "ios": [],
         "nrf52840": [],
@@ -548,6 +560,10 @@
           "std"
         ],
         "esp32-s3-heltec": [
+          "default",
+          "std"
+        ],
+        "esp32-s3-heltec-r8": [
           "default",
           "std"
         ],
@@ -711,6 +727,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "bitfield",
@@ -728,6 +745,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "bitfield-macros",
@@ -764,6 +782,7 @@
         ],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -821,6 +840,9 @@
           "std"
         ],
         "esp32-s3-heltec": [
+          "std"
+        ],
+        "esp32-s3-heltec-r8": [
           "std"
         ],
         "esp32-s3-tbeam": [
@@ -911,6 +933,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -942,6 +965,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -973,6 +997,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -1163,6 +1188,9 @@
         "esp32-s3-heltec": [
           "uuid"
         ],
+        "esp32-s3-heltec-r8": [
+          "uuid"
+        ],
         "esp32-s3-tbeam": [
           "uuid"
         ]
@@ -1227,6 +1255,9 @@
         "esp32-s3-heltec": [
           "uuid"
         ],
+        "esp32-s3-heltec-r8": [
+          "uuid"
+        ],
         "esp32-s3-tbeam": [
           "uuid"
         ]
@@ -1262,6 +1293,7 @@
     {
       "graphs": {
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "byte-slice-cast",
@@ -1288,6 +1320,7 @@
         ],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "nrf52840": []
       },
@@ -1335,6 +1368,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -1436,6 +1470,10 @@
           "default",
           "std"
         ],
+        "esp32-s3-heltec-r8": [
+          "default",
+          "std"
+        ],
         "esp32-s3-tbeam": [
           "default",
           "std"
@@ -1511,6 +1549,9 @@
         "esp32-s3-heltec": [
           "default"
         ],
+        "esp32-s3-heltec-r8": [
+          "default"
+        ],
         "esp32-s3-tbeam": [
           "default"
         ],
@@ -1574,6 +1615,9 @@
           "block-padding"
         ],
         "esp32-s3-heltec": [
+          "block-padding"
+        ],
+        "esp32-s3-heltec-r8": [
           "block-padding"
         ],
         "esp32-s3-tbeam": [
@@ -1685,6 +1729,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -1767,6 +1812,9 @@
           "block-padding"
         ],
         "esp32-s3-heltec": [
+          "block-padding"
+        ],
+        "esp32-s3-heltec-r8": [
           "block-padding"
         ],
         "esp32-s3-tbeam": [
@@ -1953,6 +2001,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -2034,6 +2083,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "const-default",
@@ -2073,6 +2123,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "convert_case",
@@ -2093,6 +2144,10 @@
           "no-cache-pad"
         ],
         "esp32-s3-heltec": [
+          "default",
+          "no-cache-pad"
+        ],
+        "esp32-s3-heltec-r8": [
           "default",
           "no-cache-pad"
         ],
@@ -2351,6 +2406,10 @@
           "default",
           "std"
         ],
+        "esp32-s3-heltec-r8": [
+          "default",
+          "std"
+        ],
         "esp32-s3-tbeam": [
           "default",
           "std"
@@ -2404,6 +2463,9 @@
           "restore-state-u32"
         ],
         "esp32-s3-heltec": [
+          "restore-state-u32"
+        ],
+        "esp32-s3-heltec-r8": [
           "restore-state-u32"
         ],
         "esp32-s3-tbeam": [
@@ -2682,6 +2744,7 @@
         ],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [
           "std"
@@ -2719,6 +2782,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -2750,6 +2814,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -2841,6 +2906,11 @@
           "zeroize"
         ],
         "esp32-s3-heltec": [
+          "digest",
+          "precomputed-tables",
+          "zeroize"
+        ],
+        "esp32-s3-heltec-r8": [
           "digest",
           "precomputed-tables",
           "zeroize"
@@ -3003,6 +3073,10 @@
           "default",
           "suggestions"
         ],
+        "esp32-s3-heltec-r8": [
+          "default",
+          "suggestions"
+        ],
         "esp32-s3-tbeam": [
           "default",
           "suggestions"
@@ -3031,6 +3105,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "darling",
@@ -3051,6 +3126,10 @@
           "suggestions"
         ],
         "esp32-s3-heltec": [
+          "default",
+          "suggestions"
+        ],
+        "esp32-s3-heltec-r8": [
           "default",
           "suggestions"
         ],
@@ -3126,6 +3205,10 @@
           "strsim",
           "suggestions"
         ],
+        "esp32-s3-heltec-r8": [
+          "strsim",
+          "suggestions"
+        ],
         "esp32-s3-tbeam": [
           "strsim",
           "suggestions"
@@ -3154,6 +3237,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "darling_core",
@@ -3174,6 +3258,10 @@
           "suggestions"
         ],
         "esp32-s3-heltec": [
+          "strsim",
+          "suggestions"
+        ],
+        "esp32-s3-heltec-r8": [
           "strsim",
           "suggestions"
         ],
@@ -3219,6 +3307,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "nrf52840": []
@@ -3238,6 +3327,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "darling_macro",
@@ -3255,6 +3345,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "darling_macro",
@@ -3415,6 +3506,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "delegate",
@@ -3515,6 +3607,11 @@
           "default"
         ],
         "esp32-s3-heltec": [
+          "block-buffer",
+          "core-api",
+          "default"
+        ],
+        "esp32-s3-heltec-r8": [
           "block-buffer",
           "core-api",
           "default"
@@ -3622,6 +3719,11 @@
           "mac"
         ],
         "esp32-s3-heltec": [
+          "block-api",
+          "default",
+          "mac"
+        ],
+        "esp32-s3-heltec-r8": [
           "block-api",
           "default",
           "mac"
@@ -3739,6 +3841,9 @@
         "esp32-s3-heltec": [
           "default"
         ],
+        "esp32-s3-heltec-r8": [
+          "default"
+        ],
         "esp32-s3-tbeam": [
           "default"
         ]
@@ -3757,6 +3862,7 @@
     {
       "graphs": {
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "display-interface-i2c",
@@ -3773,6 +3879,7 @@
     {
       "graphs": {
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "display-interface-spi",
@@ -3853,6 +3960,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "docsplay",
@@ -3870,6 +3978,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "docsplay-macros",
@@ -3910,6 +4019,9 @@
           "default"
         ],
         "esp32-s3-heltec": [
+          "default"
+        ],
+        "esp32-s3-heltec-r8": [
           "default"
         ],
         "esp32-s3-tbeam": [
@@ -3984,6 +4096,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -4042,6 +4155,10 @@
           "zeroize"
         ],
         "esp32-s3-heltec": [
+          "fast",
+          "zeroize"
+        ],
+        "esp32-s3-heltec-r8": [
           "fast",
           "zeroize"
         ],
@@ -4146,6 +4263,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "nrf52840": [
           "time"
@@ -4166,6 +4284,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "nrf52840": [
           "_platform",
@@ -4188,6 +4307,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "nrf52840": []
       },
@@ -4208,6 +4328,9 @@
           "timer-item-size-6-words"
         ],
         "esp32-s3-heltec": [
+          "timer-item-size-6-words"
+        ],
+        "esp32-s3-heltec-r8": [
           "timer-item-size-6-words"
         ],
         "esp32-s3-tbeam": [
@@ -4240,6 +4363,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -4262,6 +4386,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "nrf52840": []
       },
@@ -4365,6 +4490,16 @@
           "tcp",
           "udp"
         ],
+        "esp32-s3-heltec-r8": [
+          "dhcpv4",
+          "dns",
+          "medium-ethernet",
+          "multicast",
+          "proto-ipv4",
+          "proto-ipv6",
+          "tcp",
+          "udp"
+        ],
         "esp32-s3-tbeam": [
           "dhcpv4",
           "dns",
@@ -4426,6 +4561,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -4455,6 +4591,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -4501,6 +4638,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "embassy-sync",
@@ -4525,6 +4663,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "embassy-sync",
@@ -4549,6 +4688,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -4578,6 +4718,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -4611,6 +4752,9 @@
         "esp32-s3-heltec": [
           "tick-hz-1_000_000"
         ],
+        "esp32-s3-heltec-r8": [
+          "tick-hz-1_000_000"
+        ],
         "esp32-s3-tbeam": [
           "tick-hz-1_000_000"
         ],
@@ -4637,6 +4781,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "nrf52840": []
       },
@@ -4662,6 +4807,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -4693,6 +4839,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -4718,6 +4865,9 @@
         "esp32-s3-heltec": [
           "default"
         ],
+        "esp32-s3-heltec-r8": [
+          "default"
+        ],
         "esp32-s3-tbeam": [
           "default"
         ]
@@ -4737,6 +4887,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "embedded-can",
@@ -4771,6 +4922,9 @@
           "default"
         ],
         "esp32-s3-heltec": [
+          "default"
+        ],
+        "esp32-s3-heltec-r8": [
           "default"
         ],
         "esp32-s3-tbeam": [
@@ -4818,6 +4972,9 @@
           "default"
         ],
         "esp32-s3-heltec": [
+          "default"
+        ],
+        "esp32-s3-heltec-r8": [
           "default"
         ],
         "esp32-s3-tbeam": [
@@ -4891,6 +5048,9 @@
         "esp32-s3-heltec": [
           "unproven"
         ],
+        "esp32-s3-heltec-r8": [
+          "unproven"
+        ],
         "esp32-s3-tbeam": [
           "unproven"
         ],
@@ -4924,6 +5084,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -4953,6 +5114,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -4974,6 +5136,9 @@
     {
       "graphs": {
         "esp32-s3-heltec": [
+          "async"
+        ],
+        "esp32-s3-heltec-r8": [
           "async"
         ],
         "esp32-s3-tbeam": [
@@ -5005,6 +5170,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -5033,6 +5199,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -5062,6 +5229,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -5090,6 +5258,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -5119,6 +5288,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -5147,6 +5317,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -5176,6 +5347,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -5207,6 +5379,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -5303,6 +5476,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "enumset",
@@ -5320,6 +5494,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "enumset_derive",
@@ -5378,6 +5553,7 @@
         "desktop-macos": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-macos": []
       },
@@ -5454,6 +5630,12 @@
           "global-allocator",
           "internal-heap-stats"
         ],
+        "esp32-s3-heltec-r8": [
+          "compat",
+          "default",
+          "global-allocator",
+          "internal-heap-stats"
+        ],
         "esp32-s3-tbeam": [
           "compat",
           "default",
@@ -5482,6 +5664,13 @@
           "println"
         ],
         "esp32-s3-heltec": [
+          "esp32c6",
+          "esp32s3",
+          "panic-handler",
+          "print-float-registers",
+          "println"
+        ],
+        "esp32-s3-heltec-r8": [
           "esp32c6",
           "esp32s3",
           "panic-handler",
@@ -5523,6 +5712,13 @@
           "esp32s3",
           "validation"
         ],
+        "esp32-s3-heltec-r8": [
+          "default",
+          "esp-rom-sys",
+          "esp32c6",
+          "esp32s3",
+          "validation"
+        ],
         "esp32-s3-tbeam": [
           "default",
           "esp-rom-sys",
@@ -5548,6 +5744,9 @@
           "build"
         ],
         "esp32-s3-heltec": [
+          "build"
+        ],
+        "esp32-s3-heltec-r8": [
           "build"
         ],
         "esp32-s3-tbeam": [
@@ -5581,6 +5780,19 @@
           "unstable"
         ],
         "esp32-s3-heltec": [
+          "__bluetooth",
+          "__usb_otg",
+          "critical-section",
+          "default",
+          "esp32c6",
+          "esp32s3",
+          "exception-handler",
+          "float-save-restore",
+          "requires-unstable",
+          "rt",
+          "unstable"
+        ],
+        "esp32-s3-heltec-r8": [
           "__bluetooth",
           "__usb_otg",
           "critical-section",
@@ -5634,6 +5846,13 @@
           "rtc-fast",
           "rtc-slow"
         ],
+        "esp32-s3-heltec-r8": [
+          "__esp_idf_bootloader",
+          "has-lp-core",
+          "has-ulp-core",
+          "rtc-fast",
+          "rtc-slow"
+        ],
         "esp32-s3-tbeam": [
           "__esp_idf_bootloader",
           "has-lp-core",
@@ -5667,6 +5886,12 @@
           "esp32c6",
           "esp32s3"
         ],
+        "esp32-s3-heltec-r8": [
+          "_device-selected",
+          "build-script",
+          "esp32c6",
+          "esp32s3"
+        ],
         "esp32-s3-tbeam": [
           "_device-selected",
           "build-script",
@@ -5695,6 +5920,10 @@
           "esp32c6",
           "esp32s3"
         ],
+        "esp32-s3-heltec-r8": [
+          "esp32c6",
+          "esp32s3"
+        ],
         "esp32-s3-tbeam": [
           "esp32c6",
           "esp32s3"
@@ -5720,6 +5949,12 @@
           "log-04"
         ],
         "esp32-s3-heltec": [
+          "esp32c6",
+          "esp32s3",
+          "jtag-serial",
+          "log-04"
+        ],
+        "esp32-s3-heltec-r8": [
           "esp32c6",
           "esp32s3",
           "jtag-serial",
@@ -5769,6 +6004,18 @@
           "wifi",
           "xtensa-lx-rt"
         ],
+        "esp32-s3-heltec-r8": [
+          "__has_unstable_feature_enabled",
+          "ble",
+          "coex",
+          "esp-alloc",
+          "esp-now",
+          "esp32c6",
+          "esp32s3",
+          "unstable",
+          "wifi",
+          "xtensa-lx-rt"
+        ],
         "esp32-s3-tbeam": [
           "__has_unstable_feature_enabled",
           "ble",
@@ -5802,6 +6049,12 @@
           "ipc-implementations"
         ],
         "esp32-s3-heltec": [
+          "esp-sync",
+          "esp32c6",
+          "esp32s3",
+          "ipc-implementations"
+        ],
+        "esp32-s3-heltec-r8": [
           "esp-sync",
           "esp32c6",
           "esp32s3",
@@ -5852,6 +6105,10 @@
           "esp32c6",
           "esp32s3"
         ],
+        "esp32-s3-heltec-r8": [
+          "esp32c6",
+          "esp32s3"
+        ],
         "esp32-s3-tbeam": [
           "esp32c6",
           "esp32s3"
@@ -5879,6 +6136,14 @@
           "esp32s3"
         ],
         "esp32-s3-heltec": [
+          "alloc",
+          "default",
+          "embassy",
+          "esp-radio",
+          "esp32c6",
+          "esp32s3"
+        ],
+        "esp32-s3-heltec-r8": [
           "alloc",
           "default",
           "embassy",
@@ -5916,6 +6181,10 @@
           "esp32c6",
           "esp32s3"
         ],
+        "esp32-s3-heltec-r8": [
+          "esp32c6",
+          "esp32s3"
+        ],
         "esp32-s3-tbeam": [
           "esp32c6",
           "esp32s3"
@@ -5939,6 +6208,10 @@
           "fs"
         ],
         "esp32-s3-heltec": [
+          "esp32sx",
+          "fs"
+        ],
+        "esp32-s3-heltec-r8": [
           "esp32sx",
           "fs"
         ],
@@ -5966,6 +6239,9 @@
         "esp32-s3-heltec": [
           "default"
         ],
+        "esp32-s3-heltec-r8": [
+          "default"
+        ],
         "esp32-s3-tbeam": [
           "default"
         ]
@@ -5987,6 +6263,9 @@
           "default"
         ],
         "esp32-s3-heltec": [
+          "default"
+        ],
+        "esp32-s3-heltec-r8": [
           "default"
         ],
         "esp32-s3-tbeam": [
@@ -6012,6 +6291,11 @@
           "rt"
         ],
         "esp32-s3-heltec": [
+          "critical-section",
+          "default",
+          "rt"
+        ],
+        "esp32-s3-heltec-r8": [
           "critical-section",
           "default",
           "rt"
@@ -6045,6 +6329,11 @@
           "default",
           "rt"
         ],
+        "esp32-s3-heltec-r8": [
+          "critical-section",
+          "default",
+          "rt"
+        ],
         "esp32-s3-tbeam": [
           "critical-section",
           "default",
@@ -6070,6 +6359,11 @@
           "rt"
         ],
         "esp32-s3-heltec": [
+          "critical-section",
+          "default",
+          "rt"
+        ],
+        "esp32-s3-heltec-r8": [
           "critical-section",
           "default",
           "rt"
@@ -6103,6 +6397,11 @@
           "default",
           "rt"
         ],
+        "esp32-s3-heltec-r8": [
+          "critical-section",
+          "default",
+          "rt"
+        ],
         "esp32-s3-tbeam": [
           "critical-section",
           "default",
@@ -6128,6 +6427,11 @@
           "rt"
         ],
         "esp32-s3-heltec": [
+          "critical-section",
+          "default",
+          "rt"
+        ],
+        "esp32-s3-heltec-r8": [
           "critical-section",
           "default",
           "rt"
@@ -6161,6 +6465,11 @@
           "default",
           "rt"
         ],
+        "esp32-s3-heltec-r8": [
+          "critical-section",
+          "default",
+          "rt"
+        ],
         "esp32-s3-tbeam": [
           "critical-section",
           "default",
@@ -6186,6 +6495,11 @@
           "rt"
         ],
         "esp32-s3-heltec": [
+          "critical-section",
+          "default",
+          "rt"
+        ],
+        "esp32-s3-heltec-r8": [
           "critical-section",
           "default",
           "rt"
@@ -6414,6 +6728,11 @@
           "miniz_oxide",
           "rust_backend"
         ],
+        "esp32-s3-heltec-r8": [
+          "any_impl",
+          "miniz_oxide",
+          "rust_backend"
+        ],
         "esp32-s3-tbeam": [
           "any_impl",
           "miniz_oxide",
@@ -6464,6 +6783,11 @@
           "ratio"
         ],
         "esp32-s3-heltec": [
+          "default",
+          "num-traits",
+          "ratio"
+        ],
+        "esp32-s3-heltec-r8": [
           "default",
           "num-traits",
           "ratio"
@@ -6568,6 +6892,10 @@
           "std"
         ],
         "esp32-s3-heltec": [
+          "default",
+          "std"
+        ],
+        "esp32-s3-heltec-r8": [
           "default",
           "std"
         ],
@@ -6679,6 +7007,9 @@
         "esp32-s3-heltec": [
           "default"
         ],
+        "esp32-s3-heltec-r8": [
+          "default"
+        ],
         "esp32-s3-tbeam": [
           "default"
         ]
@@ -6761,6 +7092,14 @@
           "std"
         ],
         "esp32-s3-heltec": [
+          "alloc",
+          "async-await",
+          "default",
+          "executor",
+          "futures-executor",
+          "std"
+        ],
+        "esp32-s3-heltec-r8": [
           "alloc",
           "async-await",
           "default",
@@ -6893,6 +7232,13 @@
           "std"
         ],
         "esp32-s3-heltec": [
+          "alloc",
+          "default",
+          "futures-sink",
+          "sink",
+          "std"
+        ],
+        "esp32-s3-heltec-r8": [
           "alloc",
           "default",
           "futures-sink",
@@ -7014,6 +7360,11 @@
           "std"
         ],
         "esp32-s3-heltec": [
+          "alloc",
+          "default",
+          "std"
+        ],
+        "esp32-s3-heltec-r8": [
           "alloc",
           "default",
           "std"
@@ -7111,6 +7462,9 @@
         "esp32-s3-heltec": [
           "std"
         ],
+        "esp32-s3-heltec-r8": [
+          "std"
+        ],
         "esp32-s3-tbeam": [
           "std"
         ],
@@ -7163,6 +7517,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "futures-intrusive",
@@ -7213,6 +7568,9 @@
           "std"
         ],
         "esp32-s3-heltec": [
+          "std"
+        ],
+        "esp32-s3-heltec-r8": [
           "std"
         ],
         "esp32-s3-tbeam": [
@@ -7299,6 +7657,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "ios": [],
         "nrf52840": []
@@ -7371,6 +7730,10 @@
           "std"
         ],
         "esp32-s3-heltec": [
+          "alloc",
+          "std"
+        ],
+        "esp32-s3-heltec-r8": [
           "alloc",
           "std"
         ],
@@ -7466,6 +7829,10 @@
           "std"
         ],
         "esp32-s3-heltec": [
+          "alloc",
+          "std"
+        ],
+        "esp32-s3-heltec-r8": [
           "alloc",
           "std"
         ],
@@ -7692,6 +8059,21 @@
           "slab",
           "std"
         ],
+        "esp32-s3-heltec-r8": [
+          "alloc",
+          "async-await",
+          "async-await-macro",
+          "channel",
+          "futures-channel",
+          "futures-io",
+          "futures-macro",
+          "futures-sink",
+          "io",
+          "memchr",
+          "sink",
+          "slab",
+          "std"
+        ],
         "esp32-s3-tbeam": [
           "alloc",
           "async-await",
@@ -7817,6 +8199,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "gcd",
@@ -7860,6 +8243,9 @@
           "more_lengths"
         ],
         "esp32-s3-heltec": [
+          "more_lengths"
+        ],
+        "esp32-s3-heltec-r8": [
           "more_lengths"
         ],
         "esp32-s3-tbeam": [
@@ -7920,6 +8306,7 @@
         ],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -8005,6 +8392,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -8050,6 +8438,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -8129,6 +8518,7 @@
         "desktop-macos": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-macos": []
       },
@@ -8155,6 +8545,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -8185,6 +8576,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -8234,6 +8626,7 @@
         "desktop-linux": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": []
       },
@@ -8289,6 +8682,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -8320,6 +8714,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -8367,6 +8762,23 @@
       },
       "name": "hopspot-heltec-v4",
       "source": "personal-hopspot/embedded/esp32/boards/heltec-v4",
+      "unsafe": {
+        "blocks": 0,
+        "externs": 0,
+        "functions": 0,
+        "impls": 0,
+        "tokens": 0
+      },
+      "version": "0.1.0"
+    },
+    {
+      "graphs": {
+        "esp32-s3-heltec-r8": [
+          "default"
+        ]
+      },
+      "name": "hopspot-heltec-v4-r8",
+      "source": "personal-hopspot/embedded/esp32/boards/heltec-v4-r8",
       "unsafe": {
         "blocks": 0,
         "externs": 0,
@@ -8507,6 +8919,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "ios": [],
         "nrf52840": []
@@ -8697,6 +9110,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "nrf52840": []
@@ -8775,6 +9189,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -8868,6 +9283,10 @@
           "default",
           "std"
         ],
+        "esp32-s3-heltec-r8": [
+          "default",
+          "std"
+        ],
         "esp32-s3-tbeam": [
           "default",
           "std"
@@ -8892,6 +9311,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "indoc",
@@ -8937,6 +9357,9 @@
         "esp32-s3-heltec": [
           "block-padding"
         ],
+        "esp32-s3-heltec-r8": [
+          "block-padding"
+        ],
         "esp32-s3-tbeam": [
           "block-padding"
         ],
@@ -8974,6 +9397,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "instability",
@@ -9037,6 +9461,10 @@
           "std"
         ],
         "esp32-s3-heltec": [
+          "default",
+          "std"
+        ],
+        "esp32-s3-heltec-r8": [
           "default",
           "std"
         ],
@@ -9145,6 +9573,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -9168,6 +9597,10 @@
           "std"
         ],
         "esp32-s3-heltec": [
+          "alloc",
+          "std"
+        ],
+        "esp32-s3-heltec-r8": [
           "alloc",
           "std"
         ],
@@ -9394,6 +9827,9 @@
         "esp32-s3-heltec": [
           "rust-allocator"
         ],
+        "esp32-s3-heltec-r8": [
+          "rust-allocator"
+        ],
         "esp32-s3-tbeam": [
           "rust-allocator"
         ],
@@ -9470,6 +9906,11 @@
           "std"
         ],
         "esp32-s3-heltec": [
+          "default",
+          "extra_traits",
+          "std"
+        ],
+        "esp32-s3-heltec-r8": [
           "default",
           "extra_traits",
           "std"
@@ -9573,6 +10014,9 @@
         "esp32-s3-heltec": [
           "const_mut_refs"
         ],
+        "esp32-s3-heltec-r8": [
+          "const_mut_refs"
+        ],
         "esp32-s3-tbeam": [
           "const_mut_refs"
         ]
@@ -9674,6 +10118,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -9730,6 +10175,10 @@
           "atomic_usize",
           "default"
         ],
+        "esp32-s3-heltec-r8": [
+          "atomic_usize",
+          "default"
+        ],
         "esp32-s3-tbeam": [
           "atomic_usize",
           "default"
@@ -9765,6 +10214,10 @@
           "std"
         ],
         "esp32-s3-heltec": [
+          "release_max_level_info",
+          "std"
+        ],
+        "esp32-s3-heltec-r8": [
           "release_max_level_info",
           "std"
         ],
@@ -9883,6 +10336,10 @@
           "default",
           "std"
         ],
+        "esp32-s3-heltec-r8": [
+          "default",
+          "std"
+        ],
         "esp32-s3-tbeam": [
           "default",
           "std"
@@ -9983,6 +10440,9 @@
         "esp32-s3-heltec": [
           "map"
         ],
+        "esp32-s3-heltec-r8": [
+          "map"
+        ],
         "esp32-s3-tbeam": [
           "map"
         ],
@@ -10019,6 +10479,13 @@
           "syn1",
           "syn2"
         ],
+        "esp32-s3-heltec-r8": [
+          "default",
+          "macros",
+          "syn",
+          "syn1",
+          "syn2"
+        ],
         "esp32-s3-tbeam": [
           "default",
           "macros",
@@ -10041,6 +10508,7 @@
     {
       "graphs": {
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "manyhow-macros",
@@ -10077,6 +10545,11 @@
     {
       "graphs": {
         "esp32-s3-heltec": [
+          "default",
+          "doctests",
+          "pulldown-cmark"
+        ],
+        "esp32-s3-heltec-r8": [
           "default",
           "doctests",
           "pulldown-cmark"
@@ -10202,6 +10675,11 @@
           "default",
           "std"
         ],
+        "esp32-s3-heltec-r8": [
+          "alloc",
+          "default",
+          "std"
+        ],
         "esp32-s3-tbeam": [
           "alloc",
           "default",
@@ -10296,6 +10774,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "ios": [],
         "nrf52840": [],
@@ -10344,6 +10823,11 @@
           "with-alloc"
         ],
         "esp32-s3-heltec": [
+          "simd",
+          "simd-adler32",
+          "with-alloc"
+        ],
+        "esp32-s3-heltec-r8": [
           "simd",
           "simd-adler32",
           "with-alloc"
@@ -10414,6 +10898,11 @@
           "os-poll"
         ],
         "esp32-s3-heltec": [
+          "net",
+          "os-ext",
+          "os-poll"
+        ],
+        "esp32-s3-heltec-r8": [
           "net",
           "os-ext",
           "os-poll"
@@ -10569,6 +11058,9 @@
         "esp32-s3-heltec": [
           "unstable"
         ],
+        "esp32-s3-heltec-r8": [
+          "unstable"
+        ],
         "esp32-s3-tbeam": [
           "unstable"
         ],
@@ -10602,6 +11094,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -10686,6 +11179,12 @@
           "gateway"
         ],
         "esp32-s3-heltec": [
+          "android-extra",
+          "apple-system-configuration-extra",
+          "default",
+          "gateway"
+        ],
+        "esp32-s3-heltec-r8": [
           "android-extra",
           "apple-system-configuration-extra",
           "default",
@@ -11019,6 +11518,7 @@
         "desktop-linux": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": []
       },
@@ -11121,6 +11621,10 @@
           "std"
         ],
         "esp32-s3-heltec": [
+          "default",
+          "std"
+        ],
+        "esp32-s3-heltec-r8": [
           "default",
           "std"
         ],
@@ -12963,6 +13467,10 @@
           "elf",
           "read_core"
         ],
+        "esp32-s3-heltec-r8": [
+          "elf",
+          "read_core"
+        ],
         "esp32-s3-tbeam": [
           "elf",
           "read_core"
@@ -13206,6 +13714,7 @@
         "desktop-linux": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": []
       },
@@ -13298,6 +13807,7 @@
         ],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "ios": [
           "host"
@@ -13359,6 +13869,15 @@
           "usb",
           "wifi-auto"
         ],
+        "esp32-s3-heltec-r8": [
+          "bluetooth-auto",
+          "default",
+          "esp-now",
+          "lora",
+          "tcp",
+          "usb",
+          "wifi-auto"
+        ],
         "esp32-s3-tbeam": [
           "bluetooth-auto",
           "default",
@@ -13372,11 +13891,11 @@
       "name": "personal-hopspot-esp32",
       "source": "personal-hopspot/embedded/esp32",
       "unsafe": {
-        "blocks": 14,
+        "blocks": 18,
         "externs": 0,
-        "functions": 1,
-        "impls": 1,
-        "tokens": 16
+        "functions": 2,
+        "impls": 2,
+        "tokens": 22
       },
       "version": "0.1.0"
     },
@@ -13587,6 +14106,20 @@
           "usb",
           "wifi-auto"
         ],
+        "esp32-s3-heltec-r8": [
+          "alloc",
+          "bluetooth-auto",
+          "embassy-host",
+          "esp-now",
+          "external-alloc",
+          "flash",
+          "log",
+          "lora",
+          "tcp",
+          "tcp-dns",
+          "usb",
+          "wifi-auto"
+        ],
         "esp32-s3-tbeam": [
           "alloc",
           "bluetooth-auto",
@@ -13752,6 +14285,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -13885,6 +14419,13 @@
           "require-cas",
           "unsafe-assume-single-core"
         ],
+        "esp32-s3-heltec-r8": [
+          "critical-section",
+          "default",
+          "fallback",
+          "require-cas",
+          "unsafe-assume-single-core"
+        ],
         "esp32-s3-tbeam": [
           "critical-section",
           "default",
@@ -13951,6 +14492,9 @@
         "esp32-s3-heltec": [
           "portable-atomic"
         ],
+        "esp32-s3-heltec-r8": [
+          "portable-atomic"
+        ],
         "esp32-s3-tbeam": [
           "portable-atomic"
         ]
@@ -13970,6 +14514,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "portable_atomic_enum_macros",
@@ -14191,6 +14736,14 @@
           "tokio-host"
         ],
         "esp32-s3-heltec": [
+          "alloc",
+          "embassy-host",
+          "external-alloc",
+          "flash",
+          "std",
+          "tokio-host"
+        ],
+        "esp32-s3-heltec-r8": [
           "alloc",
           "embassy-host",
           "external-alloc",
@@ -14445,6 +14998,17 @@
           "usb",
           "wifi-auto"
         ],
+        "esp32-s3-heltec-r8": [
+          "bluetooth-auto",
+          "bluetooth-auto-trouble",
+          "esp-now",
+          "log",
+          "lora",
+          "tcp",
+          "tcp-dns",
+          "usb",
+          "wifi-auto"
+        ],
         "esp32-s3-tbeam": [
           "bluetooth-auto",
           "bluetooth-auto-trouble",
@@ -14630,6 +15194,15 @@
           "usb",
           "wifi-auto"
         ],
+        "esp32-s3-heltec-r8": [
+          "bluetooth-auto",
+          "log",
+          "network-device-selection",
+          "serial",
+          "tcp",
+          "usb",
+          "wifi-auto"
+        ],
         "esp32-s3-tbeam": [
           "bluetooth-auto",
           "log",
@@ -14789,6 +15362,12 @@
           "resource-bzip2",
           "std"
         ],
+        "esp32-s3-heltec-r8": [
+          "alloc",
+          "external-alloc",
+          "resource-bzip2",
+          "std"
+        ],
         "esp32-s3-tbeam": [
           "alloc",
           "external-alloc",
@@ -14877,6 +15456,10 @@
           "alloc",
           "log"
         ],
+        "esp32-s3-heltec-r8": [
+          "alloc",
+          "log"
+        ],
         "esp32-s3-tbeam": [
           "alloc",
           "log"
@@ -14942,6 +15525,7 @@
         ],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [
           "interface-discovery",
@@ -15052,6 +15636,7 @@
         "desktop-linux": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "proc-macro-crate",
@@ -15068,6 +15653,14 @@
     {
       "graphs": {
         "esp32-s3-heltec": [
+          "default",
+          "parser",
+          "proc-macro",
+          "proc-macro2",
+          "quote",
+          "smallvec"
+        ],
+        "esp32-s3-heltec-r8": [
           "default",
           "parser",
           "proc-macro",
@@ -15134,6 +15727,10 @@
           "proc-macro"
         ],
         "esp32-s3-heltec": [
+          "default",
+          "proc-macro"
+        ],
+        "esp32-s3-heltec-r8": [
           "default",
           "proc-macro"
         ],
@@ -15247,6 +15844,7 @@
     {
       "graphs": {
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "pulldown-cmark",
@@ -15345,6 +15943,10 @@
           "default",
           "proc-macro"
         ],
+        "esp32-s3-heltec-r8": [
+          "default",
+          "proc-macro"
+        ],
         "esp32-s3-tbeam": [
           "default",
           "proc-macro"
@@ -15429,6 +16031,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "ral-registers",
@@ -15568,6 +16171,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "rand_core",
@@ -15597,6 +16201,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -15636,6 +16241,7 @@
         ],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [
           "os_rng",
@@ -16014,6 +16620,9 @@
         "esp32-s3-heltec": [
           "unstable"
         ],
+        "esp32-s3-heltec-r8": [
+          "unstable"
+        ],
         "esp32-s3-tbeam": [
           "unstable"
         ]
@@ -16084,6 +16693,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -16114,6 +16724,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -16159,6 +16770,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -16254,6 +16866,7 @@
         "desktop-linux": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "nrf52840": [],
         "wasm": []
@@ -16307,6 +16920,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "ryu",
@@ -16346,6 +16960,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -16440,6 +17055,9 @@
         "esp32-s3-heltec": [
           "openocd-semihosting"
         ],
+        "esp32-s3-heltec-r8": [
+          "openocd-semihosting"
+        ],
         "esp32-s3-tbeam": [
           "openocd-semihosting"
         ]
@@ -16511,6 +17129,10 @@
           "std"
         ],
         "esp32-s3-heltec": [
+          "default",
+          "std"
+        ],
+        "esp32-s3-heltec-r8": [
           "default",
           "std"
         ],
@@ -16620,6 +17242,12 @@
           "std"
         ],
         "esp32-s3-heltec": [
+          "default",
+          "derive",
+          "serde_derive",
+          "std"
+        ],
+        "esp32-s3-heltec-r8": [
           "default",
           "derive",
           "serde_derive",
@@ -16765,6 +17393,11 @@
           "result",
           "std"
         ],
+        "esp32-s3-heltec-r8": [
+          "alloc",
+          "result",
+          "std"
+        ],
         "esp32-s3-tbeam": [
           "alloc",
           "result",
@@ -16837,6 +17470,9 @@
           "default"
         ],
         "esp32-s3-heltec": [
+          "default"
+        ],
+        "esp32-s3-heltec-r8": [
           "default"
         ],
         "esp32-s3-tbeam": [
@@ -16978,6 +17614,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "serde_yaml",
@@ -17002,6 +17639,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -17030,6 +17668,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -17109,6 +17748,7 @@
         ],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -17144,6 +17784,7 @@
         ],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -17288,6 +17929,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -17345,6 +17987,7 @@
         ],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "simd-adler32",
@@ -17397,6 +18040,9 @@
         "esp32-s3-heltec": [
           "std"
         ],
+        "esp32-s3-heltec-r8": [
+          "std"
+        ],
         "esp32-s3-tbeam": [
           "std"
         ],
@@ -17433,6 +18079,9 @@
     {
       "graphs": {
         "esp32-s3-heltec": [
+          "const_generics"
+        ],
+        "esp32-s3-heltec-r8": [
           "const_generics"
         ],
         "esp32-s3-tbeam": [
@@ -17591,6 +18240,20 @@
           "socket-tcp",
           "socket-udp"
         ],
+        "esp32-s3-heltec-r8": [
+          "async",
+          "medium-ethernet",
+          "multicast",
+          "proto-dhcpv4",
+          "proto-dns",
+          "proto-ipv4",
+          "proto-ipv6",
+          "socket",
+          "socket-dhcpv4",
+          "socket-dns",
+          "socket-tcp",
+          "socket-udp"
+        ],
         "esp32-s3-tbeam": [
           "async",
           "medium-ethernet",
@@ -17699,6 +18362,9 @@
         "esp32-s3-heltec": [
           "all"
         ],
+        "esp32-s3-heltec-r8": [
+          "all"
+        ],
         "esp32-s3-tbeam": [
           "all"
         ],
@@ -17747,6 +18413,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "somni-expr",
@@ -17764,6 +18431,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "somni-parser",
@@ -17831,6 +18499,11 @@
           "embedded-graphics-core",
           "graphics"
         ],
+        "esp32-s3-heltec-r8": [
+          "default",
+          "embedded-graphics-core",
+          "graphics"
+        ],
         "esp32-s3-tbeam": [
           "default",
           "embedded-graphics-core",
@@ -17878,6 +18551,7 @@
         ],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -17931,6 +18605,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -17975,6 +18650,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "nrf52840": []
@@ -18032,6 +18708,10 @@
           "derive",
           "strum_macros"
         ],
+        "esp32-s3-heltec-r8": [
+          "derive",
+          "strum_macros"
+        ],
         "esp32-s3-tbeam": [
           "derive",
           "strum_macros"
@@ -18069,6 +18749,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "strum_macros",
@@ -18094,6 +18775,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -18119,6 +18801,9 @@
           "default"
         ],
         "esp32-s3-heltec": [
+          "default"
+        ],
+        "esp32-s3-heltec-r8": [
           "default"
         ],
         "esp32-s3-tbeam": [
@@ -18151,6 +18836,18 @@
           "visit-mut"
         ],
         "esp32-s3-heltec": [
+          "clone-impls",
+          "default",
+          "derive",
+          "extra-traits",
+          "full",
+          "parsing",
+          "printing",
+          "proc-macro",
+          "quote",
+          "visit-mut"
+        ],
+        "esp32-s3-heltec-r8": [
           "clone-impls",
           "default",
           "derive",
@@ -18277,6 +18974,18 @@
           "visit-mut"
         ],
         "esp32-s3-heltec": [
+          "clone-impls",
+          "default",
+          "derive",
+          "extra-traits",
+          "full",
+          "parsing",
+          "printing",
+          "proc-macro",
+          "visit",
+          "visit-mut"
+        ],
+        "esp32-s3-heltec-r8": [
           "clone-impls",
           "default",
           "derive",
@@ -18636,6 +19345,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "termcolor",
@@ -19167,6 +19877,22 @@
           "tokio-macros",
           "windows-sys"
         ],
+        "esp32-s3-heltec-r8": [
+          "bytes",
+          "default",
+          "fs",
+          "io-util",
+          "libc",
+          "macros",
+          "mio",
+          "net",
+          "rt",
+          "socket2",
+          "sync",
+          "time",
+          "tokio-macros",
+          "windows-sys"
+        ],
         "esp32-s3-tbeam": [
           "bytes",
           "default",
@@ -19311,6 +20037,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "ios": [],
         "nrf52840": []
@@ -19586,6 +20313,11 @@
           "default",
           "std"
         ],
+        "esp32-s3-heltec-r8": [
+          "alloc",
+          "default",
+          "std"
+        ],
         "esp32-s3-tbeam": [
           "alloc",
           "default",
@@ -19609,6 +20341,9 @@
           "parse"
         ],
         "esp32-s3-heltec": [
+          "parse"
+        ],
+        "esp32-s3-heltec-r8": [
           "parse"
         ],
         "esp32-s3-tbeam": [
@@ -19659,6 +20394,11 @@
           "std"
         ],
         "esp32-s3-heltec": [
+          "alloc",
+          "default",
+          "std"
+        ],
+        "esp32-s3-heltec-r8": [
           "alloc",
           "default",
           "std"
@@ -20143,6 +20883,19 @@
           "scan",
           "trouble-host-macros"
         ],
+        "esp32-s3-heltec-r8": [
+          "central",
+          "default-packet-pool",
+          "default-packet-pool-mtu-255",
+          "default-packet-pool-size-32",
+          "default-packet-pool-size-8",
+          "derive",
+          "gatt",
+          "log",
+          "peripheral",
+          "scan",
+          "trouble-host-macros"
+        ],
         "esp32-s3-tbeam": [
           "central",
           "default-packet-pool",
@@ -20179,6 +20932,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "trouble-host-macros",
@@ -20294,6 +21048,9 @@
         "esp32-s3-heltec": [
           "const-generics"
         ],
+        "esp32-s3-heltec-r8": [
+          "const-generics"
+        ],
         "esp32-s3-tbeam": [
           "const-generics"
         ],
@@ -20346,6 +21103,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "ufmt-write",
@@ -20377,6 +21135,7 @@
     {
       "graphs": {
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "unicase",
@@ -20402,6 +21161,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -20432,6 +21192,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "unicode-segmentation",
@@ -20455,6 +21216,10 @@
           "cjk",
           "default"
         ],
+        "esp32-s3-heltec-r8": [
+          "cjk",
+          "default"
+        ],
         "esp32-s3-tbeam": [
           "cjk",
           "default"
@@ -20475,6 +21240,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "unsafe-libyaml",
@@ -20518,6 +21284,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "nrf52840": []
       },
@@ -20646,6 +21413,12 @@
           "v4"
         ],
         "esp32-s3-heltec": [
+          "default",
+          "rng",
+          "std",
+          "v4"
+        ],
+        "esp32-s3-heltec-r8": [
           "default",
           "rng",
           "std",
@@ -20787,6 +21560,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "nrf52840": []
       },
@@ -20830,6 +21604,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -20860,6 +21635,7 @@
         "desktop-windows": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "host-c-linux": [],
         "host-c-macos": [],
@@ -21729,6 +22505,14 @@
           "parser",
           "std"
         ],
+        "esp32-s3-heltec-r8": [
+          "alloc",
+          "ascii",
+          "binary",
+          "default",
+          "parser",
+          "std"
+        ],
         "esp32-s3-tbeam": [
           "alloc",
           "ascii",
@@ -21854,6 +22638,10 @@
           "precomputed-tables",
           "static_secrets"
         ],
+        "esp32-s3-heltec-r8": [
+          "precomputed-tables",
+          "static_secrets"
+        ],
         "esp32-s3-tbeam": [
           "precomputed-tables",
           "static_secrets"
@@ -21914,6 +22702,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "xtensa-lx",
@@ -21935,6 +22724,9 @@
         "esp32-s3-heltec": [
           "float-save-restore"
         ],
+        "esp32-s3-heltec-r8": [
+          "float-save-restore"
+        ],
         "esp32-s3-tbeam": [
           "float-save-restore"
         ]
@@ -21954,6 +22746,7 @@
       "graphs": {
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "xtensa-lx-rt-proc-macros",
@@ -22124,6 +22917,7 @@
         ],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": []
       },
       "name": "zerocopy",
@@ -22279,6 +23073,11 @@
           "derive",
           "zeroize_derive"
         ],
+        "esp32-s3-heltec-r8": [
+          "alloc",
+          "derive",
+          "zeroize_derive"
+        ],
         "esp32-s3-tbeam": [
           "alloc",
           "derive",
@@ -22364,6 +23163,7 @@
         "engine": [],
         "esp32-c6": [],
         "esp32-s3-heltec": [],
+        "esp32-s3-heltec-r8": [],
         "esp32-s3-tbeam": [],
         "ios": [],
         "nrf52840": []

--- a/docs/website/src/pages/flash/bridge.rs
+++ b/docs/website/src/pages/flash/bridge.rs
@@ -588,7 +588,6 @@ pub(super) fn phase_label(phase: BridgePhase) -> &'static str {
 mod tests {
     use super::*;
     use crate::platforms::{board_target_by_slug, BoardFlashTarget};
-    use prns_flash_manifest::{board_catalog, ValidatedFlashManifest};
     use std::collections::BTreeSet;
 
     const EVENT_FIELDS: [&str; 11] = [
@@ -692,9 +691,6 @@ mod tests {
     #[test]
     fn typed_targets_preserve_the_javascript_request_shape(
     ) -> Result<(), Box<dyn std::error::Error>> {
-        const MANIFEST: &[u8] = include_bytes!(
-            "../../../web-flasher/browser/fixtures/signed-candidate/releases/0.2.6/flash-manifest.json"
-        );
         const UF2_REQUEST_FIELDS: [&str; 13] = [
             "schema",
             "boardSlug",
@@ -729,8 +725,7 @@ mod tests {
         ];
         const PART_FIELDS: [&str; 6] = ["kind", "path", "url", "offset", "size", "sha256"];
 
-        let catalog = board_catalog()?;
-        let manifest = ValidatedFlashManifest::from_json(MANIFEST, &catalog)?;
+        let manifest = super::super::release_0_2_6_fixture()?;
         for target in manifest.targets() {
             let manifest_url = "https://reticulum.rs/releases/0.2.6/flash-manifest.json";
             let catalog_target = board_target_by_slug(target.board_id().as_str())

--- a/docs/website/src/pages/flash/mod.rs
+++ b/docs/website/src/pages/flash/mod.rs
@@ -71,7 +71,7 @@ fn FlashExperience(selected_slug: Option<String>) -> Element {
                 if selected_target.is_some() { "Change board" } else { "Select the exact board" }
             }
             p { class: "mt-3 max-w-3xl leading-relaxed text-soft",
-                "The four shipping targets are first. Hardware still in bring-up remains visible, but cannot be flashed from a public release."
+                "The five shipping targets are first. Hardware still in bring-up remains visible, but cannot be flashed from a public release."
             }
             div { class: "mt-6 grid gap-4 md:grid-cols-2",
                 for board in SHIPPING_BOARD_TARGETS.iter() {

--- a/docs/website/src/pages/flash/mod.rs
+++ b/docs/website/src/pages/flash/mod.rs
@@ -53,6 +53,24 @@ fn release_0_2_6_fixture(
     validate_release_0_2_6_fixture(MANIFEST)
 }
 
+#[cfg(test)]
+#[test]
+fn release_0_2_6_fixture_retains_its_historical_board_set() -> Result<(), Box<dyn std::error::Error>>
+{
+    let manifest = release_0_2_6_fixture()?;
+    let boards = manifest
+        .targets()
+        .iter()
+        .map(|target| target.board_id().as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        boards,
+        ["heltec-v4", "t-beam-supreme", "xiao-esp32-c6", "t-echo"]
+    );
+    Ok(())
+}
+
 #[component]
 pub fn FlashPage() -> Element {
     rsx! { FlashExperience { selected_slug: None } }

--- a/docs/website/src/pages/flash/mod.rs
+++ b/docs/website/src/pages/flash/mod.rs
@@ -17,6 +17,35 @@ use crate::routes::Route;
 
 use view::{BoardTargetCard, GuidedFlasher, LocalBuildUnavailablePanel, UnavailablePanel};
 
+#[cfg(test)]
+fn release_0_2_6_fixture(
+) -> Result<prns_flash_manifest::ValidatedFlashManifest, Box<dyn std::error::Error>> {
+    const MANIFEST: &[u8] = include_bytes!(
+        "../../../web-flasher/browser/fixtures/signed-candidate/releases/0.2.6/flash-manifest.json"
+    );
+
+    let mut catalog = prns_flash_manifest::board_catalog()?;
+    let historical_heltec = catalog
+        .boards
+        .iter_mut()
+        .find(|board| board.slug == "heltec-v4")
+        .ok_or("0.2.6 fixture board is missing from the current catalog")?;
+    historical_heltec.display_name = "Heltec LoRa 32 V4".to_string();
+    historical_heltec.silicon = "ESP32-S3 + SX1262".to_string();
+    let historical_targets = prns_flash_manifest::ManifestTargetSetPolicy::local_development(
+        &catalog,
+        &["heltec-v4", "t-beam-supreme", "t-echo", "xiao-esp32-c6"],
+    )?;
+
+    Ok(
+        prns_flash_manifest::ValidatedFlashManifest::from_json_with_target_set(
+            MANIFEST,
+            &catalog,
+            &historical_targets,
+        )?,
+    )
+}
+
 #[component]
 pub fn FlashPage() -> Element {
     rsx! { FlashExperience { selected_slug: None } }

--- a/docs/website/src/pages/flash/mod.rs
+++ b/docs/website/src/pages/flash/mod.rs
@@ -17,13 +17,10 @@ use crate::routes::Route;
 
 use view::{BoardTargetCard, GuidedFlasher, LocalBuildUnavailablePanel, UnavailablePanel};
 
-#[cfg(test)]
-fn release_0_2_6_fixture(
+#[cfg(any(test, feature = "browser-test-fixture"))]
+fn validate_release_0_2_6_fixture(
+    manifest: &[u8],
 ) -> Result<prns_flash_manifest::ValidatedFlashManifest, Box<dyn std::error::Error>> {
-    const MANIFEST: &[u8] = include_bytes!(
-        "../../../web-flasher/browser/fixtures/signed-candidate/releases/0.2.6/flash-manifest.json"
-    );
-
     let mut catalog = prns_flash_manifest::board_catalog()?;
     let historical_heltec = catalog
         .boards
@@ -39,11 +36,21 @@ fn release_0_2_6_fixture(
 
     Ok(
         prns_flash_manifest::ValidatedFlashManifest::from_json_with_target_set(
-            MANIFEST,
+            manifest,
             &catalog,
             &historical_targets,
         )?,
     )
+}
+
+#[cfg(test)]
+fn release_0_2_6_fixture(
+) -> Result<prns_flash_manifest::ValidatedFlashManifest, Box<dyn std::error::Error>> {
+    const MANIFEST: &[u8] = include_bytes!(
+        "../../../web-flasher/browser/fixtures/signed-candidate/releases/0.2.6/flash-manifest.json"
+    );
+
+    validate_release_0_2_6_fixture(MANIFEST)
 }
 
 #[component]

--- a/docs/website/src/pages/flash/release.rs
+++ b/docs/website/src/pages/flash/release.rs
@@ -468,7 +468,6 @@ mod tests {
         FETCH_SIGNED_DOCUMENTS_SCRIPT,
     };
     use crate::pages::flash::model::{InstallMode, WifiAction};
-    use prns_flash_manifest::{board_catalog, ValidatedFlashManifest};
 
     #[test]
     fn manifest_url_must_be_exact_and_normalized() {
@@ -490,11 +489,7 @@ mod tests {
     #[test]
     fn unsupported_provisioning_is_rejected_instead_of_discarded(
     ) -> Result<(), Box<dyn std::error::Error>> {
-        const MANIFEST: &[u8] = include_bytes!(
-            "../../../web-flasher/browser/fixtures/signed-candidate/releases/0.2.6/flash-manifest.json"
-        );
-        let catalog = board_catalog()?;
-        let manifest = ValidatedFlashManifest::from_json(MANIFEST, &catalog)?;
+        let manifest = super::super::release_0_2_6_fixture()?;
         let target = manifest
             .targets()
             .iter()

--- a/docs/website/src/pages/flash/release.rs
+++ b/docs/website/src/pages/flash/release.rs
@@ -1,8 +1,7 @@
 use dioxus::prelude::*;
 use prns_flash_manifest::{
-    board_catalog, provisioning_image, sha256_hex, verify_minisign, ProvisioningAction,
-    ReleaseChannel, ReleaseTarget, TcpClientEndpoint, TcpClientHost, ValidatedChannelDescriptor,
-    ValidatedFlashManifest, WifiCredentials,
+    provisioning_image, sha256_hex, verify_minisign, ProvisioningAction, ReleaseChannel,
+    ReleaseTarget, TcpClientEndpoint, TcpClientHost, ValidatedChannelDescriptor, WifiCredentials,
 };
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -240,21 +239,30 @@ async fn acquire_release(
         trust::PUBLIC_KEY,
     )
     .map_err(|error| error.to_string())?;
-    let catalog = board_catalog().map_err(|error| error.to_string())?;
+    #[cfg(feature = "browser-test-fixture")]
+    let manifest = super::validate_release_0_2_6_fixture(documents.document.as_bytes())
+        .map_err(|error| error.to_string())?;
     #[cfg(feature = "local-dev-flasher")]
     let manifest = {
+        let catalog = prns_flash_manifest::board_catalog().map_err(|error| error.to_string())?;
         let policy = crate::local_development::manifest_target_set_policy(&catalog)
             .map_err(|error| error.to_string())?;
-        ValidatedFlashManifest::from_json_with_target_set(
+        prns_flash_manifest::ValidatedFlashManifest::from_json_with_target_set(
             documents.document.as_bytes(),
             &catalog,
             &policy,
         )
         .map_err(|error| error.to_string())?
     };
-    #[cfg(not(feature = "local-dev-flasher"))]
-    let manifest = ValidatedFlashManifest::from_json(documents.document.as_bytes(), &catalog)
-        .map_err(|error| error.to_string())?;
+    #[cfg(not(any(feature = "browser-test-fixture", feature = "local-dev-flasher")))]
+    let manifest = {
+        let catalog = prns_flash_manifest::board_catalog().map_err(|error| error.to_string())?;
+        prns_flash_manifest::ValidatedFlashManifest::from_json(
+            documents.document.as_bytes(),
+            &catalog,
+        )
+        .map_err(|error| error.to_string())?
+    };
     let expected_key_id = trust::key_id()
         .ok_or_else(|| "The pinned release key has no canonical key ID.".to_string())?;
     if !manifest

--- a/docs/website/src/platforms.rs
+++ b/docs/website/src/platforms.rs
@@ -155,6 +155,7 @@ impl BoardTarget {
     pub fn image(&self) -> Option<&'static BoardImage> {
         match self.slug {
             "heltec-v4" => Some(&board_images::HELTEC_V4),
+            "heltec-v4-r8" => Some(&board_images::HELTEC_V4),
             "t-beam-supreme" => Some(&board_images::T_BEAM_SUPREME),
             "xiao-esp32-c6" => Some(&board_images::XIAO_ESP32_C6),
             "t-echo" => Some(&board_images::T_ECHO),

--- a/docs/website/web-flasher/browser/README.md
+++ b/docs/website/web-flasher/browser/README.md
@@ -4,11 +4,11 @@ This suite runs the Dioxus flasher against a deterministic, signed four-board
 candidate and an injected fake device bridge. The candidate uses a public
 test-only Minisign key. Its private key is not stored in this repository.
 
-`browser-test-fixture` changes only the compile-time trust root: channel and
-manifest signatures, manifest semantics, artifact sizes, and SHA-256 values are
-still verified. It cannot compile with `embedded-site`, is not a default
-feature, and is rejected from production build commands and output by the
-production-boundary gate.
+`browser-test-fixture` selects the compile-time test trust root and the pinned
+0.2.6 release's historical board contract. Channel and manifest signatures,
+manifest semantics, artifact sizes, and SHA-256 values are still verified. It
+cannot compile with `embedded-site`, is not a default feature, and is rejected
+from production build commands and output by the production-boundary gate.
 
 Install the pinned Chromium revision once, then run the suites:
 

--- a/docs/website/web-flasher/browser/support/build-fixture.mjs
+++ b/docs/website/web-flasher/browser/support/build-fixture.mjs
@@ -79,7 +79,7 @@ const expectedBoards = [
 ];
 const actualBoards = manifest.targets.map((target) => target.board_slug).sort();
 if (JSON.stringify(actualBoards) !== JSON.stringify([...expectedBoards].sort())) {
-  throw new Error("the browser fixture must contain every shipping board exactly once");
+  throw new Error("the browser fixture must contain its historical board set exactly once");
 }
 
 const immutableReleaseRoot = path.join(

--- a/docs/website/web-flasher/browser/support/build-fixture.mjs
+++ b/docs/website/web-flasher/browser/support/build-fixture.mjs
@@ -79,7 +79,7 @@ const expectedBoards = [
 ];
 const actualBoards = manifest.targets.map((target) => target.board_slug).sort();
 if (JSON.stringify(actualBoards) !== JSON.stringify([...expectedBoards].sort())) {
-  throw new Error("the browser fixture must contain all four shipping boards exactly once");
+  throw new Error("the browser fixture must contain every shipping board exactly once");
 }
 
 const immutableReleaseRoot = path.join(

--- a/personal-hopspot/README.md
+++ b/personal-hopspot/README.md
@@ -42,6 +42,7 @@ Desktop, from `desktop/`:
 ESP32 firmware, from `embedded/esp32/` with the board on USB:
 
     cargo heltec-v4-flash
+    cargo heltec-v4-r8-flash
     cargo tbeam-supreme-flash
     cargo c6-flash
 

--- a/personal-hopspot/embedded/esp32/.cargo/config.toml
+++ b/personal-hopspot/embedded/esp32/.cargo/config.toml
@@ -23,7 +23,7 @@ ESP_LOG = "personal_hopspot_esp32=info,personal_rns=info"
 # fragment is in flight. esp-config reads these as `<CRATE>_<NAME>` at build time.
 TROUBLE_HOST_GATT_CLIENT_NOTIFICATION_MAX_SUBSCRIBERS = "2"
 TROUBLE_HOST_GATT_CLIENT_NOTIFICATION_QUEUE_SIZE = "2"
-ESP_HAL_CONFIG_STACK_GUARD_OFFSET = "8192"
+ESP_HAL_CONFIG_STACK_GUARD_OFFSET = "4096"
 
 [alias]
 heltec-v4 = "build --release -p hopspot-heltec-v4 --target xtensa-esp32s3-none-elf -Zbuild-std=core,alloc"

--- a/personal-hopspot/embedded/esp32/.cargo/config.toml
+++ b/personal-hopspot/embedded/esp32/.cargo/config.toml
@@ -1,5 +1,6 @@
-#   cargo heltec-v4        build the Heltec V4 firmware
+#   cargo heltec-v4        build the Heltec V4 (S3R2) firmware
 #   cargo heltec-v4-flash  build + flash + monitor (board on USB)
+#   cargo heltec-v4-r8     / -flash   the Heltec V4-R8 (S3R8 / Octal PSRAM)
 #   cargo tbeam-supreme    / -flash   the LilyGO T-Beam S3 Supreme
 #   cargo c6               / -flash   the headless XIAO ESP32-C6
 
@@ -27,6 +28,8 @@ ESP_HAL_CONFIG_STACK_GUARD_OFFSET = "8192"
 [alias]
 heltec-v4 = "build --release -p hopspot-heltec-v4 --target xtensa-esp32s3-none-elf -Zbuild-std=core,alloc"
 heltec-v4-flash = "run --release -p hopspot-heltec-v4 --target xtensa-esp32s3-none-elf -Zbuild-std=core,alloc"
+heltec-v4-r8 = "build --release -p hopspot-heltec-v4-r8 --target xtensa-esp32s3-none-elf -Zbuild-std=core,alloc"
+heltec-v4-r8-flash = "run --release -p hopspot-heltec-v4-r8 --target xtensa-esp32s3-none-elf -Zbuild-std=core,alloc"
 tbeam-supreme = "build --release -p hopspot-t-beam-supreme --target xtensa-esp32s3-none-elf -Zbuild-std=core,alloc"
 tbeam-supreme-flash = "run --release -p hopspot-t-beam-supreme --target xtensa-esp32s3-none-elf -Zbuild-std=core,alloc"
 # Seeed XIAO ESP32-C6 Hopspot: USB-auto + ESP-NOW + BLE on the headless board. ESP-NOW uses

--- a/personal-hopspot/embedded/esp32/Cargo.lock
+++ b/personal-hopspot/embedded/esp32/Cargo.lock
@@ -1723,6 +1723,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hopspot-heltec-v4-r8"
+version = "0.1.0"
+dependencies = [
+ "embassy-executor",
+ "esp-hal",
+ "esp-rtos",
+ "personal-hopspot-esp32",
+]
+
+[[package]]
 name = "hopspot-t-beam-supreme"
 version = "0.1.0"
 dependencies = [

--- a/personal-hopspot/embedded/esp32/Cargo.toml
+++ b/personal-hopspot/embedded/esp32/Cargo.toml
@@ -4,11 +4,12 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false
-description = "Personal Hopspot ESP32 firmware: the Heltec V4 and T-Beam Supreme (ESP32-S3) and the headless XIAO (ESP32-C6) faces."
+description = "Personal Hopspot ESP32 firmware: the Heltec V4 / V4-R8 and T-Beam Supreme (ESP32-S3) and the headless XIAO (ESP32-C6) faces."
 
 [workspace]
 members = [
     "boards/heltec-v4",
+    "boards/heltec-v4-r8",
     "boards/t-beam-supreme",
     "boards/xiao-esp32-c6",
 ]

--- a/personal-hopspot/embedded/esp32/boards/heltec-v4-r8/Cargo.toml
+++ b/personal-hopspot/embedded/esp32/boards/heltec-v4-r8/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "hopspot-heltec-v4"
+name = "hopspot-heltec-v4-r8"
 version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false
-description = "Personal Hopspot firmware for the Heltec WiFi LoRa 32 V4 (ESP32-S3R2)"
+description = "Personal Hopspot firmware for the Heltec WiFi LoRa 32 V4-R8 (ESP32-S3R8)"
 
 [dependencies]
 personal-hopspot-esp32 = { path = "../..", default-features = false, features = ["bluetooth-auto", "wifi-auto", "esp-now", "lora", "usb", "tcp"] }

--- a/personal-hopspot/embedded/esp32/boards/heltec-v4-r8/build.rs
+++ b/personal-hopspot/embedded/esp32/boards/heltec-v4-r8/build.rs
@@ -1,0 +1,6 @@
+#[path = "../s3_build.rs"]
+mod s3_build;
+
+fn main() {
+    s3_build::link_memory_layout();
+}

--- a/personal-hopspot/embedded/esp32/boards/heltec-v4-r8/src/main.rs
+++ b/personal-hopspot/embedded/esp32/boards/heltec-v4-r8/src/main.rs
@@ -1,0 +1,11 @@
+#![no_std]
+#![no_main]
+#![feature(asm_experimental_arch)]
+#![forbid(unsafe_code)]
+
+use embassy_executor::Spawner;
+
+#[esp_rtos::main]
+async fn main(spawner: Spawner) {
+    personal_hopspot_esp32::s3::boards::heltec_v4_r8::run(spawner).await
+}

--- a/personal-hopspot/embedded/esp32/src/s3/board.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/board.rs
@@ -48,6 +48,8 @@ pub(crate) trait Esp32S3Board {
     const NODE_ANNOUNCE_APP_DATA: &'static [u8];
     const BOOT_BANNER: &'static str;
     const USB_INTERFACE_ID: InterfaceId;
+    /// Stand up `esp_radio::wifi::new` (and BLE coex that depends on it).
+    const BRING_UP_WIFI: bool = true;
     type Display: DrawTarget<Color = BinaryColor>;
     type Battery: screen::BatterySource;
 

--- a/personal-hopspot/embedded/esp32/src/s3/board.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/board.rs
@@ -48,8 +48,6 @@ pub(crate) trait Esp32S3Board {
     const NODE_ANNOUNCE_APP_DATA: &'static [u8];
     const BOOT_BANNER: &'static str;
     const USB_INTERFACE_ID: InterfaceId;
-    /// Stand up `esp_radio::wifi::new` (and BLE coex that depends on it).
-    const BRING_UP_WIFI: bool = true;
     type Display: DrawTarget<Color = BinaryColor>;
     type Battery: screen::BatterySource;
 

--- a/personal-hopspot/embedded/esp32/src/s3/boards/heltec_v4_r8.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/boards/heltec_v4_r8.rs
@@ -114,7 +114,7 @@ impl Esp32S3Board for HeltecV4R8Board {
         p: esp_hal::peripherals::Peripherals,
     ) -> S3BoardHardware<Self::Display, Self::Battery> {
         // Octal 8MB @ 40MHz on a private bump (not global esp_alloc). Vext is GPIO40 — GPIO36 is
-        // FSPICLK/SPIIO7 on the R8 SiP; driving it as GPIO kills PSRAM after early probes.
+        // FSPICLK/SPIIO7 on the R8 SiP; driving it as GPIO disrupts PSRAM access after early probes.
         let (sw_int1, timebase, rtc) = s3::boot_common!(
             p,
             Self::BOOT_BANNER,
@@ -190,7 +190,6 @@ impl Esp32S3Board for HeltecV4R8Board {
             let lora_is_kct8103l = lora_csd.is_high();
             lora_csd.set_output_enable(true);
             lora_csd.set_high();
-            // R8 breaks PA_CTX out on GPIO5; KCT8103L boards use that path. GC1109 still uses GPIO46.
             let _lora_fem_switch = if lora_is_kct8103l {
                 Output::new(p.GPIO5, Level::High, OutputConfig::default())
             } else {

--- a/personal-hopspot/embedded/esp32/src/s3/boards/heltec_v4_r8.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/boards/heltec_v4_r8.rs
@@ -1,0 +1,259 @@
+use esp_hal::analog::adc::{Adc, AdcCalCurve, AdcConfig, AdcPin, Attenuation};
+use esp_hal::gpio::{Flex, Input, InputConfig, Level, Output, OutputConfig};
+use esp_hal::i2c::master::{Config as I2cConfig, I2c};
+use esp_hal::spi::master::{Config as SpiConfig, Spi};
+use esp_hal::time::Rate;
+
+use embassy_executor::Spawner;
+use embassy_time::{Delay, Duration, Timer};
+use embedded_hal_bus::spi::ExclusiveDevice;
+use ssd1306::mode::BufferedGraphicsMode;
+use ssd1306::prelude::*;
+use ssd1306::{I2CDisplayInterface, Ssd1306};
+
+use personal_rns::interfaces::InterfaceId;
+use personal_rns::radios::sx126x::{BoardConfig, Sx126x, TcxoVoltage};
+
+use personal_hopspot_core as screen;
+
+use crate::s3::{
+    self, BoardDisplay, BoardFace, Esp32S3Board, S3BoardHardware, S3InterfaceHardware,
+    S3ManifoldHardware,
+};
+
+/// This board's USB-auto interface id (the always-present top-level wire on pool slot 0).
+const USB_INTERFACE_ID: InterfaceId = InterfaceId::new(*b"heltecr8");
+
+/// This node's `lxmf.delivery` announce app_data: `msgpack([display_name, stamp_cost])`
+/// = `fixarray(2)` ‖ `bin8("Personal Hopspot HeltecV4-R8")` ‖ `nil`, the shape LXMF apps parse.
+const ANNOUNCE_APP_DATA: &[u8] = b"\x92\xc4\x1cPersonal Hopspot HeltecV4-R8\xc0";
+const NODE_ANNOUNCE_APP_DATA: &[u8] = b"Personal Hopspot HeltecV4-R8";
+
+const VBAT_DIVIDER_NUM: u32 = 49;
+const VBAT_DIVIDER_DEN: u32 = 10;
+
+/// How far the fast voltage average must lead the slow one to read as "charging". The Heltec V4-R8
+/// has no charge/VBUS pin, so charging is inferred from the cell's voltage trend: plugging in steps
+/// the terminal voltage up and charging trends it up. Below this the cell is idle, discharging, or
+/// full (flat). Tuned above ADC/load noise (load dips pull the fast average *down*, never up).
+const CHARGE_RISE_MV: u32 = 16;
+
+/// The Heltec V4-R8's battery sense: VBAT on a 49:10 divider into ADC1 (GPIO1). Unlike the S3R2 V4,
+/// ADC_Ctrl is not broken out — do not claim GPIO37 (that pad is SPIDQS on the Octal SiP). The shared
+/// [`BatteryGauge`](screen::BatteryGauge) owns the percentage curve; this reads the divided
+/// millivolts and keeps two EMAs (fast + slow) so [`is_charging`](Self::is_charging) can infer the
+/// plugged/charging state this board gives no direct signal for. ADC oneshots can report
+/// `WouldBlock`, so a read is retried briefly.
+pub struct HeltecR8Battery {
+    adc: Adc<'static, esp_hal::peripherals::ADC1<'static>, esp_hal::Blocking>,
+    pin: AdcPin<
+        esp_hal::peripherals::GPIO1<'static>,
+        esp_hal::peripherals::ADC1<'static>,
+        AdcCalCurve<esp_hal::peripherals::ADC1<'static>>,
+    >,
+    fast_ema_mv: u32,
+    slow_ema_mv: u32,
+}
+
+impl screen::BatterySource for HeltecR8Battery {
+    fn read_millivolts(&mut self) -> Option<u32> {
+        for _ in 0..1000 {
+            if let Ok(raw) = self.adc.read_oneshot(&mut self.pin) {
+                let mv = raw as u32 * VBAT_DIVIDER_NUM / VBAT_DIVIDER_DEN;
+                if self.slow_ema_mv == 0 {
+                    self.fast_ema_mv = mv;
+                    self.slow_ema_mv = mv;
+                } else {
+                    self.fast_ema_mv = (self.fast_ema_mv * 3 + mv) / 4;
+                    self.slow_ema_mv = (self.slow_ema_mv * 15 + mv) / 16;
+                }
+                return Some(mv);
+            }
+        }
+        None
+    }
+
+    /// Inferred charging: the fast voltage average leading the slow one by [`CHARGE_RISE_MV`] means
+    /// the terminal voltage is stepping/trending up (plug-in or active charge). Fades when the cell
+    /// is full (flat) or on unplug (step down) — an approximation that answers "did plugging in
+    /// actually start charging?", which is the signal that matters on a board with no charge pin.
+    fn is_charging(&mut self) -> bool {
+        self.fast_ema_mv > self.slow_ema_mv.saturating_add(CHARGE_RISE_MV)
+    }
+}
+
+type HeltecDisplay = Ssd1306<
+    I2CInterface<I2c<'static, esp_hal::Blocking>>,
+    DisplaySize128x64,
+    BufferedGraphicsMode<DisplaySize128x64>,
+>;
+
+/// The Heltec V4-R8's board half (OLED/battery/radio bring-up); everything past it is the shared
+/// [`s3`] core. Pinout differs from the S3R2 V4 for Vext and battery gating; PSRAM is Octal 8MB.
+pub struct HeltecV4R8Board;
+
+impl Esp32S3Board for HeltecV4R8Board {
+    const ANNOUNCE_APP_DATA: &'static [u8] = ANNOUNCE_APP_DATA;
+    const NODE_ANNOUNCE_APP_DATA: &'static [u8] = NODE_ANNOUNCE_APP_DATA;
+    const BOOT_BANNER: &'static str = "HOPSPOT_HELTECV4_R8";
+    const USB_INTERFACE_ID: InterfaceId = USB_INTERFACE_ID;
+    type Display = HeltecDisplay;
+    type Battery = HeltecR8Battery;
+
+    fn flush(display: &mut Self::Display) {
+        if let Err(error) = display.flush() {
+            log::error!("OLED render failed: {error:?}");
+        }
+    }
+
+    fn set_display_awake(display: &mut Self::Display, awake: bool) {
+        let _ = display.set_display_on(awake);
+    }
+
+    async fn bringup(
+        p: esp_hal::peripherals::Peripherals,
+    ) -> S3BoardHardware<Self::Display, Self::Battery> {
+        // Octal 8MB @ 40MHz on a private bump (not global esp_alloc). Vext is GPIO40 — GPIO36 is
+        // FSPICLK/SPIIO7 on the R8 SiP; driving it as GPIO kills PSRAM after early probes.
+        let (sw_int1, timebase, rtc) = s3::boot_common!(
+            p,
+            Self::BOOT_BANNER,
+            ::esp_hal::psram::PsramConfig {
+                mode: ::esp_hal::psram::PsramMode::OctalSpi,
+                size: ::esp_hal::psram::PsramSize::Size(8 * 1024 * 1024),
+                ram_frequency: ::esp_hal::psram::SpiRamFreq::Freq40m,
+                ..::core::default::Default::default()
+            }
+        );
+
+        s3::boot_stage(s3::BootPhase::OledBegin);
+        // OLED (V4-R8: Vext on GPIO40 active-low; pulse RST; I2C0 on 17/18).
+        let mut _vext = Output::new(p.GPIO40, Level::Low, OutputConfig::default());
+        let mut rst = Output::new(p.GPIO21, Level::High, OutputConfig::default());
+        rst.set_low();
+        Timer::after(Duration::from_millis(20)).await;
+        rst.set_high();
+        Timer::after(Duration::from_millis(20)).await;
+        let i2c = I2c::new(
+            p.I2C0,
+            I2cConfig::default().with_frequency(Rate::from_khz(400)),
+        )
+        .expect("i2c0")
+        .with_sda(p.GPIO17)
+        .with_scl(p.GPIO18);
+        let mut display = Ssd1306::new(
+            I2CDisplayInterface::new(i2c),
+            DisplaySize128x64,
+            DisplayRotation::Rotate90,
+        )
+        .into_buffered_graphics_mode();
+        let oled_ok = match display.init() {
+            Ok(()) => {
+                s3::boot_stage(s3::BootPhase::OledReady);
+                log::info!("OLED initialized");
+                true
+            }
+            Err(error) => {
+                s3::boot_stage(s3::BootPhase::OledFailed);
+                log::error!("OLED initialization failed: {error:?}");
+                false
+            }
+        };
+        if oled_ok {
+            screen::splash(&mut display, screen::SplashContent::Brand);
+            if let Err(error) = display.flush() {
+                log::error!("OLED splash failed: {error:?}");
+            }
+        }
+
+        #[cfg(feature = "lora")]
+        let lora_radio = {
+            let lora_spi = Spi::new(
+                p.SPI2,
+                SpiConfig::default().with_frequency(Rate::from_mhz(8)),
+            )
+            .expect("lora spi2")
+            .with_sck(p.GPIO9)
+            .with_mosi(p.GPIO10)
+            .with_miso(p.GPIO11)
+            .into_async();
+            let lora_cs = Output::new(p.GPIO8, Level::High, OutputConfig::default());
+            let lora_spi_device =
+                ExclusiveDevice::new(lora_spi, lora_cs, Delay).expect("lora spi device");
+            let lora_reset = Output::new(p.GPIO12, Level::High, OutputConfig::default());
+            let lora_busy = Input::new(p.GPIO13, InputConfig::default());
+            let lora_dio1 = Input::new(p.GPIO14, InputConfig::default());
+            let _lora_pa_pwr = Output::new(p.GPIO7, Level::High, OutputConfig::default());
+            let mut lora_csd = Flex::new(p.GPIO2);
+            lora_csd.apply_input_config(&InputConfig::default());
+            lora_csd.set_input_enable(true);
+            let lora_is_kct8103l = lora_csd.is_high();
+            lora_csd.set_output_enable(true);
+            lora_csd.set_high();
+            // R8 breaks PA_CTX out on GPIO5; KCT8103L boards use that path. GC1109 still uses GPIO46.
+            let _lora_fem_switch = if lora_is_kct8103l {
+                Output::new(p.GPIO5, Level::High, OutputConfig::default())
+            } else {
+                Output::new(p.GPIO46, Level::High, OutputConfig::default())
+            };
+            Sx126x::new(
+                lora_spi_device,
+                lora_busy,
+                lora_dio1,
+                lora_reset,
+                Delay,
+                BoardConfig {
+                    tcxo_voltage: Some(TcxoVoltage::V1_8),
+                    use_dcdc: true,
+                    rx_boost: true,
+                    dio2_as_rf_switch: true,
+                },
+            )
+        };
+
+        // Battery sense: VBAT on GPIO1, ungated (ADC_Ctrl removed on R8).
+        let mut adc_cfg = AdcConfig::new();
+        let vbat_pin =
+            adc_cfg.enable_pin_with_cal::<_, AdcCalCurve<_>>(p.GPIO1, Attenuation::_11dB);
+        let vbat_adc = Adc::new(p.ADC1, adc_cfg);
+        let battery = HeltecR8Battery {
+            adc: vbat_adc,
+            pin: vbat_pin,
+            fast_ema_mv: 0,
+            slow_ema_mv: 0,
+        };
+
+        S3BoardHardware {
+            face: BoardFace {
+                display: BoardDisplay {
+                    device: display,
+                    initialized: oled_ok,
+                },
+                battery,
+                button: Input::new(
+                    p.GPIO0,
+                    InputConfig::default().with_pull(esp_hal::gpio::Pull::Up),
+                ),
+            },
+            interface_hardware: S3InterfaceHardware {
+                usb_device: p.USB_DEVICE,
+                #[cfg(feature = "lora")]
+                lora_radio,
+                #[cfg(feature = "wifi-auto")]
+                wifi: p.WIFI,
+                #[cfg(feature = "bluetooth-auto")]
+                bluetooth: p.BT,
+            },
+            manifold: S3ManifoldHardware {
+                cpu_control: p.CPU_CTRL,
+                software_interrupt: sw_int1,
+                timebase,
+                rtc,
+            },
+        }
+    }
+}
+
+pub async fn run(spawner: Spawner) {
+    s3::run::<HeltecV4R8Board>(spawner).await
+}

--- a/personal-hopspot/embedded/esp32/src/s3/boards/mod.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/boards/mod.rs
@@ -1,2 +1,3 @@
 pub mod heltec_v4;
+pub mod heltec_v4_r8;
 pub mod t_beam_supreme;

--- a/personal-hopspot/embedded/esp32/src/s3/connectivity.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/connectivity.rs
@@ -75,9 +75,12 @@ pub(super) fn build_wifi(
         .with_static_rx_buf_num(3)
         .with_dynamic_rx_buf_num(3)
         .with_rx_ba_win(2);
+    log::info!("wifi::new begin");
     let Ok((mut controller, interfaces)) = esp_radio::wifi::new(wifi, wifi_config) else {
+        log::info!("wifi::new failed");
         return (None, None, None);
     };
+    log::info!("wifi::new ready");
     let esp_now = interfaces.esp_now;
 
     // In SoftAP mode, APSTA brings the AP up whether or not a station uplink is configured;

--- a/personal-hopspot/embedded/esp32/src/s3/connectivity.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/connectivity.rs
@@ -75,12 +75,9 @@ pub(super) fn build_wifi(
         .with_static_rx_buf_num(3)
         .with_dynamic_rx_buf_num(3)
         .with_rx_ba_win(2);
-    log::info!("wifi::new begin");
     let Ok((mut controller, interfaces)) = esp_radio::wifi::new(wifi, wifi_config) else {
-        log::info!("wifi::new failed");
         return (None, None, None);
     };
-    log::info!("wifi::new ready");
     let esp_now = interfaces.esp_now;
 
     // In SoftAP mode, APSTA brings the AP up whether or not a station uplink is configured;

--- a/personal-hopspot/embedded/esp32/src/s3/firmware.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/firmware.rs
@@ -80,6 +80,10 @@ pub(super) async fn run_core<B: Esp32S3Board>(
     );
     let lora_spectrum: &'static LoRaSpectrumStatus =
         mk_static!(LoRaSpectrumStatus, LoRaSpectrumStatus::new());
+    // Reclaim the private R8 probe allocation before placing the live LoRa queue in PSRAM.
+    // This is a no-op on boards whose PSRAM belongs to the global heap.
+    #[cfg(feature = "lora")]
+    crate::storage::reinit_private_psram_heap();
     #[cfg(feature = "lora")]
     let lora_tx_queue = crate::storage::allocate_lora_tx_queue();
     #[cfg(feature = "lora")]
@@ -100,27 +104,23 @@ pub(super) async fn run_core<B: Esp32S3Board>(
     // The Wi-Fi stack carries both the Wi-Fi Auto UDP and the TCP client, so it stands up before the
     // node moves to core 1 — activating the TCP slot is a core-0-only act.
     #[cfg(feature = "wifi-auto")]
-    let (wifi, tcp_stack, esp_now) = if B::BRING_UP_WIFI {
-        boot_stage(BootPhase::WifiBegin);
-        let built = build_wifi(
-            &spawner,
-            wifi_hardware,
-            mac_octets,
-            &wifi_config,
-            radio_mode == RadioMode::AccessPoint,
-        );
-        boot_stage(BootPhase::WifiReady);
-        log::info!(
-            "Wi-Fi initialized station={} network_stack={}",
-            built.0.is_some(),
-            built.1.is_some()
-        );
-        built
-    } else {
-        log::info!("Wi-Fi bring-up skipped for this board");
-        let _ = wifi_hardware;
-        (None, None, None)
-    };
+    boot_stage(BootPhase::WifiBegin);
+    #[cfg(feature = "wifi-auto")]
+    let (wifi, tcp_stack, esp_now) = build_wifi(
+        &spawner,
+        wifi_hardware,
+        mac_octets,
+        &wifi_config,
+        radio_mode == RadioMode::AccessPoint,
+    );
+    #[cfg(feature = "wifi-auto")]
+    boot_stage(BootPhase::WifiReady);
+    #[cfg(feature = "wifi-auto")]
+    log::info!(
+        "Wi-Fi initialized station={} network_stack={}",
+        wifi.is_some(),
+        tcp_stack.is_some()
+    );
     #[cfg(not(feature = "wifi-auto"))]
     let wifi: Option<AutoWifi<'static, MEMBERS>> = None;
     #[cfg(not(feature = "wifi-auto"))]
@@ -238,42 +238,25 @@ pub(super) async fn run_core<B: Esp32S3Board>(
     );
     let host = EmbassyHost::new_with_timebase(timebase, hardware_entropy as fn(&mut [u8]));
 
-    // Private PSRAM bump: deallocate is a no-op, so reset after the boot probe before engine init.
-    crate::storage::reinit_private_psram_heap();
-
-    if B::BRING_UP_WIFI {
-        let core1_stack = mk_static!(CpuStack<CORE1_STACK_BYTES>, CpuStack::new());
-        boot_stage(BootPhase::CoreOneStartBegin);
-        esp_rtos::start_second_core(cpu_control, software_interrupt, core1_stack, move || {
-            static NODE: StaticCell<S3Node> = StaticCell::new();
-            let (node, persistence) =
-                PrnsNode::init_static_with_persistence(&NODE, recipe, manifold_wiring, host);
-            static PERSISTENCE: StaticCell<crate::persistence::S3Persistence> = StaticCell::new();
-            let persistence = PERSISTENCE.init(persistence);
-
-            static EXECUTOR: StaticCell<esp_rtos::embassy::Executor> = StaticCell::new();
-            boot_stage(BootPhase::CoreOneExecutorReady);
-            EXECUTOR
-                .init(esp_rtos::embassy::Executor::new())
-                .run(|spawner| {
-                    spawner.spawn(manifold_task(node, persistence).expect("manifold task fits"));
-                    spawner.spawn(core_one_liveness_task().expect("core-one liveness task fits"));
-                })
-        });
-        boot_stage(BootPhase::CoreOneStartReady);
-    } else {
-        // Optional single-core bring-up when a board sets `BRING_UP_WIFI = false`.
-        let _ = (cpu_control, software_interrupt);
+    let core1_stack = mk_static!(CpuStack<CORE1_STACK_BYTES>, CpuStack::new());
+    boot_stage(BootPhase::CoreOneStartBegin);
+    esp_rtos::start_second_core(cpu_control, software_interrupt, core1_stack, move || {
         static NODE: StaticCell<S3Node> = StaticCell::new();
         let (node, persistence) =
             PrnsNode::init_static_with_persistence(&NODE, recipe, manifold_wiring, host);
         static PERSISTENCE: StaticCell<crate::persistence::S3Persistence> = StaticCell::new();
         let persistence = PERSISTENCE.init(persistence);
-        // Single-core path: the RWDT is fed from CORE_ONE_HEARTBEAT. With no core 1, run the
-        // liveness ticker here or the board resets ~15s after boot.
-        spawner.spawn(core_one_liveness_task().expect("core-one liveness task fits"));
-        spawner.spawn(manifold_task(node, persistence).expect("manifold task fits"));
-    }
+
+        static EXECUTOR: StaticCell<esp_rtos::embassy::Executor> = StaticCell::new();
+        boot_stage(BootPhase::CoreOneExecutorReady);
+        EXECUTOR
+            .init(esp_rtos::embassy::Executor::new())
+            .run(|spawner| {
+                spawner.spawn(manifold_task(node, persistence).expect("manifold task fits"));
+                spawner.spawn(core_one_liveness_task().expect("core-one liveness task fits"));
+            })
+    });
+    boot_stage(BootPhase::CoreOneStartReady);
 
     let (usb_rx, usb_tx) = UsbSerialJtag::new(usb_device).into_async().split();
     let usb_seam = usb_lane.into_seam(NOTIFY.sender(), hardware_entropy);
@@ -335,7 +318,7 @@ pub(super) async fn run_core<B: Esp32S3Board>(
 
     let render = async move {
         boot_stage(BootPhase::DisplayRuntimeBegin);
-        let access_point = if !cfg!(feature = "wifi-auto") || !B::BRING_UP_WIFI {
+        let access_point = if !cfg!(feature = "wifi-auto") {
             screen::AccessPointState::Unsupported
         } else if radio_mode == RadioMode::AccessPoint {
             screen::AccessPointState::Active
@@ -737,25 +720,20 @@ pub(super) async fn run_core<B: Esp32S3Board>(
         }
         match radio_mode {
             RadioMode::Ble => {
-                if B::BRING_UP_WIFI {
-                    boot_stage(BootPhase::BluetoothBegin);
-                    let ble_connector = esp_radio::ble::controller::BleConnector::new(
-                        bluetooth,
-                        esp_radio::ble::Config::default()
-                            .with_task_stack_size(4096)
-                            .with_max_connections(BLE_PEER_CAPACITY as u8),
-                    )
-                    .expect("ble connector");
-                    boot_stage(BootPhase::BluetoothReady);
-                    if let Some((identity, fleet)) = ble {
-                        spawner.spawn(
-                            ble_task(spawner, ble_connector, mac_octets, identity, fleet)
-                                .expect("Bluetooth task fits"),
-                        );
-                    }
-                } else {
-                    let _ = (bluetooth, ble);
-                    log::info!("Bluetooth bring-up skipped with Wi-Fi");
+                boot_stage(BootPhase::BluetoothBegin);
+                let ble_connector = esp_radio::ble::controller::BleConnector::new(
+                    bluetooth,
+                    esp_radio::ble::Config::default()
+                        .with_task_stack_size(4096)
+                        .with_max_connections(BLE_PEER_CAPACITY as u8),
+                )
+                .expect("ble connector");
+                boot_stage(BootPhase::BluetoothReady);
+                if let Some((identity, fleet)) = ble {
+                    spawner.spawn(
+                        ble_task(spawner, ble_connector, mac_octets, identity, fleet)
+                            .expect("Bluetooth task fits"),
+                    );
                 }
             }
             RadioMode::AccessPoint => {

--- a/personal-hopspot/embedded/esp32/src/s3/firmware.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/firmware.rs
@@ -53,13 +53,12 @@ pub(super) async fn run_core<B: Esp32S3Board>(
         wifi_config.tcp_client.is_some()
     );
 
+    // Defer claiming USB-JTAG until after Wi-Fi bring-up so boot logs stay visible through radio init.
     let usb_status: &'static EmbassyInterfaceStatus = mk_static!(
         EmbassyInterfaceStatus,
         EmbassyInterfaceStatus::new(B::USB_INTERFACE_ID, ConnectionState::Initializing)
     );
     let usb_id = usb_status.id();
-    let (usb_rx, usb_tx) = UsbSerialJtag::new(usb_device).into_async().split();
-
     let mac = base_mac_address();
     let mut mac_octets = [0u8; 6];
     mac_octets.copy_from_slice(&mac.as_bytes()[..6]);
@@ -101,23 +100,27 @@ pub(super) async fn run_core<B: Esp32S3Board>(
     // The Wi-Fi stack carries both the Wi-Fi Auto UDP and the TCP client, so it stands up before the
     // node moves to core 1 — activating the TCP slot is a core-0-only act.
     #[cfg(feature = "wifi-auto")]
-    boot_stage(BootPhase::WifiBegin);
-    #[cfg(feature = "wifi-auto")]
-    let (wifi, tcp_stack, esp_now) = build_wifi(
-        &spawner,
-        wifi_hardware,
-        mac_octets,
-        &wifi_config,
-        radio_mode == RadioMode::AccessPoint,
-    );
-    #[cfg(feature = "wifi-auto")]
-    boot_stage(BootPhase::WifiReady);
-    #[cfg(feature = "wifi-auto")]
-    log::info!(
-        "Wi-Fi initialized station={} network_stack={}",
-        wifi.is_some(),
-        tcp_stack.is_some()
-    );
+    let (wifi, tcp_stack, esp_now) = if B::BRING_UP_WIFI {
+        boot_stage(BootPhase::WifiBegin);
+        let built = build_wifi(
+            &spawner,
+            wifi_hardware,
+            mac_octets,
+            &wifi_config,
+            radio_mode == RadioMode::AccessPoint,
+        );
+        boot_stage(BootPhase::WifiReady);
+        log::info!(
+            "Wi-Fi initialized station={} network_stack={}",
+            built.0.is_some(),
+            built.1.is_some()
+        );
+        built
+    } else {
+        log::info!("Wi-Fi bring-up skipped for this board");
+        let _ = wifi_hardware;
+        (None, None, None)
+    };
     #[cfg(not(feature = "wifi-auto"))]
     let wifi: Option<AutoWifi<'static, MEMBERS>> = None;
     #[cfg(not(feature = "wifi-auto"))]
@@ -235,26 +238,44 @@ pub(super) async fn run_core<B: Esp32S3Board>(
     );
     let host = EmbassyHost::new_with_timebase(timebase, hardware_entropy as fn(&mut [u8]));
 
-    let core1_stack = mk_static!(CpuStack<CORE1_STACK_BYTES>, CpuStack::new());
-    boot_stage(BootPhase::CoreOneStartBegin);
-    esp_rtos::start_second_core(cpu_control, software_interrupt, core1_stack, move || {
+    // Private PSRAM bump: deallocate is a no-op, so reset after the boot probe before engine init.
+    crate::storage::reinit_private_psram_heap();
+
+    if B::BRING_UP_WIFI {
+        let core1_stack = mk_static!(CpuStack<CORE1_STACK_BYTES>, CpuStack::new());
+        boot_stage(BootPhase::CoreOneStartBegin);
+        esp_rtos::start_second_core(cpu_control, software_interrupt, core1_stack, move || {
+            static NODE: StaticCell<S3Node> = StaticCell::new();
+            let (node, persistence) =
+                PrnsNode::init_static_with_persistence(&NODE, recipe, manifold_wiring, host);
+            static PERSISTENCE: StaticCell<crate::persistence::S3Persistence> = StaticCell::new();
+            let persistence = PERSISTENCE.init(persistence);
+
+            static EXECUTOR: StaticCell<esp_rtos::embassy::Executor> = StaticCell::new();
+            boot_stage(BootPhase::CoreOneExecutorReady);
+            EXECUTOR
+                .init(esp_rtos::embassy::Executor::new())
+                .run(|spawner| {
+                    spawner.spawn(manifold_task(node, persistence).expect("manifold task fits"));
+                    spawner.spawn(core_one_liveness_task().expect("core-one liveness task fits"));
+                })
+        });
+        boot_stage(BootPhase::CoreOneStartReady);
+    } else {
+        // Optional single-core bring-up when a board sets `BRING_UP_WIFI = false`.
+        let _ = (cpu_control, software_interrupt);
         static NODE: StaticCell<S3Node> = StaticCell::new();
         let (node, persistence) =
             PrnsNode::init_static_with_persistence(&NODE, recipe, manifold_wiring, host);
         static PERSISTENCE: StaticCell<crate::persistence::S3Persistence> = StaticCell::new();
         let persistence = PERSISTENCE.init(persistence);
+        // Single-core path: the RWDT is fed from CORE_ONE_HEARTBEAT. With no core 1, run the
+        // liveness ticker here or the board resets ~15s after boot.
+        spawner.spawn(core_one_liveness_task().expect("core-one liveness task fits"));
+        spawner.spawn(manifold_task(node, persistence).expect("manifold task fits"));
+    }
 
-        static EXECUTOR: StaticCell<esp_rtos::embassy::Executor> = StaticCell::new();
-        boot_stage(BootPhase::CoreOneExecutorReady);
-        EXECUTOR
-            .init(esp_rtos::embassy::Executor::new())
-            .run(|spawner| {
-                spawner.spawn(manifold_task(node, persistence).expect("manifold task fits"));
-                spawner.spawn(core_one_liveness_task().expect("core-one liveness task fits"));
-            })
-    });
-    boot_stage(BootPhase::CoreOneStartReady);
-
+    let (usb_rx, usb_tx) = UsbSerialJtag::new(usb_device).into_async().split();
     let usb_seam = usb_lane.into_seam(NOTIFY.sender(), hardware_entropy);
     spawner.spawn(usb_device_task(usb_rx, usb_tx, usb_seam, usb_status).expect("usb task fits"));
 
@@ -314,7 +335,7 @@ pub(super) async fn run_core<B: Esp32S3Board>(
 
     let render = async move {
         boot_stage(BootPhase::DisplayRuntimeBegin);
-        let access_point = if !cfg!(feature = "wifi-auto") {
+        let access_point = if !cfg!(feature = "wifi-auto") || !B::BRING_UP_WIFI {
             screen::AccessPointState::Unsupported
         } else if radio_mode == RadioMode::AccessPoint {
             screen::AccessPointState::Active
@@ -716,20 +737,25 @@ pub(super) async fn run_core<B: Esp32S3Board>(
         }
         match radio_mode {
             RadioMode::Ble => {
-                boot_stage(BootPhase::BluetoothBegin);
-                let ble_connector = esp_radio::ble::controller::BleConnector::new(
-                    bluetooth,
-                    esp_radio::ble::Config::default()
-                        .with_task_stack_size(4096)
-                        .with_max_connections(BLE_PEER_CAPACITY as u8),
-                )
-                .expect("ble connector");
-                boot_stage(BootPhase::BluetoothReady);
-                if let Some((identity, fleet)) = ble {
-                    spawner.spawn(
-                        ble_task(spawner, ble_connector, mac_octets, identity, fleet)
-                            .expect("Bluetooth task fits"),
-                    );
+                if B::BRING_UP_WIFI {
+                    boot_stage(BootPhase::BluetoothBegin);
+                    let ble_connector = esp_radio::ble::controller::BleConnector::new(
+                        bluetooth,
+                        esp_radio::ble::Config::default()
+                            .with_task_stack_size(4096)
+                            .with_max_connections(BLE_PEER_CAPACITY as u8),
+                    )
+                    .expect("ble connector");
+                    boot_stage(BootPhase::BluetoothReady);
+                    if let Some((identity, fleet)) = ble {
+                        spawner.spawn(
+                            ble_task(spawner, ble_connector, mac_octets, identity, fleet)
+                                .expect("Bluetooth task fits"),
+                        );
+                    }
+                } else {
+                    let _ = (bluetooth, ble);
+                    log::info!("Bluetooth bring-up skipped with Wi-Fi");
                 }
             }
             RadioMode::AccessPoint => {

--- a/personal-hopspot/embedded/esp32/src/s3/mod.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/mod.rs
@@ -475,21 +475,21 @@ async fn usb_device_task(
 ///
 /// Heap region order is load-bearing for Wi-Fi boards: PSRAM must register first so capability-free
 /// boot allocations land externally and leave the small internal regions for the radio. Heltec V4-R8
-/// (Octal private bump) passes a custom `PsramConfig` and uses `internal_first` so boot/log allocs
-/// cannot share a freelist with engine construction.
+/// (Octal private bump) passes a custom `PsramConfig` and uses `private_psram_bump` so boot/log
+/// allocations cannot share a freelist with engine construction.
 macro_rules! boot_common {
     ($p:ident, $banner:expr) => {
         $crate::s3::boot_common!(
             $p,
             $banner,
             ::esp_hal::psram::PsramConfig::default(),
-            psram_first
+            global_psram_heap
         )
     };
     ($p:ident, $banner:expr, $psram_config:expr) => {
-        $crate::s3::boot_common!($p, $banner, $psram_config, internal_first)
+        $crate::s3::boot_common!($p, $banner, $psram_config, private_psram_bump)
     };
-    ($p:ident, $banner:expr, $psram_config:expr, psram_first) => {{
+    ($p:ident, $banner:expr, $psram_config:expr, global_psram_heap) => {{
         ::esp_println::logger::init_logger_from_env();
         $crate::s3::boot_add_psram_global!($p, $psram_config);
         ::esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 43 * 1024);
@@ -497,7 +497,7 @@ macro_rules! boot_common {
         $crate::s3::boot_psram_probe!();
         $crate::s3::boot_rtos_tail!($p, $banner)
     }};
-    ($p:ident, $banner:expr, $psram_config:expr, internal_first) => {{
+    ($p:ident, $banner:expr, $psram_config:expr, private_psram_bump) => {{
         ::esp_println::logger::init_logger_from_env();
         // Heltec V4-R8: keep Octal PSRAM out of the global heap so boot/log allocs cannot spill into it.
         ::esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 43 * 1024);
@@ -522,7 +522,6 @@ macro_rules! boot_add_psram_global {
                 ::esp_alloc::MemoryCapability::External.into(),
             ));
         }
-        ::core::mem::forget(psram);
     }};
 }
 pub(crate) use boot_add_psram_global;
@@ -534,7 +533,6 @@ macro_rules! boot_add_psram_private {
         ::esp_println::println!("PSRAM mapped start={start:?} size={size} (private)");
         // SAFETY: exclusive mapped window for PsramAlloc; not registered with esp_alloc.
         unsafe { $crate::storage::init_private_psram_heap(start, size) };
-        ::core::mem::forget(psram);
     }};
 }
 pub(crate) use boot_add_psram_private;
@@ -545,17 +543,17 @@ macro_rules! boot_psram_probe {
         // (deallocate is a no-op), and large probes would permanently consume the window
         // until the pre-engine reinit.
         let layout = ::core::alloc::Layout::from_size_align(4, 4).expect("u32 layout");
-        match ::allocator_api2::alloc::Allocator::allocate(&$crate::storage::PsramAlloc, layout) {
-            Ok(ptr) => {
-                // SAFETY: exclusive PsramAlloc allocation; write/read (leak is fine — bump).
-                unsafe {
-                    let p = ptr.cast::<u32>().as_ptr();
-                    p.write_volatile(0xA5A5_5A5A);
-                    let read = p.read_volatile();
-                    ::esp_println::println!("PSRAM probe ok read=0x{read:08X}");
-                }
-            }
-            Err(_) => ::esp_println::println!("PSRAM probe alloc failed"),
+        let ptr =
+            ::allocator_api2::alloc::Allocator::allocate(&$crate::storage::PsramAlloc, layout)
+                .expect("PSRAM probe allocation failed");
+        // SAFETY: exclusive PsramAlloc allocation; write/read (leak is fine — bump).
+        unsafe {
+            const PATTERN: u32 = 0xA5A5_5A5A;
+            let p = ptr.cast::<u32>().as_ptr();
+            p.write_volatile(PATTERN);
+            let read = p.read_volatile();
+            assert_eq!(read, PATTERN, "PSRAM probe readback mismatch");
+            ::esp_println::println!("PSRAM probe ok read=0x{read:08X}");
         }
     }};
 }

--- a/personal-hopspot/embedded/esp32/src/s3/mod.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/mod.rs
@@ -472,16 +472,97 @@ async fn usb_device_task(
 /// internal + the reclaimed D-cache region), the RTOS timer, and the RTC with its watchdogs disabled
 /// for the slow PSRAM-backed engine construction. A block expression (so its bindings escape
 /// macro hygiene) owning `$p`'s early peripherals, yielding `(software_interrupt1, timebase, rtc)`.
-/// PSRAM registers first and that order is load-bearing: the allocator serves a capability-free
-/// allocation from the first region with space, so external must lead or ordinary boot
-/// allocations bleed the two small internal regions dry and the radio bring-up — whose
-/// allocations genuinely require internal SRAM — finds crumbs and dies on core 0.
+///
+/// Heap region order is load-bearing for Wi-Fi boards: PSRAM must register first so capability-free
+/// boot allocations land externally and leave the small internal regions for the radio. Heltec V4-R8
+/// (Octal private bump) passes a custom `PsramConfig` and uses `internal_first` so boot/log allocs
+/// cannot share a freelist with engine construction.
 macro_rules! boot_common {
-    ($p:ident, $banner:expr) => {{
+    ($p:ident, $banner:expr) => {
+        $crate::s3::boot_common!(
+            $p,
+            $banner,
+            ::esp_hal::psram::PsramConfig::default(),
+            psram_first
+        )
+    };
+    ($p:ident, $banner:expr, $psram_config:expr) => {
+        $crate::s3::boot_common!($p, $banner, $psram_config, internal_first)
+    };
+    ($p:ident, $banner:expr, $psram_config:expr, psram_first) => {{
         ::esp_println::logger::init_logger_from_env();
-        ::esp_alloc::psram_allocator!($p.PSRAM, ::esp_hal::psram);
+        $crate::s3::boot_add_psram_global!($p, $psram_config);
         ::esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 43 * 1024);
         $crate::s3::reclaim_dcache_region();
+        $crate::s3::boot_psram_probe!();
+        $crate::s3::boot_rtos_tail!($p, $banner)
+    }};
+    ($p:ident, $banner:expr, $psram_config:expr, internal_first) => {{
+        ::esp_println::logger::init_logger_from_env();
+        // Heltec V4-R8: keep Octal PSRAM out of the global heap so boot/log allocs cannot spill into it.
+        ::esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 43 * 1024);
+        $crate::s3::reclaim_dcache_region();
+        $crate::s3::boot_add_psram_private!($p, $psram_config);
+        $crate::s3::boot_psram_probe!();
+        $crate::s3::boot_rtos_tail!($p, $banner)
+    }};
+}
+pub(crate) use boot_common;
+
+macro_rules! boot_add_psram_global {
+    ($p:ident, $psram_config:expr) => {{
+        let psram = ::esp_hal::psram::Psram::new($p.PSRAM, $psram_config);
+        let (start, size) = psram.raw_parts();
+        ::esp_println::println!("PSRAM mapped start={start:?} size={size} (global)");
+        // SAFETY: region comes from esp-hal's PSRAM mapper; added once at boot.
+        unsafe {
+            ::esp_alloc::HEAP.add_region(::esp_alloc::HeapRegion::new(
+                start,
+                size,
+                ::esp_alloc::MemoryCapability::External.into(),
+            ));
+        }
+        ::core::mem::forget(psram);
+    }};
+}
+pub(crate) use boot_add_psram_global;
+
+macro_rules! boot_add_psram_private {
+    ($p:ident, $psram_config:expr) => {{
+        let psram = ::esp_hal::psram::Psram::new($p.PSRAM, $psram_config);
+        let (start, size) = psram.raw_parts();
+        ::esp_println::println!("PSRAM mapped start={start:?} size={size} (private)");
+        // SAFETY: exclusive mapped window for PsramAlloc; not registered with esp_alloc.
+        unsafe { $crate::storage::init_private_psram_heap(start, size) };
+        ::core::mem::forget(psram);
+    }};
+}
+pub(crate) use boot_add_psram_private;
+
+macro_rules! boot_psram_probe {
+    () => {{
+        // Keep the smoke test tiny: Heltec's private PSRAM path is a bump allocator
+        // (deallocate is a no-op), and large probes would permanently consume the window
+        // until the pre-engine reinit.
+        let layout = ::core::alloc::Layout::from_size_align(4, 4).expect("u32 layout");
+        match ::allocator_api2::alloc::Allocator::allocate(&$crate::storage::PsramAlloc, layout) {
+            Ok(ptr) => {
+                // SAFETY: exclusive PsramAlloc allocation; write/read (leak is fine — bump).
+                unsafe {
+                    let p = ptr.cast::<u32>().as_ptr();
+                    p.write_volatile(0xA5A5_5A5A);
+                    let read = p.read_volatile();
+                    ::esp_println::println!("PSRAM probe ok read=0x{read:08X}");
+                }
+            }
+            Err(_) => ::esp_println::println!("PSRAM probe alloc failed"),
+        }
+    }};
+}
+pub(crate) use boot_psram_probe;
+
+macro_rules! boot_rtos_tail {
+    ($p:ident, $banner:expr) => {{
         let timg0 = ::esp_hal::timer::timg::TimerGroup::new($p.TIMG0);
         let sw_int =
             ::esp_hal::interrupt::software::SoftwareInterruptControl::new($p.SW_INTERRUPT);
@@ -505,7 +586,7 @@ macro_rules! boot_common {
         (sw_int.software_interrupt1, timebase, rtc)
     }};
 }
-pub(crate) use boot_common;
+pub(crate) use boot_rtos_tail;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(not(feature = "wifi-auto"), allow(dead_code))]

--- a/personal-hopspot/embedded/esp32/src/storage.rs
+++ b/personal-hopspot/embedded/esp32/src/storage.rs
@@ -1,10 +1,6 @@
 #[cfg(target_arch = "xtensa")]
 use allocator_api2::alloc::{AllocError, Allocator};
 #[cfg(target_arch = "xtensa")]
-use allocator_api2::boxed::Box;
-#[cfg(target_arch = "xtensa")]
-use allocator_api2::vec::Vec;
-#[cfg(target_arch = "xtensa")]
 use core::alloc::Layout;
 #[cfg(target_arch = "xtensa")]
 use core::ptr::NonNull;
@@ -39,33 +35,116 @@ const _: () = assert!(
     Esp32S3::<PsramAlloc>::MAX_COMPACTED_FLASH_JOURNAL_BYTES <= crate::persistence::S3_ARENA_BYTES
 );
 
-/// A `Default`-able allocator that places allocations in PSRAM. esp-alloc's own
-/// `ExternalMemory` targets the same region but is not `Default`, which the column recipes
-/// need to build themselves from `StorageLayout`; this thin ZST forwards to it.
+/// A `Default`-able allocator that places allocations in PSRAM.
+///
+/// On Heltec V4-R8, PSRAM is owned by a private bump allocator (see [`init_private_psram_heap`]) so
+/// ordinary boot/`log` allocs cannot share a freelist with engine construction. Other S3 boards
+/// keep PSRAM in `esp_alloc`'s global heap and this forwards to `ExternalMemory`.
 #[cfg(target_arch = "xtensa")]
 #[derive(Default, Clone, Copy)]
 pub struct PsramAlloc;
 
 #[cfg(target_arch = "xtensa")]
-pub fn allocate_lora_tx_queue() -> &'static mut [u8; personal_rns::lora::LORA_TX_QUEUE_BYTES] {
-    let mut storage = Vec::with_capacity_in(personal_rns::lora::LORA_TX_QUEUE_BYTES, PsramAlloc);
-    storage.resize(personal_rns::lora::LORA_TX_QUEUE_BYTES, 0);
-    Box::leak(storage.into_boxed_slice())
-        .try_into()
-        .expect("the LoRa transmit queue allocation has its requested length")
+use core::cell::RefCell;
+#[cfg(target_arch = "xtensa")]
+use core::sync::atomic::{AtomicUsize, Ordering};
+#[cfg(target_arch = "xtensa")]
+use critical_section::Mutex;
+
+#[cfg(target_arch = "xtensa")]
+struct PSRAMBump {
+    start: *mut u8,
+    size: usize,
+    offset: usize,
+}
+
+// SAFETY: start/offset are only touched under PRIVATE_PSRAM's critical section.
+#[cfg(target_arch = "xtensa")]
+unsafe impl Send for PSRAMBump {}
+
+#[cfg(target_arch = "xtensa")]
+static PRIVATE_PSRAM: Mutex<RefCell<Option<PSRAMBump>>> = Mutex::new(RefCell::new(None));
+#[cfg(target_arch = "xtensa")]
+static PRIVATE_PSRAM_START: AtomicUsize = AtomicUsize::new(0);
+#[cfg(target_arch = "xtensa")]
+static PRIVATE_PSRAM_SIZE: AtomicUsize = AtomicUsize::new(0);
+
+/// Install a PSRAM bump allocator used only by [`PsramAlloc`]. Do not also register the same
+/// range with `esp_alloc::HEAP`. Deallocate is a no-op (boot/engine construction is allocate-heavy);
+/// call [`reinit_private_psram_heap`] to reclaim.
+#[cfg(target_arch = "xtensa")]
+pub unsafe fn init_private_psram_heap(start: *mut u8, size: usize) {
+    PRIVATE_PSRAM_START.store(start as usize, Ordering::Relaxed);
+    PRIVATE_PSRAM_SIZE.store(size, Ordering::Relaxed);
+    critical_section::with(|cs| {
+        let mut slot = PRIVATE_PSRAM.borrow_ref_mut(cs);
+        assert!(slot.is_none(), "private PSRAM heap already initialized");
+        *slot = Some(PSRAMBump {
+            start,
+            size,
+            offset: 0,
+        });
+    });
+}
+
+/// Reset the private PSRAM bump cursor over the window from [`init_private_psram_heap`].
+/// No-op when this board uses the global `esp_alloc` external region instead.
+#[cfg(target_arch = "xtensa")]
+pub fn reinit_private_psram_heap() {
+    let start = PRIVATE_PSRAM_START.load(Ordering::Relaxed) as *mut u8;
+    let size = PRIVATE_PSRAM_SIZE.load(Ordering::Relaxed);
+    if start.is_null() || size == 0 {
+        return;
+    }
+    critical_section::with(|cs| {
+        *PRIVATE_PSRAM.borrow_ref_mut(cs) = None;
+    });
+    // SAFETY: same mapped window as init; exclusive to PsramAlloc.
+    unsafe { init_private_psram_heap(start, size) };
 }
 
 #[cfg(target_arch = "xtensa")]
-// SAFETY: Every operation is forwarded unchanged to esp-alloc's ExternalMemory allocator. This ZST
-// neither creates a second heap nor changes pointer/layout provenance.
+pub fn allocate_lora_tx_queue() -> &'static mut [u8; personal_rns::lora::LORA_TX_QUEUE_BYTES] {
+    // Keep this in static RAM like the T-Echo face. Allocating it from PSRAM via PsramAlloc hangs
+    // during Heltec V4-R8 bring-up when the private bump owns the Octal window.
+    use static_cell::ConstStaticCell;
+    static CELL: ConstStaticCell<[u8; personal_rns::lora::LORA_TX_QUEUE_BYTES]> =
+        ConstStaticCell::new([0; personal_rns::lora::LORA_TX_QUEUE_BYTES]);
+    CELL.take()
+}
+
+#[cfg(target_arch = "xtensa")]
+// SAFETY: Private bump returns exclusive slices from the mapped PSRAM window; ExternalMemory
+// fallback preserves esp-alloc's contract. Deallocate is a no-op for the bump path.
 unsafe impl Allocator for PsramAlloc {
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        esp_alloc::ExternalMemory.allocate(layout)
+        critical_section::with(|cs| {
+            if let Some(bump) = PRIVATE_PSRAM.borrow_ref_mut(cs).as_mut() {
+                let align = layout.align().max(8);
+                let aligned = (bump.offset + align - 1) & !(align - 1);
+                let end = aligned.checked_add(layout.size()).ok_or(AllocError)?;
+                if end > bump.size {
+                    return Err(AllocError);
+                }
+                // SAFETY: offset stays within the mapped window; bump is exclusive.
+                let ptr = unsafe { NonNull::new_unchecked(bump.start.add(aligned)) };
+                bump.offset = end;
+                Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))
+            } else {
+                esp_alloc::ExternalMemory.allocate(layout)
+            }
+        })
     }
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        // SAFETY: The Allocator contract requires callers to return the same pointer/layout pair
-        // produced by this allocator; forwarding preserves that contract and provenance.
-        unsafe { esp_alloc::ExternalMemory.deallocate(ptr, layout) }
+        critical_section::with(|cs| {
+            if PRIVATE_PSRAM.borrow_ref(cs).is_some() {
+                // Bump: intentional leak until reinit.
+                let _ = (ptr, layout);
+            } else {
+                // SAFETY: same pointer/layout as a prior ExternalMemory allocate.
+                unsafe { esp_alloc::ExternalMemory.deallocate(ptr, layout) };
+            }
+        })
     }
 }
 

--- a/personal-hopspot/embedded/esp32/src/storage.rs
+++ b/personal-hopspot/embedded/esp32/src/storage.rs
@@ -1,6 +1,10 @@
 #[cfg(target_arch = "xtensa")]
 use allocator_api2::alloc::{AllocError, Allocator};
 #[cfg(target_arch = "xtensa")]
+use allocator_api2::boxed::Box;
+#[cfg(target_arch = "xtensa")]
+use allocator_api2::vec::Vec;
+#[cfg(target_arch = "xtensa")]
 use core::alloc::Layout;
 #[cfg(target_arch = "xtensa")]
 use core::ptr::NonNull;
@@ -47,12 +51,10 @@ pub struct PsramAlloc;
 #[cfg(target_arch = "xtensa")]
 use core::cell::RefCell;
 #[cfg(target_arch = "xtensa")]
-use core::sync::atomic::{AtomicUsize, Ordering};
-#[cfg(target_arch = "xtensa")]
 use critical_section::Mutex;
 
 #[cfg(target_arch = "xtensa")]
-struct PSRAMBump {
+struct PsramBump {
     start: *mut u8,
     size: usize,
     offset: usize,
@@ -60,26 +62,20 @@ struct PSRAMBump {
 
 // SAFETY: start/offset are only touched under PRIVATE_PSRAM's critical section.
 #[cfg(target_arch = "xtensa")]
-unsafe impl Send for PSRAMBump {}
+unsafe impl Send for PsramBump {}
 
 #[cfg(target_arch = "xtensa")]
-static PRIVATE_PSRAM: Mutex<RefCell<Option<PSRAMBump>>> = Mutex::new(RefCell::new(None));
-#[cfg(target_arch = "xtensa")]
-static PRIVATE_PSRAM_START: AtomicUsize = AtomicUsize::new(0);
-#[cfg(target_arch = "xtensa")]
-static PRIVATE_PSRAM_SIZE: AtomicUsize = AtomicUsize::new(0);
+static PRIVATE_PSRAM: Mutex<RefCell<Option<PsramBump>>> = Mutex::new(RefCell::new(None));
 
 /// Install a PSRAM bump allocator used only by [`PsramAlloc`]. Do not also register the same
 /// range with `esp_alloc::HEAP`. Deallocate is a no-op (boot/engine construction is allocate-heavy);
 /// call [`reinit_private_psram_heap`] to reclaim.
 #[cfg(target_arch = "xtensa")]
 pub unsafe fn init_private_psram_heap(start: *mut u8, size: usize) {
-    PRIVATE_PSRAM_START.store(start as usize, Ordering::Relaxed);
-    PRIVATE_PSRAM_SIZE.store(size, Ordering::Relaxed);
     critical_section::with(|cs| {
         let mut slot = PRIVATE_PSRAM.borrow_ref_mut(cs);
         assert!(slot.is_none(), "private PSRAM heap already initialized");
-        *slot = Some(PSRAMBump {
+        *slot = Some(PsramBump {
             start,
             size,
             offset: 0,
@@ -91,26 +87,20 @@ pub unsafe fn init_private_psram_heap(start: *mut u8, size: usize) {
 /// No-op when this board uses the global `esp_alloc` external region instead.
 #[cfg(target_arch = "xtensa")]
 pub fn reinit_private_psram_heap() {
-    let start = PRIVATE_PSRAM_START.load(Ordering::Relaxed) as *mut u8;
-    let size = PRIVATE_PSRAM_SIZE.load(Ordering::Relaxed);
-    if start.is_null() || size == 0 {
-        return;
-    }
     critical_section::with(|cs| {
-        *PRIVATE_PSRAM.borrow_ref_mut(cs) = None;
+        if let Some(bump) = PRIVATE_PSRAM.borrow_ref_mut(cs).as_mut() {
+            bump.offset = 0;
+        }
     });
-    // SAFETY: same mapped window as init; exclusive to PsramAlloc.
-    unsafe { init_private_psram_heap(start, size) };
 }
 
 #[cfg(target_arch = "xtensa")]
 pub fn allocate_lora_tx_queue() -> &'static mut [u8; personal_rns::lora::LORA_TX_QUEUE_BYTES] {
-    // Keep this in static RAM like the T-Echo face. Allocating it from PSRAM via PsramAlloc hangs
-    // during Heltec V4-R8 bring-up when the private bump owns the Octal window.
-    use static_cell::ConstStaticCell;
-    static CELL: ConstStaticCell<[u8; personal_rns::lora::LORA_TX_QUEUE_BYTES]> =
-        ConstStaticCell::new([0; personal_rns::lora::LORA_TX_QUEUE_BYTES]);
-    CELL.take()
+    let mut storage = Vec::with_capacity_in(personal_rns::lora::LORA_TX_QUEUE_BYTES, PsramAlloc);
+    storage.resize(personal_rns::lora::LORA_TX_QUEUE_BYTES, 0);
+    Box::leak(storage.into_boxed_slice())
+        .try_into()
+        .expect("the LoRa transmit queue allocation has its requested length")
 }
 
 #[cfg(target_arch = "xtensa")]
@@ -118,8 +108,8 @@ pub fn allocate_lora_tx_queue() -> &'static mut [u8; personal_rns::lora::LORA_TX
 // fallback preserves esp-alloc's contract. Deallocate is a no-op for the bump path.
 unsafe impl Allocator for PsramAlloc {
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        critical_section::with(|cs| {
-            if let Some(bump) = PRIVATE_PSRAM.borrow_ref_mut(cs).as_mut() {
+        let private_allocation = critical_section::with(|cs| {
+            PRIVATE_PSRAM.borrow_ref_mut(cs).as_mut().map(|bump| {
                 let align = layout.align().max(8);
                 let aligned = (bump.offset + align - 1) & !(align - 1);
                 let end = aligned.checked_add(layout.size()).ok_or(AllocError)?;
@@ -130,21 +120,19 @@ unsafe impl Allocator for PsramAlloc {
                 let ptr = unsafe { NonNull::new_unchecked(bump.start.add(aligned)) };
                 bump.offset = end;
                 Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))
-            } else {
-                esp_alloc::ExternalMemory.allocate(layout)
-            }
-        })
+            })
+        });
+        private_allocation.unwrap_or_else(|| esp_alloc::ExternalMemory.allocate(layout))
     }
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        critical_section::with(|cs| {
-            if PRIVATE_PSRAM.borrow_ref(cs).is_some() {
-                // Bump: intentional leak until reinit.
-                let _ = (ptr, layout);
-            } else {
-                // SAFETY: same pointer/layout as a prior ExternalMemory allocate.
-                unsafe { esp_alloc::ExternalMemory.deallocate(ptr, layout) };
-            }
-        })
+        let private = critical_section::with(|cs| PRIVATE_PSRAM.borrow_ref(cs).is_some());
+        if private {
+            // Bump: intentional leak until reinit.
+            let _ = (ptr, layout);
+        } else {
+            // SAFETY: same pointer/layout as a prior ExternalMemory allocate.
+            unsafe { esp_alloc::ExternalMemory.deallocate(ptr, layout) };
+        }
     }
 }
 

--- a/personal-hopspot/flasher/src/build.rs
+++ b/personal-hopspot/flasher/src/build.rs
@@ -785,6 +785,7 @@ fn report_sparse_size(
 fn sparse_size_gate(board_slug: &str) -> Option<(u64, u64)> {
     match board_slug {
         "heltec-v4" => Some((7_643_152, 3_057_260)),
+        "heltec-v4-r8" => Some((7_643_152, 3_057_260)),
         "t-beam-supreme" => Some((7_639_296, 3_055_718)),
         _ => None,
     }
@@ -900,7 +901,7 @@ mod tests {
     #[test]
     fn all_catalog_boards_have_a_build_recipe() -> Result<(), Box<dyn std::error::Error>> {
         let catalog = prns_flash_manifest::board_catalog()?;
-        assert_eq!(catalog.boards.len(), 4);
+        assert_eq!(catalog.boards.len(), 5);
         assert!(catalog.boards.iter().all(|board| {
             matches!(
                 (&board.transport, &board.build),
@@ -914,6 +915,10 @@ mod tests {
     #[test]
     fn s3_size_gates_are_board_specific_and_at_least_sixty_percent() {
         assert_eq!(sparse_size_gate("heltec-v4"), Some((7_643_152, 3_057_260)));
+        assert_eq!(
+            sparse_size_gate("heltec-v4-r8"),
+            Some((7_643_152, 3_057_260))
+        );
         assert_eq!(
             sparse_size_gate("t-beam-supreme"),
             Some((7_639_296, 3_055_718))

--- a/personal-hopspot/flasher/src/cache/mod.rs
+++ b/personal-hopspot/flasher/src/cache/mod.rs
@@ -1021,7 +1021,7 @@ mod tests {
 
         assert_eq!(imported.version, "0.2.6");
         assert_eq!(imported.channel, "preview");
-        assert_eq!(imported.artifact_count, 10);
+        assert_eq!(imported.artifact_count, 13);
         assert!(cache
             .path()
             .join("releases/0.2.6/heltec-v4/application.bin")

--- a/personal-hopspot/flasher/src/cli.rs
+++ b/personal-hopspot/flasher/src/cli.rs
@@ -108,7 +108,7 @@ pub(crate) enum CommandMode {
         #[arg(long, value_name = "VERSION", hide = true)]
         developer_version: Option<String>,
     },
-    /// Assemble manifest v2 after all four developer artifacts have been built.
+    /// Assemble manifest v2 after all shipping developer artifacts have been built.
     #[command(hide = true)]
     AssembleManifest {
         #[arg(long, value_name = "DIR")]

--- a/personal-hopspot/flasher/src/main.rs
+++ b/personal-hopspot/flasher/src/main.rs
@@ -690,7 +690,7 @@ fn print_board(board: &BoardCatalogEntry) {
     ui::print_key_value("interfaces", &board.interfaces.join(", "));
     if board.slug == "heltec-v4" || board.slug == "heltec-v4-r8" {
         ui::print_note(
-            "Heltec V4 S3R2 and S3R8 share the same chip and 16MB flash; pick the matching firmware (wrong pinout can kill Octal PSRAM).",
+            "Heltec V4 S3R2 and S3R8 share the same chip and 16MB flash; pick the matching firmware because the S3R2 pinout prevents Octal PSRAM from operating on the S3R8.",
         );
     }
 }

--- a/personal-hopspot/flasher/src/main.rs
+++ b/personal-hopspot/flasher/src/main.rs
@@ -688,9 +688,9 @@ fn print_board(board: &BoardCatalogEntry) {
     ui::print_key_value("silicon", &board.silicon);
     ui::print_key_value("transport", transport_label(board.transport));
     ui::print_key_value("interfaces", &board.interfaces.join(", "));
-    if board.slug == "heltec-v4" || board.slug == "t-beam-supreme" {
+    if board.slug == "heltec-v4" || board.slug == "heltec-v4-r8" {
         ui::print_note(
-            "This board shares ESP32-S3 silicon with another target; its exact model cannot be detected automatically.",
+            "Heltec V4 S3R2 and S3R8 share the same chip and 16MB flash; pick the matching firmware (wrong pinout can kill Octal PSRAM).",
         );
     }
 }
@@ -745,7 +745,7 @@ mod doctor_tests {
             check: Some(DoctorCheck::EspSerial {
                 port: "fake-port".to_string(),
                 detected_chip: "esp32s3".to_string(),
-                flash_size: 8 * 1024 * 1024,
+                flash_size: 16 * 1024 * 1024,
                 same_chip_board_ambiguity: true,
                 note: Some("cannot distinguish these two board models".to_string()),
             }),
@@ -753,16 +753,25 @@ mod doctor_tests {
         .expect("doctor output serializes");
         assert_eq!(
             encoded,
-            r#"{"schema":1,"event":"doctor","phase":"complete","board":"heltec-v4","requested_port":"fake-port","serial_ports":[{"name":"fake-port","kind":"usb"}],"techo_mounts":[],"check":{"transport":"esp-serial","port":"fake-port","detected_chip":"esp32s3","flash_size":8388608,"same_chip_board_ambiguity":true,"note":"cannot distinguish these two board models"}}"#
+            r#"{"schema":1,"event":"doctor","phase":"complete","board":"heltec-v4","requested_port":"fake-port","serial_ports":[{"name":"fake-port","kind":"usb"}],"techo_mounts":[],"check":{"transport":"esp-serial","port":"fake-port","detected_chip":"esp32s3","flash_size":16777216,"same_chip_board_ambiguity":true,"note":"cannot distinguish these two board models"}}"#
         );
     }
 
     #[test]
     fn catalog_capacities_distinguish_shipping_esp_identities() {
         let catalog = board_catalog().expect("catalog");
-        assert!(
+        assert_eq!(
             ambiguous_esp_identity_peer(&catalog, catalog.board("heltec-v4").expect("Heltec"))
-                .is_none()
+                .map(|board| board.slug.as_str()),
+            Some("heltec-v4-r8")
+        );
+        assert_eq!(
+            ambiguous_esp_identity_peer(
+                &catalog,
+                catalog.board("heltec-v4-r8").expect("Heltec R8")
+            )
+            .map(|board| board.slug.as_str()),
+            Some("heltec-v4")
         );
         assert!(ambiguous_esp_identity_peer(
             &catalog,

--- a/prns-flash-manifest/src/catalog.rs
+++ b/prns-flash-manifest/src/catalog.rs
@@ -8,7 +8,13 @@ use crate::{
 };
 
 const CATALOG_JSON: &str = include_str!("../../release/flash/boards.json");
-const SHIPPING_BOARD_SLUGS: [&str; 4] = ["heltec-v4", "t-beam-supreme", "xiao-esp32-c6", "t-echo"];
+const SHIPPING_BOARD_SLUGS: [&str; 5] = [
+    "heltec-v4",
+    "heltec-v4-r8",
+    "t-beam-supreme",
+    "xiao-esp32-c6",
+    "t-echo",
+];
 
 /// Complete, versioned catalog of publicly supported boards.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -383,7 +389,13 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(
             slugs,
-            ["heltec-v4", "t-beam-supreme", "xiao-esp32-c6", "t-echo"]
+            [
+                "heltec-v4",
+                "heltec-v4-r8",
+                "t-beam-supreme",
+                "xiao-esp32-c6",
+                "t-echo"
+            ]
         );
         Ok(())
     }
@@ -397,7 +409,7 @@ mod tests {
             .filter(|board| board.source_archive_capable)
             .map(|board| board.slug.as_str())
             .collect::<Vec<_>>();
-        assert_eq!(capable, ["heltec-v4", "t-beam-supreme"]);
+        assert_eq!(capable, ["heltec-v4", "heltec-v4-r8", "t-beam-supreme"]);
         Ok(())
     }
 
@@ -427,6 +439,11 @@ mod tests {
                     Some(("partitions-hopspot-16mb.csv", "16mb"))
                 ),
                 (
+                    "heltec-v4-r8",
+                    Some(16_777_216),
+                    Some(("partitions-hopspot-16mb.csv", "16mb"))
+                ),
+                (
                     "t-beam-supreme",
                     Some(8_388_608),
                     Some(("partitions-hopspot-8mb.csv", "8mb"))
@@ -452,7 +469,7 @@ mod tests {
             .filter(|board| board.supports_tcp_client_provisioning())
             .map(|board| board.slug.as_str())
             .collect::<Vec<_>>();
-        assert_eq!(capable, ["heltec-v4", "t-beam-supreme"]);
+        assert_eq!(capable, ["heltec-v4", "heltec-v4-r8", "t-beam-supreme"]);
         Ok(())
     }
 

--- a/prns-flash-manifest/src/manifest.rs
+++ b/prns-flash-manifest/src/manifest.rs
@@ -540,7 +540,7 @@ mod tests {
         let validated = ValidatedFlashManifest::from_json(&encoded, &catalog)?;
         assert_eq!(validated.schema(), FLASH_MANIFEST_SCHEMA);
         assert_eq!(validated.release().version().as_str(), "0.2.6");
-        assert_eq!(validated.targets().len(), 4);
+        assert_eq!(validated.targets().len(), 5);
         assert_eq!(
             validated
                 .targets()
@@ -555,7 +555,7 @@ mod tests {
                 .iter()
                 .filter(|target| matches!(target, ReleaseTarget::EspSerial(_)))
                 .count(),
-            3
+            4
         );
         let t_echo = validated
             .targets()

--- a/release/acceptance/roster-template.json
+++ b/release/acceptance/roster-template.json
@@ -11,7 +11,10 @@
       "surface": "web",
       "os": "linux",
       "architecture": "x86_64",
-      "browser": {"name": "chrome", "channel": "stable"},
+      "browser": {
+        "name": "chrome",
+        "channel": "stable"
+      },
       "tester": "REPLACE_WITH_PUBLIC_TESTER_IDENTITY",
       "cables_ready": true,
       "device_permissions_ready": true,
@@ -28,11 +31,38 @@
       "recovery_instructions_reviewed": true
     },
     {
+      "board": "heltec-v4-r8",
+      "surface": "web",
+      "os": "linux",
+      "architecture": "x86_64",
+      "browser": {
+        "name": "chrome",
+        "channel": "stable"
+      },
+      "tester": "REPLACE_WITH_PUBLIC_TESTER_IDENTITY",
+      "cables_ready": true,
+      "device_permissions_ready": true,
+      "recovery_instructions_reviewed": true
+    },
+    {
+      "board": "heltec-v4-r8",
+      "surface": "cli",
+      "os": "linux",
+      "architecture": "x86_64",
+      "tester": "REPLACE_WITH_PUBLIC_TESTER_IDENTITY",
+      "cables_ready": true,
+      "device_permissions_ready": true,
+      "recovery_instructions_reviewed": true
+    },
+    {
       "board": "t-beam-supreme",
       "surface": "web",
       "os": "macos",
       "architecture": "aarch64",
-      "browser": {"name": "chrome", "channel": "stable"},
+      "browser": {
+        "name": "chrome",
+        "channel": "stable"
+      },
       "tester": "REPLACE_WITH_PUBLIC_TESTER_IDENTITY",
       "cables_ready": true,
       "device_permissions_ready": true,
@@ -53,7 +83,10 @@
       "surface": "web",
       "os": "windows",
       "architecture": "x86_64",
-      "browser": {"name": "edge", "channel": "stable"},
+      "browser": {
+        "name": "edge",
+        "channel": "stable"
+      },
       "tester": "REPLACE_WITH_PUBLIC_TESTER_IDENTITY",
       "cables_ready": true,
       "device_permissions_ready": true,
@@ -74,7 +107,10 @@
       "surface": "web",
       "os": "macos",
       "architecture": "x86_64",
-      "browser": {"name": "chrome", "channel": "stable"},
+      "browser": {
+        "name": "chrome",
+        "channel": "stable"
+      },
       "tester": "REPLACE_WITH_PUBLIC_TESTER_IDENTITY",
       "cables_ready": true,
       "device_permissions_ready": true,
@@ -93,28 +129,40 @@
   ],
   "fallback_assignments": [
     {
-      "browser": {"name": "firefox", "channel": "stable"},
+      "browser": {
+        "name": "firefox",
+        "channel": "stable"
+      },
       "os": "linux",
       "architecture": "x86_64",
       "tester": "REPLACE_WITH_PUBLIC_TESTER_IDENTITY",
       "browser_ready": true
     },
     {
-      "browser": {"name": "firefox", "channel": "stable"},
+      "browser": {
+        "name": "firefox",
+        "channel": "stable"
+      },
       "os": "macos",
       "architecture": "x86_64",
       "tester": "REPLACE_WITH_PUBLIC_TESTER_IDENTITY",
       "browser_ready": true
     },
     {
-      "browser": {"name": "firefox", "channel": "stable"},
+      "browser": {
+        "name": "firefox",
+        "channel": "stable"
+      },
       "os": "windows",
       "architecture": "x86_64",
       "tester": "REPLACE_WITH_PUBLIC_TESTER_IDENTITY",
       "browser_ready": true
     },
     {
-      "browser": {"name": "safari", "channel": "stable"},
+      "browser": {
+        "name": "safari",
+        "channel": "stable"
+      },
       "os": "macos",
       "architecture": "aarch64",
       "tester": "REPLACE_WITH_PUBLIC_TESTER_IDENTITY",

--- a/release/acceptance/roster-template.json
+++ b/release/acceptance/roster-template.json
@@ -11,10 +11,7 @@
       "surface": "web",
       "os": "linux",
       "architecture": "x86_64",
-      "browser": {
-        "name": "chrome",
-        "channel": "stable"
-      },
+      "browser": {"name": "chrome", "channel": "stable"},
       "tester": "REPLACE_WITH_PUBLIC_TESTER_IDENTITY",
       "cables_ready": true,
       "device_permissions_ready": true,
@@ -35,10 +32,7 @@
       "surface": "web",
       "os": "linux",
       "architecture": "x86_64",
-      "browser": {
-        "name": "chrome",
-        "channel": "stable"
-      },
+      "browser": {"name": "chrome", "channel": "stable"},
       "tester": "REPLACE_WITH_PUBLIC_TESTER_IDENTITY",
       "cables_ready": true,
       "device_permissions_ready": true,
@@ -59,10 +53,7 @@
       "surface": "web",
       "os": "macos",
       "architecture": "aarch64",
-      "browser": {
-        "name": "chrome",
-        "channel": "stable"
-      },
+      "browser": {"name": "chrome", "channel": "stable"},
       "tester": "REPLACE_WITH_PUBLIC_TESTER_IDENTITY",
       "cables_ready": true,
       "device_permissions_ready": true,
@@ -83,10 +74,7 @@
       "surface": "web",
       "os": "windows",
       "architecture": "x86_64",
-      "browser": {
-        "name": "edge",
-        "channel": "stable"
-      },
+      "browser": {"name": "edge", "channel": "stable"},
       "tester": "REPLACE_WITH_PUBLIC_TESTER_IDENTITY",
       "cables_ready": true,
       "device_permissions_ready": true,
@@ -107,10 +95,7 @@
       "surface": "web",
       "os": "macos",
       "architecture": "x86_64",
-      "browser": {
-        "name": "chrome",
-        "channel": "stable"
-      },
+      "browser": {"name": "chrome", "channel": "stable"},
       "tester": "REPLACE_WITH_PUBLIC_TESTER_IDENTITY",
       "cables_ready": true,
       "device_permissions_ready": true,
@@ -129,40 +114,28 @@
   ],
   "fallback_assignments": [
     {
-      "browser": {
-        "name": "firefox",
-        "channel": "stable"
-      },
+      "browser": {"name": "firefox", "channel": "stable"},
       "os": "linux",
       "architecture": "x86_64",
       "tester": "REPLACE_WITH_PUBLIC_TESTER_IDENTITY",
       "browser_ready": true
     },
     {
-      "browser": {
-        "name": "firefox",
-        "channel": "stable"
-      },
+      "browser": {"name": "firefox", "channel": "stable"},
       "os": "macos",
       "architecture": "x86_64",
       "tester": "REPLACE_WITH_PUBLIC_TESTER_IDENTITY",
       "browser_ready": true
     },
     {
-      "browser": {
-        "name": "firefox",
-        "channel": "stable"
-      },
+      "browser": {"name": "firefox", "channel": "stable"},
       "os": "windows",
       "architecture": "x86_64",
       "tester": "REPLACE_WITH_PUBLIC_TESTER_IDENTITY",
       "browser_ready": true
     },
     {
-      "browser": {
-        "name": "safari",
-        "channel": "stable"
-      },
+      "browser": {"name": "safari", "channel": "stable"},
       "os": "macos",
       "architecture": "aarch64",
       "tester": "REPLACE_WITH_PUBLIC_TESTER_IDENTITY",

--- a/release/flash/boards.json
+++ b/release/flash/boards.json
@@ -3,8 +3,8 @@
   "boards": [
     {
       "slug": "heltec-v4",
-      "display_name": "Heltec LoRa 32 V4",
-      "silicon": "ESP32-S3 + SX1262",
+      "display_name": "Heltec LoRa 32 V4 (S3R2)",
+      "silicon": "ESP32-S3R2 + SX1262 (Quad PSRAM)",
       "interfaces": ["Wi-Fi Auto", "TCP Client", "BLE Auto", "LoRa", "ESP-NOW", "USB Auto"],
       "icon": "espressif",
       "transport": "esp-serial",
@@ -33,6 +33,45 @@
         "partition_table": "partitions-hopspot-16mb.csv",
         "package": "hopspot-heltec-v4",
         "binary": "hopspot-heltec-v4",
+        "flash_size_label": "16mb",
+        "flash_mode": "dio",
+        "flash_frequency": "40m",
+        "before_reset": "usb-reset",
+        "after_reset": "watchdog-reset"
+      }
+    },
+    {
+      "slug": "heltec-v4-r8",
+      "display_name": "Heltec LoRa 32 V4 (S3R8)",
+      "silicon": "ESP32-S3R8 + SX1262 (Octal PSRAM)",
+      "interfaces": ["Wi-Fi Auto", "TCP Client", "BLE Auto", "LoRa", "ESP-NOW", "USB Auto"],
+      "icon": "espressif",
+      "transport": "esp-serial",
+      "expected_chip": "esp32s3",
+      "flash_size": 16777216,
+      "source_archive_capable": true,
+      "preparation_profile": "esp-usb-boot",
+      "provisioning": {
+        "format": "HSPCFG1",
+        "version": 1,
+        "offset": 53248,
+        "size": 4096,
+        "ssid_max_bytes": 32,
+        "password_max_bytes": 64,
+        "tcp_client": {
+          "target_format": "ipv4-or-dns",
+          "max_clients": 1,
+          "default_port": 4242,
+          "hostname_max_bytes": 253
+        }
+      },
+      "build": {
+        "kind": "esp",
+        "chip": "esp32s3",
+        "rust_target": "xtensa-esp32s3-none-elf",
+        "partition_table": "partitions-hopspot-16mb.csv",
+        "package": "hopspot-heltec-v4-r8",
+        "binary": "hopspot-heltec-v4-r8",
         "flash_size_label": "16mb",
         "flash_mode": "dio",
         "flash_frequency": "40m",

--- a/tools/device/hopspot-dev-flasher.py
+++ b/tools/device/hopspot-dev-flasher.py
@@ -381,7 +381,7 @@ def build_firmware(
     selection: Selection,
     key_id: str,
 ) -> Path:
-    needs_embedded = any(board in {"heltec-v4", "t-beam-supreme"} for board in selection.boards)
+    needs_embedded = any(board in {"heltec-v4", "heltec-v4-r8", "t-beam-supreme"} for board in selection.boards)
     if needs_embedded:
         build_embedded_site(identity)
     environment = clean_build_environment()

--- a/tools/release/build-flash-artifact.sh
+++ b/tools/release/build-flash-artifact.sh
@@ -7,13 +7,17 @@ OUT_ROOT="${2:-$ROOT/target/flash-artifacts}"
 
 usage() {
     echo "usage: $0 <board-slug> [out-root]" >&2
-    echo "supported board-slugs: heltec-v4, t-beam-supreme, xiao-esp32-c6, t-echo" >&2
+    echo "supported board-slugs: heltec-v4, heltec-v4-r8, t-beam-supreme, xiao-esp32-c6, t-echo" >&2
 }
 
 case "$TARGET" in
     heltec-v4)
         cd "$ROOT"
         cargo run --locked -p hopspot-flash -- build heltec-v4 --out-root "$OUT_ROOT"
+        ;;
+    heltec-v4-r8)
+        cd "$ROOT"
+        cargo run --locked -p hopspot-flash -- build heltec-v4-r8 --out-root "$OUT_ROOT"
         ;;
     t-beam-supreme)
         cd "$ROOT"

--- a/tools/release/build-flasher-candidate.sh
+++ b/tools/release/build-flasher-candidate.sh
@@ -177,7 +177,7 @@ if find "$embedded_dist" \( -path '*/firmware/*' -o -path '*/assets/flasher/*' \
 fi
 
 cd "$root"
-for board in heltec-v4 t-beam-supreme xiao-esp32-c6 t-echo; do
+for board in heltec-v4 heltec-v4-r8 t-beam-supreme xiao-esp32-c6 t-echo; do
     PRNS_EMBEDDED_SITE_READY=1 cargo run --locked -p hopspot-flash -- build "$board" --out-root "$candidate"
 done
 cargo run --locked -p hopspot-flash -- assemble-manifest \

--- a/tools/release/finalize-flasher-candidate.py
+++ b/tools/release/finalize-flasher-candidate.py
@@ -10,6 +10,7 @@ from pathlib import Path, PurePosixPath
 import shutil
 import sys
 
+from flasher_sparse_sizes import SHIPPING_BOARDS
 from flasher_sparse_sizes import build_report as build_sparse_size_report
 from flasher_sparse_sizes import render_summary as render_sparse_size_summary
 from flasher_website_history import allowed_historical_signatures
@@ -78,8 +79,14 @@ def validate_manifest(candidate: Path, version: str, channel: str, commit: str, 
     pinned_key_id = public_key_line.removeprefix(prefix).strip()
     if not public_key_line.startswith(prefix) or pinned_key_id.upper() != key_id.upper():
         raise ValueError("candidate signing key ID disagrees with its pinned Minisign public key")
-    if len(manifest.get("targets", [])) != 4:
-        raise ValueError("candidate manifest does not contain all four shipping targets")
+    targets = manifest.get("targets", [])
+    boards = {
+        target.get("board_slug")
+        for target in targets
+        if isinstance(target, dict) and isinstance(target.get("board_slug"), str)
+    }
+    if len(targets) != len(SHIPPING_BOARDS) or boards != SHIPPING_BOARDS:
+        raise ValueError("candidate manifest does not contain exactly the shipping board set")
     return manifest
 
 

--- a/tools/release/flasher_acceptance_contract.py
+++ b/tools/release/flasher_acceptance_contract.py
@@ -11,6 +11,7 @@ import re
 
 SHIPPING_BOARDS = (
     "heltec-v4",
+    "heltec-v4-r8",
     "t-beam-supreme",
     "xiao-esp32-c6",
     "t-echo",
@@ -195,7 +196,7 @@ def scaffold(
         for target in raw_targets
     }
     if len(targets) != len(raw_targets) or set(targets) != set(SHIPPING_BOARDS):
-        raise ValueError("manifest must contain exactly the four shipping boards")
+        raise ValueError("manifest must contain exactly the shipping board set")
     if any(
         not isinstance(target.get("display_name"), str)
         or not target["display_name"].strip()

--- a/tools/release/flasher_sparse_sizes.py
+++ b/tools/release/flasher_sparse_sizes.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 
 MERGED_BASELINES = {
     "heltec-v4": 7_643_152,
+    "heltec-v4-r8": 7_643_152,
     "t-beam-supreme": 7_639_296,
     "xiao-esp32-c6": 1_309_056,
 }
 SPARSE_BASELINES = {
-    board: MERGED_BASELINES[board] for board in ("heltec-v4", "t-beam-supreme")
+    board: MERGED_BASELINES[board]
+    for board in ("heltec-v4", "heltec-v4-r8", "t-beam-supreme")
 }
-SHIPPING_BOARDS = {"heltec-v4", "t-beam-supreme", "xiao-esp32-c6", "t-echo"}
+SHIPPING_BOARDS = {"heltec-v4", "heltec-v4-r8", "t-beam-supreme", "xiao-esp32-c6", "t-echo"}
 REQUIRED_REDUCTION_PERCENT = 60
 
 

--- a/tools/release/validate-flasher-acceptance.py
+++ b/tools/release/validate-flasher-acceptance.py
@@ -344,7 +344,7 @@ def manifest_targets(manifest: dict, errors: list[str]) -> dict[str, dict]:
             errors.append(f"candidate manifest duplicates board {board}")
         targets[board] = target
     if set(targets) != set(SHIPPING_BOARDS):
-        errors.append("candidate manifest does not contain exactly the four shipping boards")
+        errors.append("candidate manifest does not contain exactly the shipping board set")
     return targets
 
 

--- a/tools/release/validate-unsigned-flasher-candidate.py
+++ b/tools/release/validate-unsigned-flasher-candidate.py
@@ -26,7 +26,8 @@ CLI_TARGETS = {
     "aarch64-unknown-linux-gnu": ".tar.gz",
     "x86_64-pc-windows-msvc": ".zip",
 }
-SHIPPING_BOARDS = {"heltec-v4", "t-beam-supreme", "xiao-esp32-c6", "t-echo"}
+SHIPPING_BOARDS = {"heltec-v4", "heltec-v4-r8", "t-beam-supreme", "xiao-esp32-c6", "t-echo"}
+S3_SOURCE_BOARDS = {"heltec-v4", "heltec-v4-r8", "t-beam-supreme"}
 ESP_PARTITION_ENTRY = struct.Struct("<HBBII16sI")
 ESP_PARTITION_MAGIC = 0x50AA
 ESP_PARTITION_MD5_MAGIC = 0xEBEB
@@ -375,7 +376,7 @@ def verify(arguments: argparse.Namespace) -> dict:
         raise ValueError("candidate manifest targets must be an array")
     boards = [target.get("board_slug") for target in targets if isinstance(target, dict)]
     if len(boards) != len(SHIPPING_BOARDS) or set(boards) != SHIPPING_BOARDS:
-        raise ValueError("candidate manifest does not contain exactly the four shipping boards")
+        raise ValueError("candidate manifest does not contain exactly the shipping board set")
     immutable_root = root / "website" / "releases" / version
     for target in targets:
         if not isinstance(target, dict):
@@ -388,7 +389,7 @@ def verify(arguments: argparse.Namespace) -> dict:
         if board_slug in {"xiao-esp32-c6", "t-echo"} and source is not None:
             raise ValueError(f"constrained target {board_slug} must not carry source metadata")
         if (
-            board_slug in {"heltec-v4", "t-beam-supreme"}
+            board_slug in S3_SOURCE_BOARDS
             and source is not None
             and source != source_identity
         ):
@@ -473,7 +474,7 @@ def verify(arguments: argparse.Namespace) -> dict:
                     raise ValueError(
                         f"target {board_slug} source page does not carry the candidate identity"
                     )
-        elif board_slug in {"heltec-v4", "t-beam-supreme"}:
+        elif board_slug in S3_SOURCE_BOARDS:
             application_part = next(
                 (
                     part
@@ -509,12 +510,12 @@ def verify(arguments: argparse.Namespace) -> dict:
         raise ValueError("source capability metadata has a malformed board set")
     target_by_board = {target["board_slug"]: target for target in targets}
     for board_slug, capability in capability_by_board.items():
-        expected_nominal = board_slug in {"heltec-v4", "t-beam-supreme"}
+        expected_nominal = board_slug in S3_SOURCE_BOARDS
         if capability.get("nominally_capable") is not expected_nominal:
             raise ValueError(
                 f"{board_slug} source capability metadata disagrees with the board catalog"
             )
-    for board_slug in {"heltec-v4", "t-beam-supreme"}:
+    for board_slug in S3_SOURCE_BOARDS:
         capability = capability_by_board[board_slug]
         status = capability.get("status")
         if status == "serving":

--- a/tools/repo/generate-third-party-notices.py
+++ b/tools/repo/generate-third-party-notices.py
@@ -48,6 +48,11 @@ GRAPHS = (
         "xtensa-esp32s3-none-elf",
     ),
     (
+        "ESP32-S3 Heltec R8",
+        "personal-hopspot/embedded/esp32/boards/heltec-v4-r8/Cargo.toml",
+        "xtensa-esp32s3-none-elf",
+    ),
+    (
         "ESP32-S3 T-Beam",
         "personal-hopspot/embedded/esp32/boards/t-beam-supreme/Cargo.toml",
         "xtensa-esp32s3-none-elf",

--- a/tools/tests/test_create_flasher_acceptance.py
+++ b/tools/tests/test_create_flasher_acceptance.py
@@ -34,6 +34,8 @@ def complete_roster() -> dict:
     hosts = {
         ("heltec-v4", "cli"): ("linux", "x86_64"),
         ("heltec-v4", "web"): ("linux", "x86_64"),
+        ("heltec-v4-r8", "cli"): ("linux", "x86_64"),
+        ("heltec-v4-r8", "web"): ("linux", "x86_64"),
         ("t-beam-supreme", "cli"): ("macos", "aarch64"),
         ("t-beam-supreme", "web"): ("macos", "aarch64"),
         ("xiao-esp32-c6", "cli"): ("windows", "x86_64"),
@@ -95,7 +97,8 @@ def complete_roster() -> dict:
 
 def manifest() -> dict:
     boards = (
-        ("heltec-v4", "Heltec LoRa 32 V4", "esp-serial", "esp32s3", True),
+        ("heltec-v4", "Heltec LoRa 32 V4 (S3R2)", "esp-serial", "esp32s3", True),
+        ("heltec-v4-r8", "Heltec LoRa 32 V4 (S3R8)", "esp-serial", "esp32s3", True),
         ("t-beam-supreme", "LilyGO T-Beam Supreme", "esp-serial", "esp32s3", True),
         ("xiao-esp32-c6", "Seeed XIAO ESP32-C6", "esp-serial", "esp32c6", False),
         ("t-echo", "LilyGO T-Echo", "uf2-mass-storage", None, False),
@@ -163,7 +166,7 @@ class AcceptanceScaffoldTests(unittest.TestCase):
         )
         self.assertEqual(candidate["prerelease_published_at"], PUBLISHED_AT)
         self.assertEqual(record["schema"], 3)
-        self.assertEqual(len(record["runs"]), 8)
+        self.assertEqual(len(record["runs"]), 10)
         self.assertEqual(len(record["browser_fallbacks"]), 4)
         self.assertEqual(len(record["installation_smoke"]), 5)
         self.assertTrue(

--- a/tools/tests/test_flasher_release_custody.py
+++ b/tools/tests/test_flasher_release_custody.py
@@ -185,13 +185,13 @@ class CandidateFixture:
         targets = []
         self.firmware_paths = []
         for index, board in enumerate(
-            ("heltec-v4", "t-beam-supreme", "xiao-esp32-c6", "t-echo"), start=1
+            ("heltec-v4", "heltec-v4-r8", "t-beam-supreme", "xiao-esp32-c6", "t-echo"), start=1
         ):
             relative = f"firmware/{board}/application.bin"
             artifact = root / relative
             artifact.parent.mkdir(parents=True, exist_ok=True)
             payload = f"firmware-{index}-{board}".encode()
-            if board in {"heltec-v4", "t-beam-supreme"}:
+            if board in {"heltec-v4", "heltec-v4-r8", "t-beam-supreme"}:
                 payload = (
                     source_archive
                     + b" "
@@ -217,7 +217,7 @@ class CandidateFixture:
             if board != "t-echo":
                 application_part["offset"] = 0x10000
             parts = [application_part]
-            if board in {"heltec-v4", "t-beam-supreme"}:
+            if board in {"heltec-v4", "heltec-v4-r8", "t-beam-supreme"}:
                 partition_relative = f"firmware/{board}/partition-table.bin"
                 partition_artifact = root / partition_relative
                 partition_artifact.write_bytes(esp_partition_table(0xFF0000))
@@ -244,7 +244,7 @@ class CandidateFixture:
                 ),
                 "parts": parts,
             }
-            if board in {"heltec-v4", "t-beam-supreme"}:
+            if board in {"heltec-v4", "heltec-v4-r8", "t-beam-supreme"}:
                 target["source"] = source_identity
             targets.append(target)
         write_json(
@@ -258,25 +258,26 @@ class CandidateFixture:
                         "schema": 1,
                         "board_slug": board,
                         "nominally_capable": board
-                        in {"heltec-v4", "t-beam-supreme"},
+                        in {"heltec-v4", "heltec-v4-r8", "t-beam-supreme"},
                         "status": (
                             "serving"
-                            if board in {"heltec-v4", "t-beam-supreme"}
+                            if board in {"heltec-v4", "heltec-v4-r8", "t-beam-supreme"}
                             else "absent"
                         ),
                         "source": (
                             source_identity
-                            if board in {"heltec-v4", "t-beam-supreme"}
+                            if board in {"heltec-v4", "heltec-v4-r8", "t-beam-supreme"}
                             else None
                         ),
                         "reserve_bytes": (
                             SOURCE_APPLICATION_HEADROOM
-                            if board in {"heltec-v4", "t-beam-supreme"}
+                            if board in {"heltec-v4", "heltec-v4-r8", "t-beam-supreme"}
                             else None
                         ),
                     }
                     for board in (
                         "heltec-v4",
+                        "heltec-v4-r8",
                         "t-beam-supreme",
                         "xiao-esp32-c6",
                         "t-echo",
@@ -379,6 +380,8 @@ class CandidateFixture:
         physical_hosts = {
             ("heltec-v4", "cli"): ("linux", "x86_64"),
             ("heltec-v4", "web"): ("linux", "x86_64"),
+            ("heltec-v4-r8", "cli"): ("linux", "x86_64"),
+            ("heltec-v4-r8", "web"): ("linux", "x86_64"),
             ("t-beam-supreme", "cli"): ("macos", "aarch64"),
             ("t-beam-supreme", "web"): ("macos", "aarch64"),
             ("xiao-esp32-c6", "cli"): ("windows", "x86_64"),

--- a/tools/tests/test_flasher_reproducibility.py
+++ b/tools/tests/test_flasher_reproducibility.py
@@ -59,6 +59,7 @@ def tools() -> dict[str, str]:
 def manifest(
     *,
     heltec_size: int = 1_000_000,
+    heltec_r8_size: int = 1_000_000,
     t_beam_size: int = 1_000_000,
     xiao_size: int = 900_000,
     source_size: int | None = None,
@@ -70,6 +71,11 @@ def manifest(
                 "board_slug": "heltec-v4",
                 "transport": "esp-serial",
                 "parts": [{"size": heltec_size}],
+            },
+            {
+                "board_slug": "heltec-v4-r8",
+                "transport": "esp-serial",
+                "parts": [{"size": heltec_r8_size}],
             },
             {
                 "board_slug": "t-beam-supreme",
@@ -89,8 +95,9 @@ def manifest(
         ],
     }
     if source_size is not None:
-        for target in value["targets"][:2]:
-            target["source"] = {"size": source_size}
+        for target in value["targets"]:
+            if target["board_slug"] in {"heltec-v4", "heltec-v4-r8", "t-beam-supreme"}:
+                target["source"] = {"size": source_size}
     return value
 
 
@@ -456,7 +463,7 @@ class FlasherReproducibilityTests(unittest.TestCase):
 
     def test_sparse_report_covers_all_boards_and_enforces_sixty_percent(self) -> None:
         report = build_report(manifest())
-        self.assertEqual(len(report["targets"]), 4)
+        self.assertEqual(len(report["targets"]), 5)
         self.assertEqual(report["aggregate_esp"]["gate"], "passed")
         heltec = next(
             target for target in report["targets"] if target["board_slug"] == "heltec-v4"
@@ -471,6 +478,7 @@ class FlasherReproducibilityTests(unittest.TestCase):
             build_report(
                 manifest(
                     heltec_size=SPARSE_BASELINES["heltec-v4"] * 40 // 100,
+                    heltec_r8_size=SPARSE_BASELINES["heltec-v4-r8"] * 40 // 100,
                     t_beam_size=SPARSE_BASELINES["t-beam-supreme"] * 40 // 100,
                     xiao_size=MERGED_BASELINES["xiao-esp32-c6"],
                 )
@@ -481,6 +489,7 @@ class FlasherReproducibilityTests(unittest.TestCase):
         report = build_report(
             manifest(
                 heltec_size=6_000_000,
+                heltec_r8_size=6_000_000,
                 t_beam_size=6_000_000,
                 source_size=source_size,
             )
@@ -728,7 +737,7 @@ class FlasherReproducibilityTests(unittest.TestCase):
         first = shipping.index("release firmware build -- heltec-v4")
         ready = shipping.index("PRNS_EMBEDDED_SITE_READY=1")
         remaining = shipping.index(
-            "for board in t-beam-supreme xiao-esp32-c6 t-echo"
+            "for board in heltec-v4-r8 t-beam-supreme xiao-esp32-c6 t-echo"
         )
         self.assertLess(first, remaining)
         self.assertLess(remaining, ready)

--- a/tools/tests/test_validate_flasher_acceptance.py
+++ b/tools/tests/test_validate_flasher_acceptance.py
@@ -24,7 +24,8 @@ KEY_ID = "0123456789ABCDEF"
 PUBLISHED_AT = "2026-07-20T12:00:00Z"
 COMPLETED_AT = "2026-07-20T13:00:00Z"
 MODELS = {
-    "heltec-v4": "Heltec LoRa 32 V4",
+    "heltec-v4": "Heltec LoRa 32 V4 (S3R2)",
+    "heltec-v4-r8": "Heltec LoRa 32 V4 (S3R8)",
     "t-beam-supreme": "LilyGO T-Beam Supreme",
     "xiao-esp32-c6": "Seeed XIAO ESP32-C6",
     "t-echo": "LilyGO T-Echo",
@@ -35,7 +36,7 @@ def manifest() -> dict:
     targets = []
     for board, model in MODELS.items():
         esp = board != "t-echo"
-        chip = "esp32s3" if board in {"heltec-v4", "t-beam-supreme"} else "esp32c6"
+        chip = "esp32s3" if board in {"heltec-v4", "heltec-v4-r8", "t-beam-supreme"} else "esp32c6"
         targets.append(
             {
                 "board_slug": board,
@@ -43,7 +44,7 @@ def manifest() -> dict:
                 "transport": "esp-serial" if esp else "uf2-mass-storage",
                 "expected_chip": chip if esp else None,
                 "provisioning": {"format": "HSPCFG1"}
-                if board in {"heltec-v4", "t-beam-supreme"}
+                if board in {"heltec-v4", "heltec-v4-r8", "t-beam-supreme"}
                 else None,
             }
         )
@@ -190,6 +191,8 @@ def complete_roster() -> dict:
     hosts = {
         ("heltec-v4", "cli"): ("linux", "x86_64"),
         ("heltec-v4", "web"): ("linux", "x86_64"),
+        ("heltec-v4-r8", "cli"): ("linux", "x86_64"),
+        ("heltec-v4-r8", "web"): ("linux", "x86_64"),
         ("t-beam-supreme", "cli"): ("macos", "aarch64"),
         ("t-beam-supreme", "web"): ("macos", "aarch64"),
         ("xiao-esp32-c6", "cli"): ("windows", "x86_64"),

--- a/tools/tests/test_validate_flasher_tester_roster.py
+++ b/tools/tests/test_validate_flasher_tester_roster.py
@@ -21,6 +21,8 @@ def complete_roster() -> dict:
     hosts = {
         ("heltec-v4", "cli"): ("linux", "x86_64"),
         ("heltec-v4", "web"): ("linux", "x86_64"),
+        ("heltec-v4-r8", "cli"): ("linux", "x86_64"),
+        ("heltec-v4-r8", "web"): ("linux", "x86_64"),
         ("t-beam-supreme", "cli"): ("macos", "aarch64"),
         ("t-beam-supreme", "web"): ("macos", "aarch64"),
         ("xiao-esp32-c6", "cli"): ("windows", "x86_64"),

--- a/tools/tests/test_write_flasher_installation_evidence.py
+++ b/tools/tests/test_write_flasher_installation_evidence.py
@@ -27,6 +27,8 @@ def roster(version: str) -> dict:
     hosts = (
         ("heltec-v4", "cli", "linux", "x86_64"),
         ("heltec-v4", "web", "linux", "x86_64"),
+        ("heltec-v4-r8", "cli", "linux", "x86_64"),
+        ("heltec-v4-r8", "web", "linux", "x86_64"),
         ("t-beam-supreme", "cli", "macos", "aarch64"),
         ("t-beam-supreme", "web", "macos", "aarch64"),
         ("xiao-esp32-c6", "cli", "windows", "x86_64"),

--- a/validation/manifest.toml
+++ b/validation/manifest.toml
@@ -30,6 +30,7 @@ cargo_manifests = [
     "personal-hopspot/desktop/Cargo.toml",
     "personal-hopspot/embedded/esp32/Cargo.toml",
     "personal-hopspot/embedded/esp32/boards/heltec-v4/Cargo.toml",
+    "personal-hopspot/embedded/esp32/boards/heltec-v4-r8/Cargo.toml",
     "personal-hopspot/embedded/esp32/boards/t-beam-supreme/Cargo.toml",
     "personal-hopspot/embedded/esp32/boards/xiao-esp32-c6/Cargo.toml",
     "personal-hopspot/embedded/nrf52840/Cargo.toml",

--- a/validation/platforms/shipping-firmware.sh
+++ b/validation/platforms/shipping-firmware.sh
@@ -7,7 +7,7 @@ out_root="$artifact_root/shipping-firmware"
 
 "$root/tools/prns" release firmware build -- heltec-v4 "$out_root"
 
-for board in t-beam-supreme xiao-esp32-c6 t-echo; do
+for board in heltec-v4-r8 t-beam-supreme xiao-esp32-c6 t-echo; do
     PRNS_EMBEDDED_SITE_READY=1 \
     "$root/tools/prns" release firmware build -- "$board" "$out_root"
 done

--- a/validation/security/deps-audit.sh
+++ b/validation/security/deps-audit.sh
@@ -28,6 +28,7 @@ graphs=(
     "nrf52840|personal-hopspot/embedded/nrf52840/Cargo.toml|thumbv7em-none-eabihf"
     "esp32-c6|personal-hopspot/embedded/esp32/boards/xiao-esp32-c6/Cargo.toml|riscv32imac-unknown-none-elf"
     "esp32-s3-heltec|personal-hopspot/embedded/esp32/boards/heltec-v4/Cargo.toml|xtensa-esp32s3-none-elf"
+    "esp32-s3-heltec-r8|personal-hopspot/embedded/esp32/boards/heltec-v4-r8/Cargo.toml|xtensa-esp32s3-none-elf"
     "esp32-s3-tbeam|personal-hopspot/embedded/esp32/boards/t-beam-supreme/Cargo.toml|xtensa-esp32s3-none-elf"
     "wasm|prns-wasm/Cargo.toml|wasm32-unknown-unknown"
     "website-rust|docs/website/Cargo.toml|wasm32-unknown-unknown"

--- a/validation/security/unsafe-audit.py
+++ b/validation/security/unsafe-audit.py
@@ -55,6 +55,11 @@ GRAPHS = (
         "xtensa-esp32s3-none-elf",
     ),
     (
+        "esp32-s3-heltec-r8",
+        "personal-hopspot/embedded/esp32/boards/heltec-v4-r8/Cargo.toml",
+        "xtensa-esp32s3-none-elf",
+    ),
+    (
         "esp32-s3-tbeam",
         "personal-hopspot/embedded/esp32/boards/t-beam-supreme/Cargo.toml",
         "xtensa-esp32s3-none-elf",


### PR DESCRIPTION
## Summary
- Split Heltec WiFi LoRa 32 V4 into `heltec-v4` (S3R2 / Quad PSRAM) and `heltec-v4-r8` (S3R8 / Octal PSRAM) with distinct pinouts, USB ids, and cargo/flash packages.
- Keep R8 Octal PSRAM on a private bump path and avoid reclaiming MSPI pads (GPIO36/37) that kill PSRAM when the R2 bring-up is flashed on R8 hardware.
- Wire the new board through the flash catalog, shipping/release tooling, doctor ambiguity notes, and acceptance roster template.

## Test plan
- [x] `cargo heltec-v4` and `cargo heltec-v4-r8` release builds succeed
- [x] Flash `hopspot-heltec-v4-r8` to a Heltec V4-R8 and confirm boot past splash (`HOPSPOT_HELTECV4_R8`, OLED UI, PSRAM/Wi-Fi/LoRa come up)
- [x] Catalog/flasher/release Python unit tests covering the expanded shipping board set
- [ ] Confirm an S3R2 Heltec V4 still boots with `heltec-v4` firmware (not exercised on this hardware)


Made with [Cursor](https://cursor.com)