### PR TITLE
hardening: install the native packages the sanitizers need

### DIFF
--- a/.github/workflows/hardening.yml
+++ b/.github/workflows/hardening.yml
@@ -28,6 +28,8 @@ jobs:
         sanitizer: [address, leak, thread]
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - name: Install Linux native development packages
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
       - id: toolchain
         run: echo "nightly=$(python3 validation/run.py toolchain nightly)" >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4


### PR DESCRIPTION
The hardening workflow's three sanitizer jobs have failed on both runs the workflow has
ever had (2026-07-27 and 2026-08-03), and in both cases they died before any sanitizer
executed: `libdbus-sys`'s build script exits because `pkg-config` can't find `dbus-1`
while building the cross-crate integration crate. `ci.yml` installs `libdbus-1-dev` and
`pkg-config` in three separate jobs for exactly this reason; `hardening.yml` installs
nothing. miri and unsafe-inventory pass today only because neither builds that crate.

This adds the same install step ci.yml already uses to the one job that needs it.

Proof run on my fork (run 30936426899): leak passes for the first time in the
workflow's history, thread passes, miri passes, and address runs to completion for the
first time. Address then failed on a real pre-existing race in the native upload path
that the sanitizer's slowdown exposes about 2% of the time; that one's a separate
one-line fix I'm sending alongside this. With both applied, the address suite passes
300 of 300 stress iterations on my bench.
