### PR TITLE
upload: report the overrun before waking the worker

### DIFF
--- a/prns-host/impls/native/src/lib.rs
+++ b/prns-host/impls/native/src/lib.rs
@@ -514,9 +514,9 @@ impl NativeUpload {
         if written.saturating_add(length) > self.declared_length {
             self.finished.store(true, Ordering::Release);
             self.cancelled.store(true, Ordering::Release);
-            chunks.take();
             self.completion
                 .finish(Err(CommandFailure::ResourceLengthOverrun));
+            chunks.take();
             return Err(UploadWriteError::LengthOverrun);
         }
         let sender = chunks.as_ref().ok_or(UploadWriteError::Finished)?;


### PR DESCRIPTION
While proving out the hardening workflow fix I hit an intermittent failure in the C ABI
suite under the address sanitizer: `tests::creation_gates_contract_and_lifecycle` panics
with `left: 34, right: 36`, which is `ResourceUploadCancelled` where the test expects
`ResourceLengthOverrun`.

It turned out to be a real race in `NativeUpload::write`, not a sanitizer artifact. The
overrun branch drops the chunk sender before it records its verdict on the completion:

- dropping the sender EOFs the upload worker's source mid-resource
- the worker sees `cancelled` already set, maps the EOF to `ResourceUploadCancelled`,
  and calls `finish`
- `CommandCompletion::finish` is first-wins, so whichever thread gets there first
  decides the failure kind the command reports

Normally the writer wins by a mile. Slow it down and it loses: under ASan the suite
failed 5 of 300 stress runs, and a 50ms sleep inserted between the `take` and the
`finish` makes it fail every time with no sanitizer at all.

The fix is to latch the completion before dropping the sender, so the worker's later
`finish` is a no-op. One statement moves two lines up. The early-eof and abort paths
already agree with their racing worker (both sides produce the same kind), so they're
unchanged.

Verified on Linux x86_64:

- plain: `cargo test --locked --lib` in `prns-host/abi/c`, 10/10 pass
- ASan, same flags the hardening workflow uses (`nightly-2025-11-21`, `-Zbuild-std`,
  `-Zsanitizer=address`): full suite passes, and the previously flaky test goes
  0 failures in 300 stress iterations, from 5 in 300 without the change

The native crate's own `upload_reports_overrun_and_early_eof` can't catch this one: it
builds the upload with `isolated_upload()`, which never spawns a worker, so there's
nobody to race.
