### PR TITLE
engine: match the fleet test's if-let in the local announce test

### DIFF
--- a/prns-core/src/engine/node_egress/fanout.rs
+++ b/prns-core/src/engine/node_egress/fanout.rs
@@ -155,13 +155,13 @@ mod tests {
             AttachedInterfaces::new(&interfaces),
             FanTarget::All,
             &[0xAB],
-            &mut |reaction| match reaction {
-                EngineReaction::Directive(Directive::SendAnnounce {
+            &mut |reaction| {
+                if let EngineReaction::Directive(Directive::SendAnnounce {
                     target, hops: 0, ..
-                }) => {
+                }) = reaction
+                {
                     targets.push(target);
                 }
-                _ => {}
             },
         );
 


### PR DESCRIPTION
The `clippy` and `feature-configs` jobs have both been failing on trunk since `59c122e1`. Run
30949636599 at `a2bd0d82` is the latest, and both jobs stop at the same place:

```
error: you seem to be trying to use `match` for destructuring a single pattern.
Consider using `if let`
  --> prns-core/src/engine/node_egress/fanout.rs:158:29
```

The sink closure in `local_announces_use_every_mode_except_access_point` has one real arm and a
`_ => {}` fallback, which trips `clippy::single_match` under `-D warnings`.

The two tests directly below it already destructure their reaction with `if let`, so this uses
their shape rather than introducing a new one. The assertion and the behaviour under test are
unchanged.

Verified on Linux x86_64 against trunk at `a2bd0d82`:

- before: `cargo clippy --workspace --all-targets --locked -- -D warnings` exits 101 on this one
  error
- after: the same command exits 0, so nothing else is queued behind it
- `cargo test -p prns-core --lib local_announces` passes both tests

Happy for you to just take the diff if that's faster than merging a PR mid-release.
