### PR TITLE
validation: compile and test prns-core in the alloc-only shape

### DIFF
--- a/prns-core/src/routing/links/channel/table/impls/heap.rs
+++ b/prns-core/src/routing/links/channel/table/impls/heap.rs
@@ -387,6 +387,7 @@ mod tests {
         assert_eq!(table.earliest_tx_timeout_at(), Some(InstantMillis(3_000)));
     }
 
+    #[cfg(feature = "std")]
     fn outstanding(byte: u8, command: u64) -> OutstandingSend<'static> {
         OutstandingSend {
             packet_hash: PacketHash::new([byte; 32]),

--- a/prns-core/src/routing/path_requests/recent/core.rs
+++ b/prns-core/src/routing/path_requests/recent/core.rs
@@ -116,6 +116,7 @@ mod tests {
         DestinationHash::new([byte; 16])
     }
 
+    #[cfg(feature = "std")]
     fn dest_n(value: u64) -> DestinationHash {
         let mut bytes = [0; 16];
         bytes[..8].copy_from_slice(&value.to_le_bytes());

--- a/prns-core/src/routing/path_requests/recursive/core.rs
+++ b/prns-core/src/routing/path_requests/recursive/core.rs
@@ -153,14 +153,15 @@ impl<C: RecursivePathRequestTable> RecursivePathRequests<C> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::routing::path_requests::recursive::{
-        FixedRecursivePathRequestTable, HeapRecursivePathRequestTable,
-    };
+    use crate::routing::path_requests::recursive::FixedRecursivePathRequestTable;
+    #[cfg(feature = "std")]
+    use crate::routing::path_requests::recursive::HeapRecursivePathRequestTable;
 
     fn dest(byte: u8) -> DestinationHash {
         DestinationHash::new([byte; 16])
     }
 
+    #[cfg(feature = "std")]
     fn dest_n(value: u64) -> DestinationHash {
         let mut bytes = [0; 16];
         bytes[..8].copy_from_slice(&value.to_le_bytes());

--- a/prns-core/src/storage/impls/growable_heap.rs
+++ b/prns-core/src/storage/impls/growable_heap.rs
@@ -98,6 +98,7 @@ mod tests {
     use crate::routing::announce::stored::AnnounceRecordTable;
     use crate::routing::blackhole::{BlackholeTable, HeapBlackholeTable};
     use crate::routing::dedup::PacketHashHistory;
+    #[cfg(feature = "std")]
     use crate::routing::route_expiry::RouteExpiryIndex;
     use crate::routing::routes::RouteTable;
     use crate::routing::upstream_app_destinations::UpstreamAppDestinationTable;
@@ -125,6 +126,11 @@ mod tests {
             <GrowableHeap as StorageLayout>::LIMITS.blackholed_identities,
             StorageCapacity::Dynamic
         );
+        // The indexed expiry table is the roaring one, and that module is only compiled under
+        // `std`. Without it `RouteExpiries` is the linear fallback, whose `INDEXED` is false, so
+        // asserting unconditionally makes this test fail to compile in the alloc-only shape the
+        // embedded boards ship rather than fail at runtime.
+        #[cfg(feature = "std")]
         const {
             assert!(<<GrowableHeap as StorageLayout>::RouteExpiries as RouteExpiryIndex>::INDEXED);
         }

--- a/validation/manifest.toml
+++ b/validation/manifest.toml
@@ -432,6 +432,18 @@ inputs = ["Cargo.toml", "Cargo.lock", ".cargo/config.toml", "personal-rns/Cargo.
 artifacts = "validation-artifacts/results/guide-rust"
 
 [[suite]]
+id = "alloc-only"
+domain = "native"
+group = "feature-config"
+tiers = ["pr", "release", "scheduled"]
+platform = "any"
+toolchain = "stable"
+timeout_seconds = 1200
+command = ["bash", "validation/native/alloc-only.sh"]
+inputs = ["validation/native/alloc-only.sh", "Cargo.toml", "Cargo.lock", "prns-core/Cargo.toml", "prns-core/src"]
+artifacts = "validation-artifacts/results/alloc-only"
+
+[[suite]]
 id = "external-alloc"
 domain = "native"
 group = "feature-config"

--- a/validation/native/alloc-only.sh
+++ b/validation/native/alloc-only.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$root"
+
+# The shape the embedded boards actually ship: no std, alloc plus the caller-chosen heap region.
+# external-alloc.sh keeps the default features, so `std` stays on there and this configuration is
+# never compiled by any registered suite.
+cargo clippy -p prns-core --no-default-features --features alloc,external-alloc --all-targets --locked -- -D warnings
+cargo test -p prns-core --no-default-features --features alloc,external-alloc --locked
+
+echo "ALLOC_ONLY_GATE_OK"


### PR DESCRIPTION
`validation/native/external-alloc.sh` runs `cargo` without `--no-default-features`, so `std` stays
on and the suite adds `external-alloc` on top of an ordinary host build. No registered suite
compiles `prns-core` the way the ESP32 boards ship it, which is no `std`, `alloc` plus a
caller-chosen heap region.

That configuration does not currently compile. It is not a test failure, it is `E0080` while
building the lib test target:

```
error[E0080]: evaluation panicked: assertion failed:
  <<GrowableHeap as StorageLayout>::RouteExpiries as RouteExpiryIndex>::INDEXED
  --> prns-core/src/storage/impls/growable_heap.rs:129:13
  in storage::impls::growable_heap::tests::bundles_dynamic_heap_backends
```

`INDEXED` is only true for `RoaringRouteExpiryIndex`, and that module is `#[cfg(feature = "std")]`
in `routing/route_expiry/impls/mod.rs`. Without `std` the layout falls back to the linear index
where `INDEXED` is false, so the unconditional `const` assertion fails at compile time. Three test
helpers and two imports used only by `std`-gated tests then warn as unused once it does build,
which the suite's `-D warnings` would reject.

Six `#[cfg(feature = "std")]` gates fix it: the assertion, the two imports, and the three helpers.
No production code changes.

Results:

```
alloc-only                      1426 passed, 0 failed   (previously did not compile)
default + external-alloc        1478 passed, 0 failed   (unchanged)
```

The 52-test difference is exactly the `std`-gated set.

Registered as `alloc-only` in the `pr` tier next to `external-alloc`, taking the registry from 101
suites to 102, so this shape cannot silently stop compiling again.

Verified on this branch, rebased onto trunk at `e7e5e0a0`:

```
python3 validation/run.py verify                     ->  VALIDATION_REGISTRY_OK, 102 suites
python3 validation/run.py run --suite alloc-only     ->  ALLOC_ONLY_GATE_OK, 1426 passed
cargo clippy -p prns-core --features external-alloc --all-targets --locked -- -D warnings  ->  clean
cargo test   -p prns-core --features external-alloc --locked                               ->  1478 passed
```

The `alloc-only` suite runs the no-default-features clippy and test itself, both with `-D warnings`.

Not run: the embedded, platform and interop suites, since nothing here leaves `prns-core` and the
validation registry. Both clippy and test runs were on Linux under WSL.

Happy to split the `cfg` gates and the suite registration into separate commits if you would rather
review them apart.
