### PR TITLE
Configure CodeQL monorepo builds

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,109 @@
+name: codeql
+
+on:
+  push:
+    branches: [main, trunk]
+  pull_request:
+    branches: [main, trunk]
+  schedule:
+    - cron: "29 8 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  packages: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+            runner: ubuntu-latest
+          - language: c-cpp
+            build-mode: none
+            runner: ubuntu-latest
+          - language: csharp
+            build-mode: none
+            runner: ubuntu-latest
+          - language: go
+            build-mode: autobuild
+            runner: ubuntu-latest
+          - language: java-kotlin
+            build-mode: manual
+            runner: ubuntu-latest
+          - language: javascript-typescript
+            build-mode: none
+            runner: ubuntu-latest
+          - language: python
+            build-mode: none
+            runner: ubuntu-latest
+          - language: rust
+            build-mode: none
+            runner: ubuntu-latest
+          - language: swift
+            build-mode: autobuild
+            runner: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          submodules: false
+
+      - name: Set up Java
+        if: matrix.language == 'java-kotlin'
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Android SDK
+        if: matrix.language == 'java-kotlin'
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
+
+      - name: Install Android build dependencies
+        if: matrix.language == 'java-kotlin'
+        run: sdkmanager "platforms;android-34" "build-tools;34.0.0"
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          dependency-caching: true
+
+      - name: Autobuild
+        if: matrix.build-mode == 'autobuild'
+        uses: github/codeql-action/autobuild@d1ba80a13dd99fba24a470575428917156a28b43
+
+      - name: Build Java and Kotlin projects
+        if: matrix.language == 'java-kotlin'
+        run: |
+          ./prns-host/bindings/jvm/gradlew \
+            -p prns-host/bindings/jvm \
+            classes testClasses \
+            --no-daemon
+          ./personal-hopspot/mobile/android/gradlew \
+            -p personal-hopspot/mobile/android \
+            :app:compileDebugKotlin \
+            :app:compileDebugJavaWithJavac \
+            :app:compileDebugAndroidTestKotlin \
+            :app:compileDebugAndroidTestJavaWithJavac \
+            --no-daemon
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/release/flash/action-pins.json
+++ b/release/flash/action-pins.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "verified_at": "2026-07-24",
+  "verified_at": "2026-08-03",
   "actions": {
     "NuGet/login": {
       "resolved_ref": "v1",
@@ -81,6 +81,18 @@
     "docker/setup-buildx-action": {
       "resolved_ref": "v3",
       "sha": "8d2750c68a42422c14e847fe6c8ac0403b4cbd6f"
+    },
+    "github/codeql-action/analyze": {
+      "resolved_ref": "v4.37.5",
+      "sha": "d1ba80a13dd99fba24a470575428917156a28b43"
+    },
+    "github/codeql-action/autobuild": {
+      "resolved_ref": "v4.37.5",
+      "sha": "d1ba80a13dd99fba24a470575428917156a28b43"
+    },
+    "github/codeql-action/init": {
+      "resolved_ref": "v4.37.5",
+      "sha": "d1ba80a13dd99fba24a470575428917156a28b43"
     },
     "julia-actions/setup-julia": {
       "resolved_ref": "v2.7.0",


### PR DESCRIPTION
## Summary

- add an advanced CodeQL workflow for every language detected by default setup
- build both nested Java/Kotlin Gradle projects explicitly
- retain no-build analysis for C/C++, C#, Rust, JavaScript/TypeScript, Python, and Actions
- retain autobuild for Go and Swift on their appropriate runners
- pin CodeQL Action v4.37.5 in the repository action lock

## Root cause

CodeQL default setup detects Kotlin and selects Java/Kotlin autobuild, but the repository has separate Gradle roots under `prns-host/bindings/jvm` and `personal-hopspot/mobile/android`. The root-level autobuilder therefore cannot discover a suitable build command.

## Validation

- `python3 validation/release/workflow-contracts.py`
- workflow YAML parse and `git diff --check`
- JVM `classes testClasses` compilation
- Android main and instrumentation Kotlin/Java compilation
- repository pre-push registry, ownership, formatting, and documentation gates
- [PR CodeQL run](https://github.com/KenAKAFrosty/Prns/actions/runs/30840877244): both Gradle builds passed under CodeQL tracing; GitHub accepted the SARIF upload and then rejected processing solely because Default setup is still enabled

## Activation

GitHub default setup disables advanced CodeQL workflows and blocks their uploads. After this lands on `main`, switch **Settings → Advanced Security → CodeQL analysis** from Default to Advanced so this workflow becomes authoritative.
