### PR TITLE
Make interface rollback test deterministic

### DIFF
--- a/prnsd/tests/interfaces_live_apply.rs
+++ b/prnsd/tests/interfaces_live_apply.rs
@@ -200,17 +200,26 @@ fn failed_mutation_apply_restores_saved_configuration_and_runtime() {
     let source = "[reticulum]\nshare_instance = No\n[interfaces]\n";
     fs::write(config.path().join("config"), source).unwrap_or_else(|error| panic!("{error}"));
     let (daemon, record) = launch(&config, &state);
+    let occupied = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+        .unwrap_or_else(|error| panic!("{error}"));
+    let occupied_port = occupied
+        .local_addr()
+        .unwrap_or_else(|error| panic!("{error}"))
+        .port();
 
     let output = Command::new(env!("CARGO_BIN_EXE_prnsd"))
         .args([
             "interfaces",
             "add",
-            "auto-wifi",
+            "tcp-server",
             "--name",
-            "LAN",
-            "--apply",
-            "--config",
+            "Occupied",
+            "--listen-ip",
+            "127.0.0.1",
+            "--listen-port",
         ])
+        .arg(occupied_port.to_string())
+        .args(["--apply", "--config"])
         .arg(config.path())
         .env("PRNSD_STATE_DIR", state.path())
         .output()


### PR DESCRIPTION
## Summary

- Replace the rollback test's environment-dependent AutoInterface failure with a deterministic occupied TCP port.
- Exercise the real configuration save, live runtime apply, runtime rollback, and saved-file rollback path without production fault-injection hooks.

## Root cause

The test assumed that adding an `AutoInterface` would fail during live apply. With all features enabled, that interface is supported and can apply successfully, so the test expected exit code 1 but received exit code 0.

The revised test holds a local TCP listener open and applies a `TCPServerInterface` to the occupied port. Runtime construction therefore fails deterministically while the original empty interface plan remains recoverable.

## Impact

This makes the rollback coverage stable across hosts and feature configurations. Production behavior is unchanged.

## Validation

- `cargo test --all-features --locked --test interfaces_live_apply failed_mutation_apply_restores_saved_configuration_and_runtime -- --nocapture`
- `cargo test --all-features --locked --test interfaces_live_apply`
- `cargo fmt --all --check`
- Repository pre-push validation, tooling registry, and formatting gates

The complete local `cargo test --workspace --all-features --locked` run was also attempted. On this macOS host it stopped in an unrelated `container_cli_context` assertion because an already-running shared instance accepted the test connection; the changed integration test passes independently and as part of its complete test binary.
