### PR TITLE
Split PSRAM on the Heltec V4-R8 so the global heap is not 75 KiB

### DIFF
--- a/personal-hopspot/embedded/esp32/src/s3/boards/heltec_v4_r8.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/boards/heltec_v4_r8.rs
@@ -113,8 +113,8 @@ impl Esp32S3Board for HeltecV4R8Board {
     async fn bringup(
         p: esp_hal::peripherals::Peripherals,
     ) -> S3BoardHardware<Self::Display, Self::Battery> {
-        // Octal 8MB @ 40MHz on a private bump (not global esp_alloc). Vext is GPIO40 — GPIO36 is
-        // FSPICLK/SPIIO7 on the R8 SiP; driving it as GPIO disrupts PSRAM access after early probes.
+        // Octal 8 MiB at 40 MHz, split between a private low engine window and a global high `esp_alloc` window.
+        // Vext is GPIO40; GPIO36 is FSPICLK/SPIIO7 on the R8 SiP, and driving it as GPIO disrupts PSRAM access after early probes.
         let (sw_int1, timebase, rtc) = s3::boot_common!(
             p,
             Self::BOOT_BANNER,

--- a/personal-hopspot/embedded/esp32/src/s3/mod.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/mod.rs
@@ -475,8 +475,8 @@ async fn usb_device_task(
 ///
 /// Heap region order is load-bearing for Wi-Fi boards: PSRAM must register first so capability-free
 /// boot allocations land externally and leave the small internal regions for the radio. Heltec V4-R8
-/// (Octal private bump) passes a custom `PsramConfig` and uses `private_psram_bump` so boot/log
-/// allocations cannot share a freelist with engine construction.
+/// (Octal) passes a custom `PsramConfig` and uses `split_psram_heap`, which splits the window so
+/// engine construction gets a freelist of its own without starving the rest of the system.
 macro_rules! boot_common {
     ($p:ident, $banner:expr) => {
         $crate::s3::boot_common!(
@@ -487,7 +487,7 @@ macro_rules! boot_common {
         )
     };
     ($p:ident, $banner:expr, $psram_config:expr) => {
-        $crate::s3::boot_common!($p, $banner, $psram_config, private_psram_bump)
+        $crate::s3::boot_common!($p, $banner, $psram_config, split_psram_heap)
     };
     ($p:ident, $banner:expr, $psram_config:expr, global_psram_heap) => {{
         ::esp_println::logger::init_logger_from_env();
@@ -497,12 +497,11 @@ macro_rules! boot_common {
         $crate::s3::boot_psram_probe!();
         $crate::s3::boot_rtos_tail!($p, $banner)
     }};
-    ($p:ident, $banner:expr, $psram_config:expr, private_psram_bump) => {{
+    ($p:ident, $banner:expr, $psram_config:expr, split_psram_heap) => {{
         ::esp_println::logger::init_logger_from_env();
-        // Heltec V4-R8: keep Octal PSRAM out of the global heap so boot/log allocs cannot spill into it.
+        $crate::s3::boot_add_psram_split!($p, $psram_config);
         ::esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 43 * 1024);
         $crate::s3::reclaim_dcache_region();
-        $crate::s3::boot_add_psram_private!($p, $psram_config);
         $crate::s3::boot_psram_probe!();
         $crate::s3::boot_rtos_tail!($p, $banner)
     }};
@@ -526,16 +525,37 @@ macro_rules! boot_add_psram_global {
 }
 pub(crate) use boot_add_psram_global;
 
-macro_rules! boot_add_psram_private {
+/// Split a board's PSRAM into two disjoint windows: a private low half owned solely by [`PsramAlloc`]
+/// for engine construction, and a high half handed to `esp_alloc`. The global half is registered
+/// before the internal region so capability-free allocations land externally and leave the small
+/// internal regions for the radios, which is the same ordering `global_psram_heap` relies on.
+///
+/// Reserving the whole window privately instead leaves the system on internal RAM alone, roughly
+/// 75 KiB across the reclaimed region and the D-cache window. The Bluetooth controller's receive
+/// buffers cannot be allocated from that, and neither can the captive portal, whose four HTTP tasks
+/// want 24 KiB each. Both fail on a board carrying 8 MiB of PSRAM.
+macro_rules! boot_add_psram_split {
     ($p:ident, $psram_config:expr) => {{
         let psram = ::esp_hal::psram::Psram::new($p.PSRAM, $psram_config);
         let (start, size) = psram.raw_parts();
-        ::esp_println::println!("PSRAM mapped start={start:?} size={size} (private)");
-        // SAFETY: exclusive mapped window for PsramAlloc; not registered with esp_alloc.
-        unsafe { $crate::storage::init_private_psram_heap(start, size) };
+        let private_size = size / 2;
+        let global_size = size - private_size;
+        ::esp_println::println!(
+            "PSRAM mapped start={start:?} size={size} (private={private_size} global={global_size})"
+        );
+        // SAFETY: the low window is given to PsramAlloc alone and is never registered with
+        // esp_alloc; the high window is disjoint from it and is added to the heap exactly once.
+        unsafe {
+            $crate::storage::init_private_psram_heap(start, private_size);
+            ::esp_alloc::HEAP.add_region(::esp_alloc::HeapRegion::new(
+                start.add(private_size),
+                global_size,
+                ::esp_alloc::MemoryCapability::External.into(),
+            ));
+        }
     }};
 }
-pub(crate) use boot_add_psram_private;
+pub(crate) use boot_add_psram_split;
 
 macro_rules! boot_psram_probe {
     () => {{

--- a/personal-hopspot/embedded/esp32/src/s3/mod.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/mod.rs
@@ -473,10 +473,8 @@ async fn usb_device_task(
 /// for the slow PSRAM-backed engine construction. A block expression (so its bindings escape
 /// macro hygiene) owning `$p`'s early peripherals, yielding `(software_interrupt1, timebase, rtc)`.
 ///
-/// Heap region order is load-bearing for Wi-Fi boards: PSRAM must register first so capability-free
-/// boot allocations land externally and leave the small internal regions for the radio. Heltec V4-R8
-/// (Octal) passes a custom `PsramConfig` and uses `split_psram_heap`, which splits the window so
-/// engine construction gets a freelist of its own without starving the rest of the system.
+/// Heap region order is load-bearing for Wi-Fi boards: PSRAM must register first so capability-free boot allocations land externally and leave the small internal regions for the radio.
+/// Heltec V4-R8 (Octal) passes a custom `PsramConfig` and uses `split_psram_heap`, which gives engine construction a private freelist without starving the rest of the system.
 macro_rules! boot_common {
     ($p:ident, $banner:expr) => {
         $crate::s3::boot_common!(
@@ -525,15 +523,11 @@ macro_rules! boot_add_psram_global {
 }
 pub(crate) use boot_add_psram_global;
 
-/// Split a board's PSRAM into two disjoint windows: a private low half owned solely by [`PsramAlloc`]
-/// for engine construction, and a high half handed to `esp_alloc`. The global half is registered
-/// before the internal region so capability-free allocations land externally and leave the small
-/// internal regions for the radios, which is the same ordering `global_psram_heap` relies on.
+/// Split a board's PSRAM into two disjoint windows: a private low half owned solely by [`crate::storage::PsramAlloc`] for engine construction, and a high half handed to `esp_alloc`.
+/// Register the global half before the internal regions so capability-free allocations land externally and leave the small internal regions for the radios, matching the ordering `global_psram_heap` relies on.
 ///
-/// Reserving the whole window privately instead leaves the system on internal RAM alone, roughly
-/// 75 KiB across the reclaimed region and the D-cache window. The Bluetooth controller's receive
-/// buffers cannot be allocated from that, and neither can the captive portal, whose four HTTP tasks
-/// want 24 KiB each. Both fail on a board carrying 8 MiB of PSRAM.
+/// Reserving the whole window privately instead leaves the system on roughly 75 KiB of internal RAM across the reclaimed region and the D-cache window.
+/// The Bluetooth controller cannot allocate its receive buffers from that, and the captive portal's four HTTP tasks each request another 24 KiB.
 macro_rules! boot_add_psram_split {
     ($p:ident, $psram_config:expr) => {{
         let psram = ::esp_hal::psram::Psram::new($p.PSRAM, $psram_config);
@@ -543,8 +537,8 @@ macro_rules! boot_add_psram_split {
         ::esp_println::println!(
             "PSRAM mapped start={start:?} size={size} (private={private_size} global={global_size})"
         );
-        // SAFETY: the low window is given to PsramAlloc alone and is never registered with
-        // esp_alloc; the high window is disjoint from it and is added to the heap exactly once.
+        // SAFETY: The low window is given to PsramAlloc alone and is never registered with esp_alloc.
+        // The high window is disjoint from it and is added to the heap exactly once.
         unsafe {
             $crate::storage::init_private_psram_heap(start, private_size);
             ::esp_alloc::HEAP.add_region(::esp_alloc::HeapRegion::new(

--- a/personal-hopspot/embedded/esp32/src/storage.rs
+++ b/personal-hopspot/embedded/esp32/src/storage.rs
@@ -41,9 +41,9 @@ const _: () = assert!(
 
 /// A `Default`-able allocator that places allocations in PSRAM.
 ///
-/// On Heltec V4-R8, PSRAM is owned by a private bump allocator (see [`init_private_psram_heap`]) so
-/// ordinary boot/`log` allocs cannot share a freelist with engine construction. Other S3 boards
-/// keep PSRAM in `esp_alloc`'s global heap and this forwards to `ExternalMemory`.
+/// On Heltec V4-R8, `PsramAlloc` owns a private low PSRAM window installed by [`init_private_psram_heap`], while `esp_alloc` owns the disjoint high window.
+/// Ordinary boot and `log` allocations therefore cannot share a freelist with engine construction.
+/// Other S3 boards keep the whole PSRAM window in `esp_alloc`'s global heap, and this allocator forwards to `ExternalMemory`.
 #[cfg(target_arch = "xtensa")]
 #[derive(Default, Clone, Copy)]
 pub struct PsramAlloc;


### PR DESCRIPTION
### Summary

A Heltec V4-R8 (ESP32-S3R8, 16 MiB flash, 8 MiB Octal PSRAM) never gets past its boot splash on
current `trunk`. Since #38 the V4-R8 is in the shipping catalog (`catalog.rs:13`,
`release/flash/boards.json:44`), so anyone flashing one from the website today gets a board that
draws the brand splash and then does nothing, with working-looking branding and dead buttons. That
is why I am opening this now rather than waiting on the design discussion in #40. The board hands all 8 MiB of PSRAM to the engine's private bump allocator and
registers none of it with `esp_alloc`, so the whole system runs on two small internal regions: the
43 KiB reclaimed-DRAM allocator and the 32 KiB D-cache window (`s3/mod.rs:429-442`). `esp_alloc::HEAP`
ends boot with no external region at all on a board carrying 8 MiB of it.

This changes the `private_psram_bump` arm of `boot_common!` to split the PSRAM window: the engine
keeps an exclusive low half, and the disjoint high half is registered with `esp_alloc` ahead of the
internal regions. The allocator behavior changes only in `personal-hopspot/embedded/esp32/src/s3/mod.rs`; adjacent comments in `storage.rs` and `s3/boards/heltec_v4_r8.rs` are updated to describe the resulting ownership model.

### Evidence

The `private_psram_bump` arm on `trunk` (`s3/mod.rs:500-508`) runs, in order:

```rust
::esp_println::logger::init_logger_from_env();
// Heltec V4-R8: keep Octal PSRAM out of the global heap so boot/log allocs cannot spill into it.
::esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 43 * 1024);
$crate::s3::reclaim_dcache_region();
$crate::s3::boot_add_psram_private!($p, $psram_config);
```

`boot_add_psram_private!` (`s3/mod.rs:529-538`) calls `storage::init_private_psram_heap(start, size)`
with the whole window and never touches `esp_alloc::HEAP`. The V4-R8 is the only board that reaches
this arm: it is the only one passing a custom `PsramConfig` (`s3/boards/heltec_v4_r8.rs:118-127`,
`PsramMode::OctalSpi`, `PsramSize::Size(8 * 1024 * 1024)`). Every other S3 board takes the two-argument
form and lands on `global_psram_heap`.

What that starves:

- The BLE controller's receive buffer allocation panics during radio bring-up. On this board both
  `wifi-auto` and `bluetooth-auto` are on, so `BleConnector::new` runs at `s3/firmware.rs:724`, inside
  the `RadioMode::Ble` arm. `boot_radio_mode` (`s3/mod.rs:604-620`) returns `RadioMode::Ble` unless the
  RTC-fast flag says otherwise, so every cold boot takes that path. That call sits before
  `render.await` at `s3/firmware.rs:743`, and `render` is the async block that opens with
  `boot_stage(BootPhase::DisplayRuntimeBegin)` at `:320`. The display runtime therefore never starts.
- The AP escape hatch cannot rescue it. "AP Mode" is a global menu item
  (`core/src/screen/state/mod.rs:16` and `:18`), so it lives behind the display runtime that never
  runs. Even reached, `s3/captive_portal.rs:314-316` allocates a 4 KiB rx buffer, a 16 KiB tx buffer,
  and a 4 KiB request buffer from that same global heap.

The fix is the ordering the file already documents for the other S3 boards. From the `boot_common!`
doc comment on `trunk` (`s3/mod.rs:476-477`):

> Heap region order is load-bearing for Wi-Fi boards: PSRAM must register first so capability-free
> boot allocations land externally and leave the small internal regions for the radio.

Splitting the window keeps the property the private bump was added for, that boot and `log`
allocations cannot share a freelist with engine construction, while restoring the ordering the other
boards depend on. The engine still allocates only from the bump, because `PsramAlloc` prefers the
private window whenever one is installed and falls back to `esp_alloc::ExternalMemory` only when
there is none (`storage.rs:109-125`).

The probe-reclaim path is unaffected. `reinit_private_psram_heap` resets `bump.offset` to 0 over
whatever window it was handed (`storage.rs:86-95`), and `s3/firmware.rs:86-88` still calls it before
placing the live LoRa transmit queue. A smaller window changes nothing about that sequence.

The existing `PSRAM mapped ...` line now reports the split alongside the window, `size=8388608
(private=4194304 global=4194304)`, and the `PSRAM probe ok` line follows it as before.

### In scope

The allocator behavior changes only in `personal-hopspot/embedded/esp32/src/s3/mod.rs`. Two comment-only updates keep adjacent ownership descriptions coupled to that behavior:

- `boot_add_psram_private!` becomes `boot_add_psram_split!`: the low half goes to `PsramAlloc` as
  before, the high half is added to `esp_alloc::HEAP` with `MemoryCapability::External`. The old macro
  is gone rather than kept behind `#[allow(unused_macros)]`, since no board calls it afterwards and
  git history keeps it if a future board wants a fully private window.
- The `private_psram_bump` arm calls it first, before the internal allocators, so region order matches
  the `global_psram_heap` arm.
- The `boot_common!` doc comment is updated to describe the split.

- The selector is renamed from `private_psram_bump` to `split_psram_heap`, since it no longer reserves
  the whole window and the old name would mislead the next reader. It is internal to the macro, so the V4-R8 board call site remains unchanged.

No other board's boot path changes. The `global_psram_heap` arm, the C6, the T-Beam Supreme, and the
S3R2 V4 are untouched.

### Deliberately not in scope

- **My LoRa channel constant.** My working branch also pins the compiled boot profile to the Chapala
  mesh channel. That is local configuration, not an upstream change, and it is not on this branch.
- **Anything in the LoRa menu.** Separate PR.

### How to verify

Without hardware, read the two macros side by side. The `private_psram_bump` arm should now register
regions in the same order the `global_psram_heap` arm does, external first.

With a Heltec V4-R8 on USB:

```console
cd personal-hopspot/embedded/esp32
cargo heltec-v4-r8-flash --locked
```

Before, the OLED holds the brand splash and the console shows an allocation panic with
`r_ble_util_buf_rx_alloc` in the backtrace. Note that `previous_boot_phase()` does not help you find
it: the next boot reports phase 12, not the 22 it died at, because core 1 keeps running after core 0
panics and walks the breadcrumb on to `persistence.restore.complete`. You need a console attached.

After, the boot-stage ladder continues past `bluetooth.begin` to `bluetooth.ready`, then
`display.runtime.begin` and `display.first-render.complete`, with `wifi.associated` and
`network.ready` arriving from the connectivity tasks (`s3/connectivity.rs:542` and `:358`). No panic.
The menus are usable.

Host coverage: one Heltec V4-R8, built and flashed from this branch. I have not put this on a V4
(S3R2), a T-Beam Supreme, or a C6, and the diff does not reach their boot arms.

### Open questions

These are laid out in more detail in discussion #40, which also carries the full diagnosis and the
boot logs. Short form:

- **The split ratio.** I used `size / 2` because it needs no measurement to justify and because the
  board boots on it: 4 MiB is demonstrably enough for this engine's construction. It is not a free
  choice, though. The bump returns `AllocError` rather than spilling once a request runs past the end
  of its window (`storage.rs:116-118`), so the ratio is a real ceiling on engine growth, and a named
  constant derived from the storage layout would be truer to the repo's stance on magic numbers and
  would hand the global heap several more megabytes. I did not want to invent that number without
  measuring the engine's high-water mark. Happy to measure and send a constant if you prefer it.
- **Whether the private bump is still earning its place.** With PSRAM back in the global heap, the
  original reason for the private window could also be met by putting this board on the
  `global_psram_heap` arm like every other S3. I kept the private window because I did not want to
  change the engine's allocation behavior inside a boot fix. If you would rather collapse the two
  arms, that is a smaller file, and I will send it.
