### PR TITLE
Use ISO 8859-1 fonts so the display can render more than English

### DIFF
--- a/personal-hopspot/core/src/screen/render/cards.rs
+++ b/personal-hopspot/core/src/screen/render/cards.rs
@@ -1,4 +1,4 @@
-use embedded_graphics::mono_font::ascii::{FONT_5X8, FONT_6X10};
+use embedded_graphics::mono_font::iso_8859_1::{FONT_5X8, FONT_6X10};
 use embedded_graphics::mono_font::{MonoFont, MonoTextStyle};
 use embedded_graphics::pixelcolor::BinaryColor;
 use embedded_graphics::prelude::*;

--- a/personal-hopspot/core/src/screen/render/glyphs.rs
+++ b/personal-hopspot/core/src/screen/render/glyphs.rs
@@ -1,4 +1,4 @@
-use embedded_graphics::mono_font::ascii::{FONT_5X8, FONT_9X15_BOLD};
+use embedded_graphics::mono_font::iso_8859_1::{FONT_5X8, FONT_9X15_BOLD};
 use embedded_graphics::mono_font::MonoTextStyle;
 use embedded_graphics::pixelcolor::BinaryColor;
 use embedded_graphics::prelude::*;

--- a/personal-hopspot/core/src/screen/render/menus/lora.rs
+++ b/personal-hopspot/core/src/screen/render/menus/lora.rs
@@ -1,6 +1,6 @@
 use core::fmt::Write as _;
 
-use embedded_graphics::mono_font::ascii::{FONT_4X6, FONT_5X8};
+use embedded_graphics::mono_font::iso_8859_1::{FONT_4X6, FONT_5X8};
 use embedded_graphics::mono_font::MonoTextStyle;
 use embedded_graphics::pixelcolor::BinaryColor;
 use embedded_graphics::prelude::*;

--- a/personal-hopspot/core/src/screen/render/menus/mod.rs
+++ b/personal-hopspot/core/src/screen/render/menus/mod.rs
@@ -2,7 +2,7 @@ pub(in crate::screen) mod lora;
 
 use core::fmt::Write as _;
 
-use embedded_graphics::mono_font::ascii::{FONT_4X6, FONT_5X8, FONT_6X10};
+use embedded_graphics::mono_font::iso_8859_1::{FONT_4X6, FONT_5X8, FONT_6X10};
 use embedded_graphics::mono_font::MonoTextStyle;
 use embedded_graphics::pixelcolor::BinaryColor;
 use embedded_graphics::prelude::*;

--- a/personal-hopspot/core/src/screen/render/metrics.rs
+++ b/personal-hopspot/core/src/screen/render/metrics.rs
@@ -1,6 +1,6 @@
 use core::fmt::Write as _;
 
-use embedded_graphics::mono_font::ascii::FONT_5X8;
+use embedded_graphics::mono_font::iso_8859_1::FONT_5X8;
 use embedded_graphics::mono_font::MonoTextStyle;
 use embedded_graphics::pixelcolor::BinaryColor;
 use embedded_graphics::prelude::*;

--- a/personal-hopspot/core/src/screen/render/mod.rs
+++ b/personal-hopspot/core/src/screen/render/mod.rs
@@ -5,7 +5,7 @@ pub(in crate::screen) mod menus;
 pub(in crate::screen) mod metrics;
 mod primitives;
 
-use embedded_graphics::mono_font::ascii::FONT_6X10;
+use embedded_graphics::mono_font::iso_8859_1::FONT_6X10;
 use embedded_graphics::mono_font::MonoTextStyle;
 use embedded_graphics::pixelcolor::BinaryColor;
 use embedded_graphics::prelude::*;


### PR DESCRIPTION

### Summary

Every render module imports its fonts from `embedded_graphics::mono_font::ascii`. Any character
outside `0x20..=0x7f` renders as `?`. This switches the six import lines to
`embedded_graphics::mono_font::iso_8859_1`, which provides the same four fonts with the same metrics
and the same ASCII glyphs.

The motivation is direct: I run a LoRa and Reticulum mesh in Chapala, Jalisco, and I want to
contribute a Spanish localization of the on-device strings. That is not worth starting while the
panel cannot draw `ñ`, `á`, or `¿`. This PR is the prerequisite. It does nothing visible on its own,
and it costs flash.

### Evidence

Six lines change. `embedded-graphics` is declared as `"0.8"` in `personal-hopspot/core/Cargo.toml:21`
(with the comment that it is held to the same 0.8 the S3's `ssd1306` stack uses) and resolves to
0.8.2 in `Cargo.lock`. `mono_font::iso_8859_1` is exposed unconditionally there, not behind a feature.

| File | Line | Current import |
| --- | --- | --- |
| `personal-hopspot/core/src/screen/render/cards.rs` | 1 | `use embedded_graphics::mono_font::ascii::{FONT_5X8, FONT_6X10};` |
| `personal-hopspot/core/src/screen/render/glyphs.rs` | 1 | `use embedded_graphics::mono_font::ascii::{FONT_5X8, FONT_9X15_BOLD};` |
| `personal-hopspot/core/src/screen/render/menus/lora.rs` | 3 | `use embedded_graphics::mono_font::ascii::{FONT_4X6, FONT_5X8};` |
| `personal-hopspot/core/src/screen/render/menus/mod.rs` | 5 | `use embedded_graphics::mono_font::ascii::{FONT_4X6, FONT_5X8, FONT_6X10};` |
| `personal-hopspot/core/src/screen/render/metrics.rs` | 3 | `use embedded_graphics::mono_font::ascii::FONT_5X8;` |
| `personal-hopspot/core/src/screen/render/mod.rs` | 8 | `use embedded_graphics::mono_font::ascii::FONT_6X10;` |

One word changes in each: `ascii` becomes `iso_8859_1`. Four distinct fonts are involved, `FONT_4X6`,
`FONT_5X8`, `FONT_6X10`, and `FONT_9X15_BOLD`, and `iso_8859_1` provides all four. Those six files are
the only ones in the repository that name `mono_font` at all; the one non-font item any of them pulls
from it is `MonoTextStyle` (and `MonoFont` in `cards.rs`), which is unaffected.

Why this should be invisible for the text the firmware draws today:

1. **The metrics are the same.** For each of the four fonts, the `iso_8859_1` const differs from the
   `ascii` const in `image` and `glyph_mapping` only. `character_size`, `character_spacing`,
   `baseline`, `underline`, and `strikethrough` carry the same values, so `FONT_6X10_CHAR_W = 6`,
   `FONT_5X8_CHAR_W = 5`, and `FONT_4X6_CHAR_W = 4` in `render/layout.rs:43`, `:55`, `:56` stay correct.
2. **The ASCII glyphs are the same image data, byte for byte.** These are 1bpp sprite sheets laid out
   16 glyphs per row, and the ISO sheet is the ASCII set followed by a second block of 96 glyphs for
   `0xa0..=0xff`. I checked this rather than assuming it: for each font,
   `fonts/raw/iso_8859_1/font_N.raw` begins with exactly the bytes of `fonts/raw/ascii/font_N.raw`.
   `cmp` of the first `len(ascii)` bytes reports no difference for `font_4x6`, `font_5x8`, and
   `font_6x10`. So no ASCII glyph can shift by a pixel. The raw sizes show the doubling:

   | font | rows x px | ascii raw | iso_8859_1 raw |
   | --- | --- | --- | --- |
   | `font_4x6` | 8 B/row x 36 px | 288 | 576 |
   | `font_5x8` | 10 B/row x 48 px | 480 | 960 |
   | `font_6x10` | 12 B/row x 60 px | 720 | 1440 |
   | `font_9x15_bold` | 18 B/row x 90 px | 1620 | 3240 |

3. **The ASCII indices are the same.** `mapping::ASCII` is `"\0\u{20}\u{7f}"` and `mapping::ISO_8859_1`
   is `"\0\u{20}\u{7f}\0\u{a0}\u{ff}"`. The first range is the same range at the same starting index,
   so any character in `0x20..=0x7f` resolves to the same glyph in both. Both use the same replacement
   index, which is why unmapped characters draw as `?` today.

That is also why no test changes. The render tests in `personal-hopspot/core/src/screen/tests/render/`
assert pixel patterns for hand-drawn icons and glyph primitives; none of them names a font, and every
string they draw is ASCII.

Two more things worth knowing:

- **No re-encoding is needed.** `GlyphMapping::index` takes a `char`, so a normal UTF-8 Rust literal
  like `"Sin señal"` works directly. "ISO 8859-1" here names the glyph subset, not a source encoding.
- **The width math is already prepared.** Text width in `render/` is computed with `.chars().count()`,
  so a two-byte `ñ` measures as one cell. The `.len()` calls in that tree are all on slices
  (`Region::ALL`, `items`, `cards`), not on strings.

### The tradeoff

Doubling the raw glyph tables is the cost. The four fonts total 3,108 bytes of ASCII glyph data and
6,216 bytes of ISO 8859-1 glyph data, so a binary linking all four grows by 3,108 bytes of glyph
data. The mapping string grows from 3 bytes to 8. Everything else is the same code.

Measured rather than estimated. Two bare application images built from the same commit for
`heltec-v4-r8`, one on each charset, via `espflash save-image --chip esp32s3`:

| build | app image |
| --- | --- |
| `ascii` | 1,585,792 bytes |
| `iso_8859_1` | 1,588,896 bytes |
| **delta** | **+3,104 bytes** |

That lands 4 bytes under the 3,108 of raw glyph data, which is alignment. Of it, 2,880 bytes is the
upper half of the three text fonts and the balance is `FONT_9X15_BOLD`, which today draws only the
battery glyph and will never carry a translated string. Keeping that one on `ascii` would save about
1.6 KiB at the cost of two charsets in one file. I chose the uniform version and I am happy to split
it if you would rather have the bytes.

The board to watch is the nRF52840 T-Echo. It reaches the same render path
(`personal-hopspot/embedded/nrf52840/src/hopspot/firmware.rs:367` calls `hopspot::render`) and it has
the tightest budget of the targets that draw anything: `APPLICATION_FLASH_BYTES = 0x99000` in
`personal-hopspot/embedded/nrf52840/memory.x`, about 612 KiB. The S3 boards have room. If ~3 KB is
unwelcome on the T-Echo specifically, the alternative is a per-target font subset, which costs a `cfg`
and a second source of truth, and I would rather you tell me that is the shape you want than guess.

### In scope

The six import lines above. Nothing else.

### Deliberately not in scope

- **The Spanish strings themselves.** That is the follow-up. I wanted the glyph question settled and
  reviewable on its own, since it is the part with a cost attached.
- **Any layout change.** No constant in `render/layout.rs` moves.
- **Any language-selection mechanism.** This PR does not add a locale concept, a build flag, or a menu
  item. It only widens what the panel is able to draw.
- **A fix for the `heapless` line buffers.** While reading, I noticed `draw_failure_reason` in
  `render/menus/mod.rs:51-92` wraps into a `heapless::String<24>` (`:73`) while its `MAX_CHARS` budget
  works out to 15 characters (`(WIDTH - MENU_REASON_X) / FONT_4X6_CHAR_W`, so `(64 - 2) / 4`). Fifteen
  ASCII characters is 15 bytes and fits; fifteen accented characters is 30 bytes, and the
  `let _ = line.push(ch)` at `:87` drops the overflow silently. This PR neither creates nor fixes
  that, and it will matter to the localization work. I will raise it separately once I have it
  reproducing on the panel rather than on paper.

### How to verify

```console
cargo test --locked -p personal-hopspot-core
```

The render tests should pass unchanged, which is the point: for ASCII input this is not a behavior
change.

To see the reason for the change, draw a string with an accented character before and after. Before,
each non-ASCII character comes out as `?`. After, it comes out as the character.

For the flash number, build a board before and after and compare the artifact:

```console
cd personal-hopspot/embedded/esp32
cargo heltec-v4-r8 --locked
```

### Open question

Six import sites means the glyph subset is stated six times. A small `screen/render/fonts.rs` that
re-exports the four fonts, with every render module importing from there, would make the subset a
single fact and would make a future per-target subset a one-file change. I kept this PR to the import
lines because that is the smallest change that is honest about what it does, but I think the fonts
module is the better shape and I am happy to send it that way instead.


