### PR TITLE
flash: explain Android's Bluetooth-only Web Serial instead of an empty port picker

### DIFF
--- a/docs/website/src/pages/flash/bridge.rs
+++ b/docs/website/src/pages/flash/bridge.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::platforms::BoardFlashTarget;
 
 use super::contract::{self, BridgeErrorCode, BridgePhase};
-use super::model::{part_kind, DestructiveConfirmation, FlasherState, InstallMode};
+use super::model::{part_kind, DestructiveConfirmation, FlasherState, InstallMode, WebSerialCapability};
 use super::protocol;
 
 const PREPARE_SCRIPT: &str = r#"
@@ -22,8 +22,20 @@ try {
 } catch (_) {}
 "#;
 
-const BROWSER_SUPPORT_SCRIPT: &str =
-    "return Boolean(window.isSecureContext && navigator.serial && navigator.serial.requestPort);";
+// Chrome for Android exposes Web Serial for Bluetooth RFCOMM services only;
+// wired USB serial ports never appear in its picker until the Android Serial
+// API lands (Chromium blink-dev PSA, February 2026: estimated 2026Q2 on a
+// limited set of devices). The platform probe exists to explain that dead
+// end instead of presenting an empty picker; remove it once Android Chrome
+// reaches wired ports on the devices people actually carry.
+const WEB_SERIAL_PROBE_SCRIPT: &str = r#"
+if (!(window.isSecureContext && navigator.serial && navigator.serial.requestPort)) {
+  return "unavailable";
+}
+const wiredPortsUnreachable = navigator.userAgentData?.platform === "Android"
+  || /\bAndroid\b/.test(navigator.userAgent);
+return wiredPortsUnreachable ? "android-bluetooth-only" : "supported";
+"#;
 
 const FOCUS_STATUS_SCRIPT: &str =
     "document.getElementById('flash-status')?.focus({ preventScroll: true });";
@@ -319,11 +331,12 @@ impl BridgeEvent {
     }
 }
 
-pub(super) async fn browser_supported() -> bool {
-    document::eval(BROWSER_SUPPORT_SCRIPT)
-        .join::<bool>()
+pub(super) async fn web_serial_capability() -> WebSerialCapability {
+    document::eval(WEB_SERIAL_PROBE_SCRIPT)
+        .join::<String>()
         .await
-        .unwrap_or(false)
+        .map(|probe| WebSerialCapability::from_probe(&probe))
+        .unwrap_or(WebSerialCapability::Unavailable)
 }
 
 pub(super) fn clear_prepared() {
@@ -931,6 +944,19 @@ mod tests {
             cancel < clear,
             "active work must be cancelled before cleanup"
         );
+    }
+
+    #[test]
+    fn web_serial_probe_script_speaks_the_model_wire_spellings() {
+        use super::super::model::{
+            WEB_SERIAL_PROBE_ANDROID_BLUETOOTH_ONLY, WEB_SERIAL_PROBE_SUPPORTED,
+        };
+
+        assert!(WEB_SERIAL_PROBE_SCRIPT.contains("window.isSecureContext"));
+        assert!(WEB_SERIAL_PROBE_SCRIPT.contains("navigator.serial.requestPort"));
+        assert!(WEB_SERIAL_PROBE_SCRIPT.contains(&format!("\"{WEB_SERIAL_PROBE_SUPPORTED}\"")));
+        assert!(WEB_SERIAL_PROBE_SCRIPT
+            .contains(&format!("\"{WEB_SERIAL_PROBE_ANDROID_BLUETOOTH_ONLY}\"")));
     }
 
     #[test]

--- a/docs/website/src/pages/flash/bridge.rs
+++ b/docs/website/src/pages/flash/bridge.rs
@@ -25,12 +25,11 @@ try {
 } catch (_) {}
 "#;
 
-// Chrome for Android exposes Web Serial for Bluetooth RFCOMM services only;
-// wired USB serial ports never appear in its picker until the Android Serial
-// API lands (Chromium blink-dev PSA, February 2026: estimated 2026Q2 on a
-// limited set of devices). The platform probe exists to explain that dead
-// end instead of presenting an empty picker; remove it once Android Chrome
-// reaches wired ports on the devices people actually carry.
+// Chrome for Android initially exposed Web Serial only for Bluetooth RFCOMM.
+// Chromium's February 2026 PSA targeted wired support for M149 on devices with the Android Serial API, with a limited rollout estimated for 2026Q2.
+//
+// That estimate has passed, but `navigator.serial` still does not reveal whether a particular device can enumerate wired ports.
+// Keep this conservative gate until verified device coverage justifies narrowing or removing the Android classification.
 fn web_serial_probe_script() -> String {
     format!(
         r#"

--- a/docs/website/src/pages/flash/bridge.rs
+++ b/docs/website/src/pages/flash/bridge.rs
@@ -5,7 +5,10 @@ use serde::{Deserialize, Serialize};
 use crate::platforms::BoardFlashTarget;
 
 use super::contract::{self, BridgeErrorCode, BridgePhase};
-use super::model::{part_kind, DestructiveConfirmation, FlasherState, InstallMode, WebSerialCapability};
+use super::model::{
+    part_kind, DestructiveConfirmation, FlasherState, InstallMode, WebSerialCapability,
+    WEB_SERIAL_PROBE_ANDROID_BLUETOOTH_ONLY, WEB_SERIAL_PROBE_SUPPORTED,
+};
 use super::protocol;
 
 const PREPARE_SCRIPT: &str = r#"
@@ -28,14 +31,18 @@ try {
 // limited set of devices). The platform probe exists to explain that dead
 // end instead of presenting an empty picker; remove it once Android Chrome
 // reaches wired ports on the devices people actually carry.
-const WEB_SERIAL_PROBE_SCRIPT: &str = r#"
-if (!(window.isSecureContext && navigator.serial && navigator.serial.requestPort)) {
+fn web_serial_probe_script() -> String {
+    format!(
+        r#"
+if (!(window.isSecureContext && navigator.serial && navigator.serial.requestPort)) {{
   return "unavailable";
-}
+}}
 const wiredPortsUnreachable = navigator.userAgentData?.platform === "Android"
   || /\bAndroid\b/.test(navigator.userAgent);
-return wiredPortsUnreachable ? "android-bluetooth-only" : "supported";
-"#;
+return wiredPortsUnreachable ? "{WEB_SERIAL_PROBE_ANDROID_BLUETOOTH_ONLY}" : "{WEB_SERIAL_PROBE_SUPPORTED}";
+"#
+    )
+}
 
 const FOCUS_STATUS_SCRIPT: &str =
     "document.getElementById('flash-status')?.focus({ preventScroll: true });";
@@ -332,7 +339,7 @@ impl BridgeEvent {
 }
 
 pub(super) async fn web_serial_capability() -> WebSerialCapability {
-    document::eval(WEB_SERIAL_PROBE_SCRIPT)
+    document::eval(&web_serial_probe_script())
         .join::<String>()
         .await
         .map(|probe| WebSerialCapability::from_probe(&probe))
@@ -948,15 +955,12 @@ mod tests {
 
     #[test]
     fn web_serial_probe_script_speaks_the_model_wire_spellings() {
-        use super::super::model::{
-            WEB_SERIAL_PROBE_ANDROID_BLUETOOTH_ONLY, WEB_SERIAL_PROBE_SUPPORTED,
-        };
+        let script = web_serial_probe_script();
 
-        assert!(WEB_SERIAL_PROBE_SCRIPT.contains("window.isSecureContext"));
-        assert!(WEB_SERIAL_PROBE_SCRIPT.contains("navigator.serial.requestPort"));
-        assert!(WEB_SERIAL_PROBE_SCRIPT.contains(&format!("\"{WEB_SERIAL_PROBE_SUPPORTED}\"")));
-        assert!(WEB_SERIAL_PROBE_SCRIPT
-            .contains(&format!("\"{WEB_SERIAL_PROBE_ANDROID_BLUETOOTH_ONLY}\"")));
+        assert!(script.contains("window.isSecureContext"));
+        assert!(script.contains("navigator.serial.requestPort"));
+        assert!(script.contains(&format!("\"{WEB_SERIAL_PROBE_SUPPORTED}\"")));
+        assert!(script.contains(&format!("\"{WEB_SERIAL_PROBE_ANDROID_BLUETOOTH_ONLY}\"")));
     }
 
     #[test]

--- a/docs/website/src/pages/flash/model.rs
+++ b/docs/website/src/pages/flash/model.rs
@@ -369,8 +369,12 @@ mod tests {
 
     #[test]
     fn blocked_capabilities_explain_themselves_and_working_states_stay_silent() {
-        assert!(WebSerialCapability::Checking.blocked_explanation().is_none());
-        assert!(WebSerialCapability::Supported.blocked_explanation().is_none());
+        assert!(WebSerialCapability::Checking
+            .blocked_explanation()
+            .is_none());
+        assert!(WebSerialCapability::Supported
+            .blocked_explanation()
+            .is_none());
 
         let android = WebSerialCapability::AndroidBluetoothOnly
             .blocked_explanation()

--- a/docs/website/src/pages/flash/model.rs
+++ b/docs/website/src/pages/flash/model.rs
@@ -31,16 +31,40 @@ pub(super) enum DestructiveConfirmation {
     Confirmed,
 }
 
+pub(super) const WEB_SERIAL_PROBE_SUPPORTED: &str = "supported";
+pub(super) const WEB_SERIAL_PROBE_ANDROID_BLUETOOTH_ONLY: &str = "android-bluetooth-only";
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(super) enum WebSerialCapability {
     Checking,
     Supported,
+    AndroidBluetoothOnly,
     Unavailable,
 }
 
 impl WebSerialCapability {
     pub(super) const fn permits_esp_flash(self) -> bool {
         matches!(self, Self::Supported)
+    }
+
+    pub(super) fn from_probe(probe: &str) -> Self {
+        match probe {
+            WEB_SERIAL_PROBE_SUPPORTED => Self::Supported,
+            WEB_SERIAL_PROBE_ANDROID_BLUETOOTH_ONLY => Self::AndroidBluetoothOnly,
+            _ => Self::Unavailable,
+        }
+    }
+
+    pub(super) const fn blocked_explanation(self) -> Option<&'static str> {
+        match self {
+            Self::Checking | Self::Supported => None,
+            Self::AndroidBluetoothOnly => Some(
+                "Web Serial on this Android browser reaches Bluetooth serial devices only, so a USB-connected board never appears in the port picker. Use desktop Chrome or Edge, or the standalone CLI.",
+            ),
+            Self::Unavailable => Some(
+                "Web Serial is unavailable in this browser or context. Open this page in current Chrome or Edge over HTTPS, or use the standalone CLI.",
+            ),
+        }
     }
 }
 
@@ -306,6 +330,7 @@ mod tests {
     #[test]
     fn web_serial_capability_fails_closed_until_support_is_proven() {
         assert!(!WebSerialCapability::Checking.permits_esp_flash());
+        assert!(!WebSerialCapability::AndroidBluetoothOnly.permits_esp_flash());
         assert!(!WebSerialCapability::Unavailable.permits_esp_flash());
         assert!(WebSerialCapability::Supported.permits_esp_flash());
     }
@@ -320,5 +345,44 @@ mod tests {
         assert!(WifiAction::for_install_mode(InstallMode::EraseAll) == WifiAction::Clear);
         assert_eq!(InstallMode::PreserveData.wire(), "preserve-data");
         assert_eq!(InstallMode::EraseAll.wire(), "erase-all");
+    }
+
+    #[test]
+    fn web_serial_probe_spellings_parse_and_unknown_probes_fail_closed() {
+        assert!(matches!(
+            WebSerialCapability::from_probe(WEB_SERIAL_PROBE_SUPPORTED),
+            WebSerialCapability::Supported
+        ));
+        assert!(matches!(
+            WebSerialCapability::from_probe(WEB_SERIAL_PROBE_ANDROID_BLUETOOTH_ONLY),
+            WebSerialCapability::AndroidBluetoothOnly
+        ));
+        assert!(matches!(
+            WebSerialCapability::from_probe("invented"),
+            WebSerialCapability::Unavailable
+        ));
+        assert!(matches!(
+            WebSerialCapability::from_probe(""),
+            WebSerialCapability::Unavailable
+        ));
+    }
+
+    #[test]
+    fn blocked_capabilities_explain_themselves_and_working_states_stay_silent() {
+        assert!(WebSerialCapability::Checking.blocked_explanation().is_none());
+        assert!(WebSerialCapability::Supported.blocked_explanation().is_none());
+
+        let android = WebSerialCapability::AndroidBluetoothOnly
+            .blocked_explanation()
+            .expect("the Android capability explains itself");
+        assert!(android.contains("Bluetooth serial devices only"));
+        assert!(android.contains("USB"));
+        assert!(android.contains("CLI"));
+
+        let unavailable = WebSerialCapability::Unavailable
+            .blocked_explanation()
+            .expect("the unavailable capability explains itself");
+        assert!(unavailable.contains("Chrome or Edge"));
+        assert!(unavailable.contains("CLI"));
     }
 }

--- a/docs/website/src/pages/flash/view.rs
+++ b/docs/website/src/pages/flash/view.rs
@@ -72,14 +72,10 @@ pub(super) fn GuidedFlasher(target: &'static BoardTarget) -> Element {
     use_effect(move || {
         if is_esp && !embedded {
             spawn(async move {
-                if bridge::browser_supported().await {
-                    web_serial.set(WebSerialCapability::Supported);
-                } else {
-                    web_serial.set(WebSerialCapability::Unavailable);
-                    status.set(
-                        "Web Serial is unavailable in this browser or context. Open this page in current Chrome or Edge over HTTPS, or use the standalone CLI."
-                            .to_string(),
-                    );
+                let capability = bridge::web_serial_capability().await;
+                web_serial.set(capability);
+                if let Some(explanation) = capability.blocked_explanation() {
+                    status.set(explanation.to_string());
                 }
             });
         }
@@ -89,6 +85,7 @@ pub(super) fn GuidedFlasher(target: &'static BoardTarget) -> Element {
     let device_operation_active = busy && !preparation_active();
     let browser_ready = !is_esp || web_serial().permits_esp_flash();
     let browser_checking = is_esp && web_serial() == WebSerialCapability::Checking;
+    let browser_android = is_esp && web_serial() == WebSerialCapability::AndroidBluetoothOnly;
     let browser_blocked = is_esp && web_serial() == WebSerialCapability::Unavailable;
     let destructive_action_permitted = destructive_confirmation().permits(install_mode());
     let can_prepare = confirmed()
@@ -455,6 +452,10 @@ pub(super) fn GuidedFlasher(target: &'static BoardTarget) -> Element {
                 } else if browser_checking {
                     div { class: "flash-web-install-message mt-5",
                         "Checking this browser for secure Web Serial support before release preparation is enabled."
+                    }
+                } else if browser_android {
+                    div { class: "flash-web-install-message mt-5",
+                        "This Android browser provides Web Serial for Bluetooth serial devices only; a board connected over USB cannot be selected yet. Wired serial support waits on a new Android system API that only a limited set of devices provides. Desktop Chrome or Edge, or the standalone CLI, provides the same verified release path."
                     }
                 } else if browser_blocked {
                     div { class: "flash-web-install-message mt-5",

--- a/docs/website/web-flasher/browser/specs/guided-flasher.spec.mjs
+++ b/docs/website/web-flasher/browser/specs/guided-flasher.spec.mjs
@@ -634,6 +634,30 @@ test("browser support is feature-detected and T-Echo stays on the signed UF2 rou
   await expect(page.getByText(/device-side verification/i)).toHaveCount(0);
 });
 
+for (const androidPlatform of ["client-hints", "legacy-ua"]) {
+  test(`Android ${androidPlatform} Web Serial explains the wired dead end and stays fail closed`, async ({
+    page,
+  }) => {
+    await installFakeBridge(page, { supported: true, androidPlatform });
+    await selectBoard(page, "xiao-esp32-c6");
+
+    await expect(page.locator("#flash-status")).toContainText(
+      /Bluetooth serial devices only.*never appears in the port picker/i,
+    );
+    await expect(page.getByText(/only a limited set of devices provides/i)).toBeVisible();
+    await page.getByRole("checkbox").check();
+    await expect(page.getByRole("button", { name: "Prepare and verify release" })).toBeDisabled();
+    await expect(page.getByRole("button", { name: "Connect and flash" })).toBeDisabled();
+    expect(await page.evaluate(() => window.__prnsFlashTest.state.readyCount)).toBe(0);
+
+    await page.goto("/flash/t-echo");
+    await appReady(page);
+    await fixtureBuildReady(page);
+    await page.getByRole("checkbox").check();
+    await expect(page.getByRole("button", { name: "Prepare and verify release" })).toBeEnabled();
+  });
+}
+
 test("a Web Serial detection failure keeps ESP preparation and connection fail closed", async ({
   page,
 }) => {

--- a/docs/website/web-flasher/browser/support/fake-bridge.mjs
+++ b/docs/website/web-flasher/browser/support/fake-bridge.mjs
@@ -2,6 +2,7 @@ export async function installFakeBridge(page, overrides = {}) {
   const configuration = {
     supported: true,
     supportDetectionFailure: false,
+    androidPlatform: null,
     failureCode: null,
     pauseAtWriting: false,
     preparationProtocolViolation: false,
@@ -42,6 +43,20 @@ export async function installFakeBridge(page, overrides = {}) {
           configurable: true,
           value: config.supported ? { requestPort: async () => ({}) } : undefined,
         });
+
+    if (config.androidPlatform) {
+      Object.defineProperty(navigator, "userAgentData", {
+        configurable: true,
+        value: config.androidPlatform === "client-hints" ? { platform: "Android" } : undefined,
+      });
+      if (config.androidPlatform === "legacy-ua") {
+        Object.defineProperty(navigator, "userAgent", {
+          configurable: true,
+          value:
+            "Mozilla/5.0 (Linux; Android 16; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Mobile Safari/537.36",
+        });
+      }
+    }
 
     const navigationGuard = (event) => {
       if (!state.active) return;


### PR DESCRIPTION
## The user-visible failure

On Chrome for Android, which has shipped Web Serial over Bluetooth since
137, the flash page lights up as fully supported. A user confirms their
board, prepares and verifies the release, taps Connect and flash, and gets
the serial port picker. Their board, plugged
into the phone's USB port, is never listed. No error, no explanation, nothing
to retry. The page's own status keeps telling them to "Choose the board's USB
serial port in the browser dialog."

Nothing in this repo changed. The regression arrived with the browser: Chrome
for Android now ships `navigator.serial`, so the flash page's feature
detection at `bridge.rs` (`BROWSER_SUPPORT_SCRIPT`) honestly reports support,
and `WebSerialCapability` resolves to `Supported`.

I care about this path specifically because the people I hand Hopspots to
around Lake Chapala mostly reach the flasher from a phone.

## The platform facts

- Chrome for Android ships the Web Serial API for Bluetooth RFCOMM serial
  services only. That shipped in Chrome 137 on Android, and the Intent to
  Ship is explicit that wired ports are excluded: the
  `SerialAllowUsbDevicesForUrls` policy "will be enabled in a future launch
  after Android provides system level support of wired serial ports".
  https://groups.google.com/a/chromium.org/g/blink-dev/c/BqUGCcurReE
- Wired USB serial ports wait on an Android-side Serial API. The Chromium
  blink-dev PSA (February 2026, estimated milestone M149) says that API
  "will become available in 2026Q2 on a limited set of devices".
  https://groups.google.com/a/chromium.org/g/blink-dev/c/yGhvQ6mEmcY
- caniuse marks current Chrome for Android (150) as supported outright, with
  no note about the Bluetooth-only limit: https://caniuse.com/web-serial
- There is no capability query that distinguishes RFCOMM-only Web Serial from
  wired-capable Web Serial. The picker's device filter is invisible to script.

## What this change does

It teaches the page's existing capability model the one platform where the
API exists but wired flashing cannot work, and fails closed with an
explanation instead of a dead-end picker.

- The support script becomes a three-way probe. The secure-context and
  `navigator.serial` feature checks stay primary and unchanged; when they
  pass, the probe additionally reports Android via
  `navigator.userAgentData.platform === "Android"` with a legacy
  UA-string fallback for Chromium derivatives that omit client hints.
- `WebSerialCapability` gains an `AndroidBluetoothOnly` variant. It does not
  permit ESP flashing, exactly like `Unavailable`, so Prepare and Connect
  stay disabled with no other logic touched. The model owns the probe wire
  spellings and the per-state explanation copy; unknown probe values parse to
  `Unavailable`, keeping the fail-closed default.
- The status region and the explanation panel tell the Android user the
  truth: this browser reaches Bluetooth serial devices only, a USB-connected
  board never appears in the picker, wired support waits on an Android
  system API that only a limited set of devices provides, and the CLI or a
  desktop browser gives the same verified release path.
- The T-Echo UF2 route is untouched and stays available on Android; the
  capability probe only runs for Web Serial targets, and a verified UF2
  download works fine in Android Chrome.
- A unit test polices the probe script literal against the model-owned wire
  spellings, in the same style as the existing `FAIL_CLOSED_SCRIPT` and
  contract wire tests.

## The tradeoff, stated plainly

This is deliberate platform detection layered on top of feature detection,
which this page has avoided until now (the Playwright suite even asserts the
unsupported path is not UA sniffing; that assertion still holds, because
feature detection still decides supported versus unavailable). With no
capability signal available, the options were: leave the silent dead end,
hide the flasher on Android without saying why, or gate with an explanation.
I chose the explanation. iOS never needed this because WebKit has no
`navigator.serial` at all, so feature detection already fails closed there
with the existing copy; Android is the only platform where the API is present
but wired ports are unreachable.

Costs I am accepting, and that you may veto:

- When a phone's Chrome really can reach wired ports (the PSA estimates
  M149, riding on an Android Serial API that reaches a limited set of
  devices from 2026Q2), this gate blocks a then-capable browser until it is
  removed. There will still be no feature signal at that point, so removal
  is a manual edit. The comment above the probe script names the removal
  condition.
- "Request desktop site" on Android spoofs both the client-hints platform and
  the UA string, so those users fall through to today's behavior: enabled
  buttons and an empty picker. I did not chase heuristics like
  `maxTouchPoints` to catch them, because those false-positive on
  touch-screen laptops and would disable a working flasher, which is worse.
- If you would rather warn without disabling (in case a Chromium derivative
  quietly enables wired ports early), the switch is small: let
  `permits_esp_flash` accept `AndroidBluetoothOnly` and keep the copy. I
  think fail closed matches the page's character, but it is your call.

## Localization

The flash page's operational copy is hardcoded English; only the
back-navigation labels live in the twelve locale .ftl files. The three new
strings follow that pattern, so no .ftl entries are added. If flash-page copy
is localized later, these ride along with the rest.

## TESTING

What I verified:

- Code reading of the full flash page flow (mod.rs, view.rs, model.rs,
  bridge.rs, contract.rs, release.rs) and the web-flasher bridge, to confirm
  the gate lives where the page already makes support decisions and that no
  other caller consumes `browser_supported()`.
- The platform behavior itself comes from the documents cited above (the
  two Chromium blink-dev threads and caniuse), not from a bench
  reproduction. I do not currently have an Android device on Chrome 150
  with an OTG-wired board to demonstrate the empty picker or the new
  explanation in situ. If you have
  one handy, the probe is the piece worth checking on real hardware.
- New automated coverage, all hardware-free:
  - model.rs: probe parsing (both spellings, unknown values fail closed),
    the new variant fails closed for ESP flashing, and blocked states carry
    explanations while working states stay silent.
  - bridge.rs: the probe script literal contains the model's wire spellings
    and the secure-context and requestPort checks.
  - Playwright: two new guided-flasher scenarios (client-hints Android and
    legacy-UA Android) assert the status and panel explanations, disabled
    Prepare and Connect, zero ready events, and that the T-Echo UF2 route
    stays enabled on the same "Android" browser.

Commands, per the verification ladder:

```console
cargo test --locked -p reticulum-site
npm run install:browser
npm run test:browser
```

What the Playwright scenarios prove is the page's reaction to each probe
outcome under injected platform signals in desktop Chromium; they do not
prove Android itself. The desktop-site spoof path is untested and degrades to
today's behavior by design.
