### PR TITLE
release: correct the stale physical row count in the acceptance README

### DIFF
--- a/release/acceptance/README.md
+++ b/release/acceptance/README.md
@@ -23,7 +23,7 @@ results, and any candidate identity that differs from those three exact files.
 
 ## Physical runs
 
-`runs` contains exactly one result for every shipping board and surface (`web` or `cli`): eight
+`runs` contains exactly one result for every shipping board and surface (`web` or `cli`): ten
 rows. The signed roster assigns each row to one supported host, with Linux, macOS, and Windows
 collectively represented on both surfaces. One person may hold multiple or all assignments; an
 assignment is a coverage obligation, not a distinct-person requirement. Each row records:


### PR DESCRIPTION
The Physical runs section still says eight rows, from when four boards shipped. `heltec-v4-r8` joined `SHIPPING_BOARDS` after that, and both the generator and the validator derive the count from `SHIPPING_BOARDS` x `SURFACES`, so it is ten.

Line 6 of the same file already says ten, as do `rosters/README.md` and `flash/README.md`. The roster validator prints it directly:

```
$ ./tools/prns release tester-roster validate -- \
    --roster release/acceptance/rosters/0.3.3.json --version 0.3.3
tester roster covers 10 physical, 4 fallback, and 5 installer assignments
```

Only the one number changes.

Gates on Windows: `python validation/run.py verify` gives `VALIDATION_REGISTRY_OK`, `./tools/prns verify` gives `TOOLING_REGISTRY_OK`.

Found this while going through QUALIFICATION.md to prep the 0.3.3 rows. One thing worth mentioning: the count is restated as prose in four places, so it will drift again the next time a board ships. Happy to follow up separately if you would rather those pointed at the derived value instead.