### PR TITLE
release: derive acceptance counts from the shipping board set

### DIFF
--- a/docs/release-dependency-audit.md
+++ b/docs/release-dependency-audit.md
@@ -93,6 +93,6 @@ allowlist and cannot contain a runtime CDN or the legacy ESP Web Tools engine.
 - cargo-about 0.9.1
 - cargo-geiger 0.13.0 (advisory evidence)
 
-OS/hardware acceptance—including the complete web/CLI four-board matrix and every published CLI
+OS/hardware acceptance—including the complete web/CLI five-board matrix and every published CLI
 architecture—must be signed off against the exact signed candidate. The protected promotion job
 validates `acceptance.json`; those physical observations cannot be inferred from CI.

--- a/release/acceptance/README.md
+++ b/release/acceptance/README.md
@@ -3,7 +3,7 @@
 The acceptance record is evidence for one exact signed candidate, not a checklist or a place to
 record intentions. Generate it only after the public prerelease exists. The generator binds the
 manifest, manifest signature, signed-candidate archive, and signed roster by exact identity and
-produces eight physical rows, four unsupported-browser rows, and five native installer rows as
+produces ten physical rows, four unsupported-browser rows, and five native installer rows as
 `not-run`:
 
 ```sh

--- a/release/acceptance/rosters/README.md
+++ b/release/acceptance/rosters/README.md
@@ -1,7 +1,7 @@
 # Flasher tester rosters
 
 Before building the candidate that will be signed, create `VERSION.json` here from
-`../roster-template.json`. It must contain eight physical board/surface assignments, four
+`../roster-template.json`. It must contain ten physical board/surface assignments, four
 Firefox/Safari fallback assignments, and five published-archive installer assignments. The
 physical assignments collectively cover Linux, macOS, and Windows on both surfaces. Use public
 nonsecret identities such as `github:handle`, not email addresses.

--- a/release/flash/README.md
+++ b/release/flash/README.md
@@ -71,7 +71,7 @@ Before signing any candidate:
 - create `release-rollback` with manual release-owner approval and no signing secrets or wait
   timer; rollback jobs only receive the repository public key and read-only release inputs;
 - confirm Actions attestations are available for the repository and `gh attestation verify` works;
-- assign the eight physical, four fallback, and five archive-installation coverage slots to real
+- assign the ten physical, four fallback, and five archive-installation coverage slots to real
   testers across their required hosts; one person may hold multiple or all slots;
 - commit and validate `release/acceptance/rosters/VERSION.json` with those real assignments;
 - review the exact default-branch workflow revisions. Do not dispatch a signing workflow from a

--- a/tools/release/flasher_acceptance_contract.py
+++ b/tools/release/flasher_acceptance_contract.py
@@ -190,7 +190,10 @@ def scaffold(
         isinstance(target, dict) and isinstance(target.get("board_slug"), str)
         for target in raw_targets
     ):
-        raise ValueError("manifest must contain exactly four well-formed targets")
+        raise ValueError(
+            "manifest must contain exactly "
+            f"{len(SHIPPING_BOARDS)} well-formed targets"
+        )
     targets = {
         target.get("board_slug"): target
         for target in raw_targets

--- a/tools/release/flasher_tester_roster.py
+++ b/tools/release/flasher_tester_roster.py
@@ -229,7 +229,10 @@ def validate_physical_assignments(
                 f"{surface} physical assignments do not cover host OSes: {missing_oses}"
             )
     if len(value) != len(required):
-        errors.append("tester roster must contain exactly eight physical assignments")
+        errors.append(
+            "tester roster must contain exactly "
+            f"{len(required)} physical assignments"
+        )
     return assignments
 
 

--- a/tools/release/validate-flasher-tester-roster.py
+++ b/tools/release/validate-flasher-tester-roster.py
@@ -12,7 +12,13 @@ SCRIPT_DIRECTORY = Path(__file__).resolve().parent
 if str(SCRIPT_DIRECTORY) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIRECTORY))
 
-from flasher_acceptance_contract import CLI_TARGETS, SHIPPING_BOARDS  # noqa: E402,F401
+from flasher_acceptance_contract import (  # noqa: E402,F401
+    CLI_TARGETS,
+    OS_ARCHITECTURES,
+    REQUIRED_FALLBACKS,
+    SHIPPING_BOARDS,
+    SURFACES,
+)
 from flasher_tester_roster import validate_roster  # noqa: E402
 
 
@@ -41,7 +47,11 @@ def main() -> int:
         for error in errors:
             print(f"tester roster validation failed: {error}", file=sys.stderr)
         return 1
-    print("tester roster covers eight physical, four fallback, and five installer assignments")
+    print(
+        f"tester roster covers {len(SHIPPING_BOARDS) * len(SURFACES)} physical, "
+        f"{len(REQUIRED_FALLBACKS)} fallback, and "
+        f"{len(OS_ARCHITECTURES)} installer assignments"
+    )
     return 0
 
 

--- a/tools/tests/test_create_flasher_acceptance.py
+++ b/tools/tests/test_create_flasher_acceptance.py
@@ -239,7 +239,7 @@ class AcceptanceScaffoldTests(unittest.TestCase):
         self.manifest_path.write_text(
             json.dumps(self.manifest_document, sort_keys=True) + "\n", encoding="utf-8"
         )
-        with self.assertRaisesRegex(ValueError, "exactly four well-formed targets"):
+        with self.assertRaisesRegex(ValueError, "well-formed targets"):
             self.create()
 
     def test_prerelease_publication_requires_full_utc_timestamp(self) -> None:


### PR DESCRIPTION
The acceptance validators compute how many rows they require, then report a stale literal, so a
roster that fails is told to supply the wrong number.

`flasher_acceptance_contract.py:189` compares against `len(SHIPPING_BOARDS)`, which is five since
`heltec-v4-r8` landed, and then raises `exactly four well-formed targets`.
`flasher_tester_roster.py:231` compares against the `SHIPPING_BOARDS` by `SURFACES` product, ten,
and reports `exactly eight physical assignments`. `validate-flasher-tester-roster.py:44` prints the
same stale eight on success.

Each message now derives from the constant its own check already uses, so the two cannot drift
apart again. Rendered today:

```
manifest must contain exactly 5 well-formed targets
tester roster must contain exactly 10 physical assignments
tester roster covers 10 physical, 4 fallback, and 5 installer assignments
```

Four prose counts are corrected to match. One deliberate omission:
`docs/website/web-flasher/browser/README.md` still says four-board, because that is the pinned
0.2.6 fixture rather than the shipping matrix, so it is correct as written.

The duplicate-target test drops the count from its regex. It exercises duplicate rejection, not
arithmetic.

No behaviour change. Every check compared the same values before and after; only the text a human
reads is different.

Verified on this branch:

```
python -m unittest tools.tests.test_create_flasher_acceptance   ->  7 tests, OK
./tools/prns verify                                            ->  TOOLING_REGISTRY_OK
python validation/run.py verify                                ->  VALIDATION_REGISTRY_OK
```

Not run: the embedded and platform suites, since nothing here touches firmware or the site. I also
saw two pre-existing errors in `tools.tests.test_task_runner`
(`test_cargo_tools_is_a_thin_task_runner_alias` and `test_verify_output_explains_guarantees`) which
reproduce identically on unmodified trunk at the same commit on a Windows host, so they are not
from this change. Happy to open a separate issue with the output if that is useful.
