### PR TITLE
flash-manifest: read UF2 bootloader identity from the catalog instead of hardcoding it

### DIFF
--- a/docs/website/src/pages/flash/model.rs
+++ b/docs/website/src/pages/flash/model.rs
@@ -176,7 +176,7 @@ pub(super) fn preparation_guide(
             ],
         },
         PreparationProfile::TechoUf2 => PreparationGuide {
-            lead: "T-Echo uses its UF2 bootloader; the website only verifies and downloads the UF2 file.",
+            lead: "This board uses its UF2 bootloader; the website only verifies and downloads the UF2 file.",
             steps: match target {
                 BoardFlashTarget::Uf2MassStorage { mount_label } => vec![
                     "Prepare the verified UF2 here before entering bootloader mode.".to_string(),

--- a/personal-hopspot/flasher/src/cli.rs
+++ b/personal-hopspot/flasher/src/cli.rs
@@ -95,7 +95,7 @@ pub(crate) enum CommandMode {
             conflicts_with_all = ["version", "offline", "local_build"]
         )]
         candidate: Option<PathBuf>,
-        /// Explicit mounted TECHOBOOT directory.
+        /// Explicit mounted UF2 bootloader directory.
         #[arg(long, value_name = "DIR", hide = true)]
         mount: Option<PathBuf>,
     },

--- a/personal-hopspot/flasher/src/error.rs
+++ b/personal-hopspot/flasher/src/error.rs
@@ -91,7 +91,7 @@ impl PreflightError {
                 "Reconnect the device in bootloader mode and verify the selected board before retrying."
             }
             Self::Uf2Mount(_) => {
-                "Double-tap RESET, wait for exactly one TECHOBOOT drive, then retry."
+                "Double-tap RESET, wait for exactly one bootloader drive, then retry."
             }
             Self::Monitor(_) => {
                 "Close other serial tools, reconnect the device, and start monitoring again."
@@ -158,7 +158,7 @@ impl WriteVerifyResetError {
     const fn recovery(&self) -> &'static str {
         match self {
             Self::Uf2Delivery(_) => {
-                "Return the T-Echo to TECHOBOOT, then copy the complete verified UF2 again."
+                "Return the board to its bootloader drive, then copy the complete verified UF2 again."
             }
             Self::Write(_) | Self::Verify(_) | Self::Reset(_) | Self::DeviceLost(_) => {
                 "Hold BOOT, tap RESET, release BOOT, then restart the complete sparse flash operation."

--- a/personal-hopspot/flasher/src/main.rs
+++ b/personal-hopspot/flasher/src/main.rs
@@ -6,8 +6,8 @@ mod esp;
 mod events;
 mod release;
 mod splash;
-mod techo;
 mod toolchain;
+mod uf2;
 mod ui;
 mod wifi;
 
@@ -279,11 +279,12 @@ fn execute_flash(
         ),
         (Transport::Uf2MassStorage, PreparedTarget::Uf2(prepared)) => {
             if !matches!(request.provisioning, ProvisioningAction::Preserve) {
-                return Err(AppError::unsupported_operation(
-                    "T-Echo does not support Wi-Fi provisioning",
-                ));
+                return Err(AppError::unsupported_operation(format!(
+                    "{} does not support Wi-Fi provisioning",
+                    board.display_name
+                )));
             }
-            techo::flash(board, &prepared, request.mount, reporter)
+            uf2::flash(board, &prepared, request.mount, reporter)
         }
         _ => Err(AppError::trust_identity(
             "prepared artifact transport does not match the selected board",
@@ -495,7 +496,7 @@ fn doctor(
         && requested_port.is_some()
     {
         return Err(AppError::unsupported_operation(
-            "--port applies only to ESP serial boards; T-Echo uses the TECHOBOOT drive",
+            "--port applies only to ESP serial boards; UF2 boards use a bootloader drive",
         ));
     }
     if board.is_some() {
@@ -507,7 +508,7 @@ fn doctor(
     } else {
         esp::diagnostic_ports()?
     };
-    let detected_mounts = techo::detect_mounts();
+    let detected_mounts = uf2::detect_any_uf2_mounts(catalog);
     let check = match board {
         Some(board) if board.transport == Transport::EspSerial => {
             if !json {
@@ -533,8 +534,8 @@ fn doctor(
                 note,
             })
         }
-        Some(_board) => {
-            let mount = techo::doctor_mount_from(detected_mounts.clone())?;
+        Some(board) => {
+            let mount = uf2::doctor_mount_from(detected_mounts.clone(), board)?;
             Some(DoctorCheck::Uf2MassStorage {
                 mount: mount.display().to_string(),
             })
@@ -600,7 +601,7 @@ fn human_doctor_output(
         }
     }
     if board.is_none_or(|board| board.transport == Transport::Uf2MassStorage) {
-        rendered.push_str("TECHOBOOT mounts:\n");
+        rendered.push_str("UF2 bootloader mounts:\n");
         if output.techo_mounts.is_empty() {
             rendered.push_str("  none\n");
         }
@@ -626,7 +627,7 @@ fn human_doctor_output(
         }
         Some(DoctorCheck::Uf2MassStorage { mount }) => {
             rendered.push_str("non-writing UF2 preflight: passed\n");
-            rendered.push_str(&format!("  identifiable TECHOBOOT mount: {mount}\n"));
+            rendered.push_str(&format!("  identifiable UF2 bootloader mount: {mount}\n"));
         }
         None => {}
     }
@@ -725,7 +726,7 @@ mod doctor_tests {
         let catalog = board_catalog().expect("catalog");
         assert!(matches!(
             doctor(&catalog, Some("t-echo"), Some("unused-port"), true),
-            Err(AppError::Usage(message)) if message.to_string().contains("TECHOBOOT")
+            Err(AppError::Usage(message)) if message.to_string().contains("bootloader drive")
         ));
     }
 
@@ -843,7 +844,7 @@ mod doctor_tests {
 
         assert_eq!(
             human_doctor_output(&output, Some(board), None),
-            "board: t-echo\nTECHOBOOT mounts:\n  /media/operator/TECHOBOOT\nnon-writing UF2 preflight: passed\n  identifiable TECHOBOOT mount: /media/operator/TECHOBOOT\n"
+            "board: t-echo\nUF2 bootloader mounts:\n  /media/operator/TECHOBOOT\nnon-writing UF2 preflight: passed\n  identifiable UF2 bootloader mount: /media/operator/TECHOBOOT\n"
         );
     }
 }

--- a/personal-hopspot/flasher/src/uf2.rs
+++ b/personal-hopspot/flasher/src/uf2.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
-use prns_flash_manifest::BoardCatalogEntry;
+use prns_flash_manifest::{BoardBuild, BoardCatalog, BoardCatalogEntry, Uf2BoardIdPrefix, Uf2Build};
 
 use crate::error::AppError;
 use crate::events::{Phase, Reporter};
@@ -23,7 +23,9 @@ pub(crate) fn flash(
     mount_override: Option<&Path>,
     reporter: Reporter,
 ) -> Result<(), AppError> {
-    let mount = select_mount(detect_mounts(), mount_override)?;
+    let build = uf2_build(board)?;
+    let mount_label = build.mount_label.as_str();
+    let mount = select_mount(board, detect_mounts_for(board)?, mount_override)?;
 
     let destination = mount.join("prns-hopspot.uf2");
     reporter.phase(
@@ -36,6 +38,7 @@ pub(crate) fn flash(
         &mount,
         target.part().bytes(),
         &board.slug,
+        mount_label,
         reporter,
     )?;
 
@@ -43,16 +46,19 @@ pub(crate) fn flash(
         reporter.phase(
             Phase::Resetting,
             Some(&board.slug),
-            "Waiting for TECHOBOOT to disappear as the device reboots…",
+            &format!("Waiting for {mount_label} to disappear as the device reboots…"),
         );
-        wait_for_reboot(&mount, REBOOT_TIMEOUT, Duration::from_millis(200))?;
+        wait_for_reboot(&mount, mount_label, REBOOT_TIMEOUT, Duration::from_millis(200))?;
     }
     if crate::esp::cancelled() {
         return Err(AppError::Cancelled);
     }
     reporter.success(
         &board.slug,
-        "Verified UF2 delivered and the T-Echo bootloader drive rebooted.",
+        &format!(
+            "Verified UF2 delivered and the {} bootloader drive rebooted.",
+            board.display_name
+        ),
     );
     Ok(())
 }
@@ -62,6 +68,7 @@ fn copy_uf2(
     mount: &Path,
     bytes: &[u8],
     board_slug: &str,
+    mount_label: &str,
     reporter: Reporter,
 ) -> Result<Uf2CopyOutcome, AppError> {
     let mut output = OpenOptions::new()
@@ -70,7 +77,7 @@ fn copy_uf2(
         .write(true)
         .open(destination)
         .map_err(|error| {
-            AppError::uf2_delivery(format!("could not create UF2 on TECHOBOOT: {error}"))
+            AppError::uf2_delivery(format!("could not create UF2 on {mount_label}: {error}"))
         })?;
     let mut written = 0usize;
     for chunk in bytes.chunks(64 * 1024) {
@@ -96,6 +103,7 @@ fn copy_uf2(
         return confirm_reboot_after_synchronization_interruption(
             mount,
             board_slug,
+            mount_label,
             reporter,
             "UF2 flush/sync failed",
             error,
@@ -107,8 +115,9 @@ fn copy_uf2(
         return confirm_reboot_after_synchronization_interruption(
             mount,
             board_slug,
+            mount_label,
             reporter,
-            "TECHOBOOT directory sync failed",
+            &format!("{mount_label} directory sync failed"),
             error,
             REBOOT_TIMEOUT,
             Duration::from_millis(200),
@@ -117,9 +126,11 @@ fn copy_uf2(
     Ok(Uf2CopyOutcome::Synchronized)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn confirm_reboot_after_synchronization_interruption(
     mount: &Path,
     board_slug: &str,
+    mount_label: &str,
     reporter: Reporter,
     operation: &str,
     error: std::io::Error,
@@ -129,16 +140,21 @@ fn confirm_reboot_after_synchronization_interruption(
     reporter.phase(
         Phase::Resetting,
         Some(board_slug),
-        "UF2 synchronization was interrupted; checking whether TECHOBOOT rebooted…",
+        &format!("UF2 synchronization was interrupted; checking whether {mount_label} rebooted…"),
     );
-    match wait_for_reboot(mount, timeout, poll) {
+    match wait_for_reboot(mount, mount_label, timeout, poll) {
         Ok(()) => Ok(Uf2CopyOutcome::RebootObserved),
         Err(AppError::Cancelled) => Err(AppError::Cancelled),
         Err(_) => Err(AppError::uf2_delivery(format!("{operation}: {error}"))),
     }
 }
 
-fn wait_for_reboot(mount: &Path, timeout: Duration, poll: Duration) -> Result<(), AppError> {
+fn wait_for_reboot(
+    mount: &Path,
+    mount_label: &str,
+    timeout: Duration,
+    poll: Duration,
+) -> Result<(), AppError> {
     let deadline = Instant::now() + timeout;
     while mount.exists() && Instant::now() < deadline {
         if crate::esp::cancelled() {
@@ -147,27 +163,30 @@ fn wait_for_reboot(mount: &Path, timeout: Duration, poll: Duration) -> Result<()
         std::thread::sleep(poll);
     }
     if mount.exists() {
-        return Err(AppError::uf2_delivery(
-            "UF2 was synchronized, but TECHOBOOT did not disappear within 20 seconds",
-        ));
+        return Err(AppError::uf2_delivery(format!(
+            "UF2 was synchronized, but {mount_label} did not disappear within 20 seconds"
+        )));
     }
     Ok(())
 }
 
 fn select_mount(
+    board: &BoardCatalogEntry,
     candidates: Vec<PathBuf>,
     mount_override: Option<&Path>,
 ) -> Result<PathBuf, AppError> {
     if let Some(mount) = mount_override {
-        return validate_mount(mount);
+        return validate_mount(board, mount);
     }
+    let mount_label = uf2_build(board)?.mount_label.as_str();
     match candidates.as_slice() {
-        [] => Err(AppError::uf2_mount(
-            "TECHOBOOT is not mounted; double-tap RESET and wait for the drive",
-        )),
-        [mount] => validate_mount(mount),
+        [] => Err(AppError::uf2_mount(format!(
+            "{mount_label} is not mounted; double-tap RESET and wait for the drive"
+        ))),
+        [mount] => validate_mount(board, mount),
         _ => Err(AppError::uf2_mount(format!(
-            "multiple identifiable T-Echo UF2 bootloader drives were found ({}); disconnect or unmount the extras, then retry",
+            "multiple identifiable {} UF2 bootloader drives were found ({}); disconnect or unmount the extras, then retry",
+            board.display_name,
             candidates
                 .iter()
                 .map(|path| path.display().to_string())
@@ -189,19 +208,59 @@ fn sync_mount_directory(_mount: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-pub(crate) fn detect_mounts() -> Vec<PathBuf> {
+fn uf2_build(board: &BoardCatalogEntry) -> Result<&Uf2Build, AppError> {
+    match &board.build {
+        BoardBuild::Uf2(build) => Ok(build),
+        BoardBuild::Esp(_) => Err(AppError::unsupported_operation(
+            "ESP board cannot use the UF2 bootloader engine",
+        )),
+    }
+}
+
+/// Mounts that identify as the selected board, and only that board.
+fn detect_mounts_for(board: &BoardCatalogEntry) -> Result<Vec<PathBuf>, AppError> {
+    Ok(scan(&[uf2_build(board)?.board_id_prefix.as_str()]))
+}
+
+/// Every cataloged UF2 bootloader, for diagnostics that have no selected board.
+pub(crate) fn detect_any_uf2_mounts(catalog: &BoardCatalog) -> Vec<PathBuf> {
+    let prefixes = catalog
+        .boards
+        .iter()
+        .filter_map(|board| match &board.build {
+            BoardBuild::Uf2(build) => Some(build.board_id_prefix.as_str()),
+            BoardBuild::Esp(_) => None,
+        })
+        .collect::<Vec<_>>();
+    scan(&prefixes)
+}
+
+pub(crate) fn doctor_mount_from(
+    candidates: Vec<PathBuf>,
+    board: &BoardCatalogEntry,
+) -> Result<PathBuf, AppError> {
+    let prefix = uf2_build(board)?.board_id_prefix.clone();
+    let candidates = candidates
+        .into_iter()
+        .filter(|path| mount_identity_matches(path, &[prefix.as_str()]))
+        .collect();
+    select_mount(board, candidates, None)
+}
+
+fn scan(prefixes: &[&str]) -> Vec<PathBuf> {
     let mut candidates = Vec::new();
     if let Some(path) = env::var_os("HOPSPOT_TECHOBOOT") {
-        push_if_techo(&mut candidates, PathBuf::from(path));
+        push_if_identified(&mut candidates, PathBuf::from(path), prefixes);
     }
     for root in ["/Volumes", "/mnt", "/media", "/run/media"] {
-        scan_root(Path::new(root), 2, &mut candidates);
+        scan_root(Path::new(root), 2, prefixes, &mut candidates);
     }
     #[cfg(windows)]
     for letter in b'D'..=b'Z' {
-        push_if_techo(
+        push_if_identified(
             &mut candidates,
             PathBuf::from(format!("{}:\\", letter as char)),
+            prefixes,
         );
     }
     candidates.sort();
@@ -209,11 +268,7 @@ pub(crate) fn detect_mounts() -> Vec<PathBuf> {
     candidates
 }
 
-pub(crate) fn doctor_mount_from(candidates: Vec<PathBuf>) -> Result<PathBuf, AppError> {
-    select_mount(candidates, None)
-}
-
-fn scan_root(root: &Path, depth: usize, candidates: &mut Vec<PathBuf>) {
+fn scan_root(root: &Path, depth: usize, prefixes: &[&str], candidates: &mut Vec<PathBuf>) {
     if depth == 0 {
         return;
     }
@@ -223,61 +278,63 @@ fn scan_root(root: &Path, depth: usize, candidates: &mut Vec<PathBuf>) {
     for entry in entries.flatten() {
         let path = entry.path();
         if path.is_dir() {
-            push_if_techo(candidates, path.clone());
-            scan_root(&path, depth - 1, candidates);
+            push_if_identified(candidates, path.clone(), prefixes);
+            scan_root(&path, depth - 1, prefixes, candidates);
         }
     }
 }
 
-fn push_if_techo(candidates: &mut Vec<PathBuf>, path: PathBuf) {
-    if is_techo_mount(&path) {
+fn push_if_identified(candidates: &mut Vec<PathBuf>, path: PathBuf, prefixes: &[&str]) {
+    if mount_identity_matches(&path, prefixes) {
         candidates.push(path);
     }
 }
 
-fn validate_mount(path: &Path) -> Result<PathBuf, AppError> {
-    if is_techo_mount(path) {
+fn validate_mount(board: &BoardCatalogEntry, path: &Path) -> Result<PathBuf, AppError> {
+    if mount_identity_matches(path, &[uf2_build(board)?.board_id_prefix.as_str()]) {
         Ok(path.to_path_buf())
     } else {
         Err(AppError::uf2_mount(format!(
-            "{} does not contain a T-Echo Board-ID in INFO_UF2.TXT",
-            path.display()
+            "{} does not contain a {} Board-ID in INFO_UF2.TXT",
+            path.display(),
+            board.display_name
         )))
     }
 }
 
-fn is_techo_mount(path: &Path) -> bool {
+fn mount_identity_matches(path: &Path, prefixes: &[&str]) -> bool {
     if !path.is_dir() {
         return false;
     }
     let Ok(info) = fs::read_to_string(path.join("INFO_UF2.TXT")) else {
         return false;
     };
-    info.lines().any(|line| {
-        let Some((field, value)) = line.split_once(':') else {
-            return false;
-        };
-        let field = field
-            .chars()
-            .filter(|character| character.is_ascii_alphanumeric())
-            .map(|character| character.to_ascii_lowercase())
-            .collect::<String>();
-        if field != "boardid" {
-            return false;
-        }
+    info.lines().any(|line| board_id_matches(line, prefixes))
+}
 
-        // LilyGO's bootloader identifies this board as
-        // `nRF52840-TEcho-v1`. Accept later hardware revisions while keeping
-        // the model portion exact; a generic UF2 drive or a coincidental mount
-        // label is not sufficient identity.
-        let board_id = value.trim().to_ascii_lowercase().replace('_', "-");
-        let Some(revision) = board_id.strip_prefix("nrf52840-techo-v") else {
-            return false;
-        };
-        !revision.is_empty()
-            && revision
-                .chars()
-                .all(|character| character.is_ascii_alphanumeric() || character == '.')
+fn board_id_matches(line: &str, prefixes: &[&str]) -> bool {
+    let Some((field, value)) = line.split_once(':') else {
+        return false;
+    };
+    let field = field
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .map(|character| character.to_ascii_lowercase())
+        .collect::<String>();
+    if field != "boardid" {
+        return false;
+    }
+    let board_id = Uf2BoardIdPrefix::normalize(value);
+    prefixes.iter().any(|prefix| {
+        // Bootloaders append a hardware revision to the cataloged prefix. Requiring a
+        // non-empty revision keeps a bare prefix, a generic UF2 drive, and a coincidental
+        // mount label from passing as identity.
+        board_id.strip_prefix(prefix).is_some_and(|revision| {
+            !revision.is_empty()
+                && revision
+                    .chars()
+                    .all(|character| character.is_ascii_alphanumeric() || character == '.')
+        })
     })
 }
 
@@ -285,6 +342,14 @@ fn is_techo_mount(path: &Path) -> bool {
 mod tests {
     use super::*;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn t_echo_board() -> BoardCatalogEntry {
+        prns_flash_manifest::board_catalog()
+            .expect("catalog")
+            .board("t-echo")
+            .expect("t-echo")
+            .clone()
+    }
 
     fn temporary_mount(name: &str) -> PathBuf {
         let nonce = SystemTime::now()
@@ -296,7 +361,7 @@ mod tests {
 
     #[test]
     fn absent_override_is_not_accepted() {
-        assert!(validate_mount(Path::new("/definitely/not/a/techo/mount")).is_err());
+        assert!(validate_mount(&t_echo_board(), Path::new("/definitely/not/a/techo/mount")).is_err());
     }
 
     #[test]
@@ -309,7 +374,7 @@ mod tests {
         )
         .expect("write info");
         assert_eq!(
-            doctor_mount_from(vec![mount.clone()]).expect("doctor fake mount"),
+            doctor_mount_from(vec![mount.clone()], &t_echo_board()).expect("doctor fake mount"),
             mount
         );
         assert_eq!(
@@ -324,13 +389,13 @@ mod tests {
     fn mount_label_or_generic_uf2_info_cannot_impersonate_a_t_echo() {
         let labelled = temporary_mount("TECHOBOOT").join("TECHOBOOT");
         fs::create_dir_all(&labelled).expect("create labelled mount");
-        assert!(validate_mount(&labelled).is_err());
+        assert!(validate_mount(&t_echo_board(), &labelled).is_err());
         fs::write(
             labelled.join("INFO_UF2.TXT"),
             "Model: LilyGo T-Echo\nBoard-ID: nRF52840-Feather-revD\n",
         )
         .expect("write generic UF2 identity");
-        assert!(validate_mount(&labelled).is_err());
+        assert!(validate_mount(&t_echo_board(), &labelled).is_err());
         fs::remove_dir_all(labelled.parent().expect("temporary parent"))
             .expect("remove labelled mount");
     }
@@ -344,14 +409,36 @@ mod tests {
             "Board ID: nRF52840_TEcho_v2.1\n",
         )
         .expect("write identity");
-        assert_eq!(validate_mount(&mount).expect("T-Echo identity"), mount);
+        assert_eq!(
+            validate_mount(&t_echo_board(), &mount).expect("T-Echo identity"),
+            mount
+        );
+        fs::remove_dir_all(&mount).expect("remove mount");
+    }
+
+    #[test]
+    fn a_cataloged_prefix_does_not_answer_for_another_board() {
+        let line = "Board-ID: nRF52840-TEcho-v1";
+        assert!(board_id_matches(line, &["nrf52840-techo-v"]));
+        assert!(!board_id_matches(line, &["nrf52840-heltec-t114-v"]));
+        assert!(board_id_matches(
+            line,
+            &["nrf52840-heltec-t114-v", "nrf52840-techo-v"]
+        ));
+
+        let mount = temporary_mount("cross-board");
+        fs::create_dir(&mount).expect("create mount");
+        fs::write(mount.join("INFO_UF2.TXT"), "Board-ID: nRF52840-TEcho-v1\n")
+            .expect("write identity");
+        assert!(!mount_identity_matches(&mount, &["nrf52840-heltec-t114-v"]));
+        assert!(mount_identity_matches(&mount, &["nrf52840-techo-v"]));
         fs::remove_dir_all(&mount).expect("remove mount");
     }
 
     #[test]
     fn zero_and_multiple_mounts_are_explicit_failures() {
         assert!(matches!(
-            doctor_mount_from(Vec::new()),
+            doctor_mount_from(Vec::new(), &t_echo_board()),
             Err(AppError::Preflight(_))
         ));
         let first = temporary_mount("multiple-a");
@@ -361,7 +448,7 @@ mod tests {
             fs::write(mount.join("INFO_UF2.TXT"), "Board-ID: nRF52840-TEcho-v1\n")
                 .expect("write identity");
         }
-        let error = doctor_mount_from(vec![first.clone(), second.clone()])
+        let error = doctor_mount_from(vec![first.clone(), second.clone()], &t_echo_board())
             .expect_err("multiple mounts must be explicit");
         assert!(matches!(error, AppError::Preflight(_)));
         let message = error.to_string();
@@ -381,6 +468,7 @@ mod tests {
             &mount,
             b"signed uf2 bytes",
             "t-echo",
+            "TECHOBOOT",
             Reporter::json_lines(),
         )
         .expect("copy fake UF2");
@@ -402,6 +490,7 @@ mod tests {
         });
         wait_for_reboot(
             &disappearing,
+            "TECHOBOOT",
             Duration::from_millis(100),
             Duration::from_millis(1),
         )
@@ -411,7 +500,7 @@ mod tests {
         let stuck = temporary_mount("stuck");
         fs::create_dir(&stuck).expect("create stuck mount");
         assert!(matches!(
-            wait_for_reboot(&stuck, Duration::ZERO, Duration::from_millis(1)),
+            wait_for_reboot(&stuck, "TECHOBOOT", Duration::ZERO, Duration::from_millis(1)),
             Err(AppError::WriteVerifyReset(_))
         ));
         fs::remove_dir(stuck).expect("remove stuck mount");
@@ -429,6 +518,7 @@ mod tests {
         let outcome = confirm_reboot_after_synchronization_interruption(
             &disappearing,
             "t-echo",
+            "TECHOBOOT",
             Reporter::json_lines(),
             "UF2 flush/sync failed",
             std::io::Error::other("bootloader disconnected"),
@@ -444,6 +534,7 @@ mod tests {
         let result = confirm_reboot_after_synchronization_interruption(
             &stuck,
             "t-echo",
+            "TECHOBOOT",
             Reporter::json_lines(),
             "UF2 flush/sync failed",
             std::io::Error::other("storage failure"),

--- a/personal-hopspot/flasher/src/uf2.rs
+++ b/personal-hopspot/flasher/src/uf2.rs
@@ -4,7 +4,9 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
-use prns_flash_manifest::{BoardBuild, BoardCatalog, BoardCatalogEntry, Uf2BoardIdPrefix, Uf2Build};
+use prns_flash_manifest::{
+    BoardBuild, BoardCatalog, BoardCatalogEntry, Uf2BoardIdPrefix, Uf2Build,
+};
 
 use crate::error::AppError;
 use crate::events::{Phase, Reporter};
@@ -48,7 +50,12 @@ pub(crate) fn flash(
             Some(&board.slug),
             &format!("Waiting for {mount_label} to disappear as the device reboots…"),
         );
-        wait_for_reboot(&mount, mount_label, REBOOT_TIMEOUT, Duration::from_millis(200))?;
+        wait_for_reboot(
+            &mount,
+            mount_label,
+            REBOOT_TIMEOUT,
+            Duration::from_millis(200),
+        )?;
     }
     if crate::esp::cancelled() {
         return Err(AppError::Cancelled);
@@ -361,7 +368,9 @@ mod tests {
 
     #[test]
     fn absent_override_is_not_accepted() {
-        assert!(validate_mount(&t_echo_board(), Path::new("/definitely/not/a/techo/mount")).is_err());
+        assert!(
+            validate_mount(&t_echo_board(), Path::new("/definitely/not/a/techo/mount")).is_err()
+        );
     }
 
     #[test]
@@ -500,7 +509,12 @@ mod tests {
         let stuck = temporary_mount("stuck");
         fs::create_dir(&stuck).expect("create stuck mount");
         assert!(matches!(
-            wait_for_reboot(&stuck, "TECHOBOOT", Duration::ZERO, Duration::from_millis(1)),
+            wait_for_reboot(
+                &stuck,
+                "TECHOBOOT",
+                Duration::ZERO,
+                Duration::from_millis(1)
+            ),
             Err(AppError::WriteVerifyReset(_))
         ));
         fs::remove_dir(stuck).expect("remove stuck mount");

--- a/prns-flash-manifest/src/catalog.rs
+++ b/prns-flash-manifest/src/catalog.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 use crate::{
     AfterResetStrategy, BeforeResetStrategy, BoardId, ChipFamily, PreparationProfile,
-    ProvisioningFormat, CONFIG_OFFSET, CONFIG_PASSWORD_MAX_BYTES, CONFIG_SIZE,
+    ProvisioningFormat, Uf2BoardIdPrefix, CONFIG_OFFSET, CONFIG_PASSWORD_MAX_BYTES, CONFIG_SIZE,
     CONFIG_SSID_MAX_BYTES, CONFIG_VERSION,
 };
 
@@ -157,6 +157,8 @@ pub struct Uf2Build {
     pub base_address: String,
     /// Bootloader volume label.
     pub mount_label: String,
+    /// Normalized `Board-ID` prefix this bootloader publishes in `INFO_UF2.TXT`.
+    pub board_id_prefix: String,
 }
 
 /// Catalog loading or invariant failure.
@@ -294,7 +296,8 @@ fn validate_transport(board: &BoardCatalogEntry) -> Result<(), CatalogError> {
                 || board.flash_size.is_some()
                 || PreparationProfile::parse(&board.preparation_profile)
                     != Ok(PreparationProfile::TechoUf2)
-                || build.mount_label != "TECHOBOOT"
+                || build.mount_label.trim().is_empty()
+                || Uf2BoardIdPrefix::parse(build.board_id_prefix.clone()).is_err()
                 || build.package.trim().is_empty()
                 || build.rust_target != "thumbv7em-none-eabihf"
                 || parse_hex_u32(&build.family_id).is_none()
@@ -465,6 +468,44 @@ mod tests {
             .pop();
         assert!(matches!(
             BoardCatalog::from_json(&serde_json::to_vec(&value)?),
+            Err(CatalogError::InvalidBoard { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn a_uf2_board_is_not_tied_to_one_bootloader_volume() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let mut catalog = board_catalog()?;
+        let board = catalog
+            .boards
+            .iter_mut()
+            .find(|board| board.transport == Transport::Uf2MassStorage)
+            .ok_or("expected a UF2 board")?;
+        let BoardBuild::Uf2(build) = &mut board.build else {
+            return Err("expected a UF2 build".into());
+        };
+        build.mount_label = "T114BOOT".to_string();
+        build.board_id_prefix = "nrf52840-heltec-t114-v".to_string();
+        catalog.validate()?;
+        Ok(())
+    }
+
+    #[test]
+    fn an_unnormalized_uf2_board_id_prefix_is_rejected() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let mut catalog = board_catalog()?;
+        let board = catalog
+            .boards
+            .iter_mut()
+            .find(|board| board.transport == Transport::Uf2MassStorage)
+            .ok_or("expected a UF2 board")?;
+        let BoardBuild::Uf2(build) = &mut board.build else {
+            return Err("expected a UF2 build".into());
+        };
+        build.board_id_prefix = "nRF52840_TEcho_v".to_string();
+        assert!(matches!(
+            catalog.validate(),
             Err(CatalogError::InvalidBoard { .. })
         ));
         Ok(())

--- a/prns-flash-manifest/src/catalog.rs
+++ b/prns-flash-manifest/src/catalog.rs
@@ -173,6 +173,14 @@ pub enum CatalogError {
     /// A board slug occurs more than once.
     #[error("duplicate board slug {0:?}")]
     DuplicateSlug(String),
+    /// Two UF2 boards could both claim one mounted bootloader drive.
+    #[error("UF2 board-id prefixes overlap between {first:?} and {second:?}")]
+    OverlappingUf2BoardIdPrefixes {
+        /// One board's slug.
+        first: String,
+        /// The other board's slug.
+        second: String,
+    },
     /// A catalog invariant is invalid.
     #[error("board {board:?}: {message}")]
     InvalidBoard {
@@ -205,6 +213,7 @@ impl BoardCatalog {
             validate_transport(board)?;
             validate_provisioning(board)?;
         }
+        validate_uf2_board_id_prefixes(&self.boards)?;
         let expected = SHIPPING_BOARD_SLUGS
             .into_iter()
             .collect::<std::collections::BTreeSet<_>>();
@@ -310,6 +319,32 @@ fn validate_transport(board: &BoardCatalogEntry) -> Result<(), CatalogError> {
             }
         }
         _ => return Err(invalid(board, "transport and build recipe disagree")),
+    }
+    Ok(())
+}
+
+/// No UF2 board may answer for another's bootloader drive. Detection strips a cataloged prefix and
+/// requires a non-empty revision token after it, so when one prefix begins with another a single
+/// mounted drive satisfies both boards' identity checks and the narrowing `flash` performs stops
+/// being a guarantee. Catalog time is the only place this can be caught, because each prefix is
+/// individually well formed.
+fn validate_uf2_board_id_prefixes(boards: &[BoardCatalogEntry]) -> Result<(), CatalogError> {
+    let prefixes = boards
+        .iter()
+        .filter_map(|board| match &board.build {
+            BoardBuild::Uf2(build) => Some((board.slug.as_str(), build.board_id_prefix.as_str())),
+            BoardBuild::Esp(_) => None,
+        })
+        .collect::<Vec<_>>();
+    for (index, (slug, prefix)) in prefixes.iter().enumerate() {
+        for (other_slug, other_prefix) in &prefixes[index + 1..] {
+            if prefix.starts_with(other_prefix) || other_prefix.starts_with(prefix) {
+                return Err(CatalogError::OverlappingUf2BoardIdPrefixes {
+                    first: (*slug).to_string(),
+                    second: (*other_slug).to_string(),
+                });
+            }
+        }
     }
     Ok(())
 }
@@ -488,6 +523,31 @@ mod tests {
         build.mount_label = "T114BOOT".to_string();
         build.board_id_prefix = "nrf52840-heltec-t114-v".to_string();
         catalog.validate()?;
+        Ok(())
+    }
+
+    #[test]
+    fn one_uf2_board_id_prefix_may_not_begin_with_another() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let mut catalog = board_catalog()?;
+        let mut second = catalog
+            .boards
+            .iter()
+            .find(|board| board.transport == Transport::Uf2MassStorage)
+            .ok_or("expected a UF2 board")?
+            .clone();
+        second.slug = "nrf52840-second-board".to_string();
+        let BoardBuild::Uf2(build) = &mut second.build else {
+            return Err("expected a UF2 build".into());
+        };
+        // Individually well formed, and a longer prefix that still begins with the first board's,
+        // so one mounted drive would satisfy both boards' identity checks.
+        build.board_id_prefix = format!("{}2-", build.board_id_prefix);
+        catalog.boards.push(second);
+        assert!(matches!(
+            catalog.validate(),
+            Err(CatalogError::OverlappingUf2BoardIdPrefixes { .. })
+        ));
         Ok(())
     }
 

--- a/prns-flash-manifest/src/catalog.rs
+++ b/prns-flash-manifest/src/catalog.rs
@@ -552,8 +552,7 @@ mod tests {
     }
 
     #[test]
-    fn an_unnormalized_uf2_board_id_prefix_is_rejected() -> Result<(), Box<dyn std::error::Error>>
-    {
+    fn an_unnormalized_uf2_board_id_prefix_is_rejected() -> Result<(), Box<dyn std::error::Error>> {
         let mut catalog = board_catalog()?;
         let board = catalog
             .boards

--- a/prns-flash-manifest/src/domain.rs
+++ b/prns-flash-manifest/src/domain.rs
@@ -8,7 +8,7 @@ pub use target::{
 pub use values::{
     AfterResetStrategy, BeforeResetStrategy, BoardId, ChipFamily, DomainValueError, FlashFrequency,
     FlashMode, ImmutableArtifactPath, KeyId, PreparationProfile, ProvisioningFormat,
-    ProvisioningSlot, ReleaseVersion, Sha256Digest,
+    ProvisioningSlot, ReleaseVersion, Sha256Digest, Uf2BoardIdPrefix,
 };
 
 pub(crate) use target::TargetIdentity;

--- a/prns-flash-manifest/src/domain/values.rs
+++ b/prns-flash-manifest/src/domain/values.rs
@@ -10,6 +10,9 @@ pub enum DomainValueError {
     /// A stable board identifier is malformed.
     #[error("board ID {0:?} must use lowercase ASCII, digits, and hyphens")]
     BoardId(String),
+    /// A UF2 bootloader identity prefix is not in canonical form.
+    #[error("UF2 Board-ID prefix {0:?} is not canonically normalized")]
+    Uf2BoardIdPrefix(String),
     /// An immutable release version is malformed.
     #[error("release version {0:?} is not an immutable path-safe identifier")]
     ReleaseVersion(String),
@@ -87,6 +90,29 @@ impl BoardId {
 }
 
 validated_string!(BoardId);
+
+/// Validated `Board-ID` prefix a UF2 bootloader publishes in `INFO_UF2.TXT`.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Uf2BoardIdPrefix(String);
+
+impl Uf2BoardIdPrefix {
+    /// Fold a bootloader-reported identity into the one spelling the catalog stores.
+    pub fn normalize(value: &str) -> String {
+        value.trim().to_ascii_lowercase().replace('_', "-")
+    }
+
+    /// Require the catalog to store an already-normalized prefix so no comparison has to
+    /// normalize the trusted side.
+    pub fn parse(value: impl Into<String>) -> Result<Self, DomainValueError> {
+        let value = value.into();
+        let canonical = !value.is_empty() && value == Self::normalize(&value);
+        canonical
+            .then_some(Self(value.clone()))
+            .ok_or(DomainValueError::Uf2BoardIdPrefix(value))
+    }
+}
+
+validated_string!(Uf2BoardIdPrefix);
 
 /// Validated immutable release version.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/prns-flash-manifest/src/lib.rs
+++ b/prns-flash-manifest/src/lib.rs
@@ -14,8 +14,8 @@ pub use domain::{
     AfterResetStrategy, BeforeResetStrategy, BoardId, ChipFamily, DomainValueError, EspFlashPart,
     EspSerialTarget, FlashFrequency, FlashMode, ImmutableArtifactPath, KeyId, PreparationProfile,
     ProvisioningFormat, ProvisioningSlot, ReleasePartRef, ReleaseTarget, ReleaseVersion,
-    Sha256Digest, Uf2Part, Uf2Target, ValidatedChannelDescriptor, ValidatedFlashManifest,
-    ValidatedReleaseInfo, ValidatedSigningInfo,
+    Sha256Digest, Uf2BoardIdPrefix, Uf2Part, Uf2Target, ValidatedChannelDescriptor,
+    ValidatedFlashManifest, ValidatedReleaseInfo, ValidatedSigningInfo,
 };
 pub use manifest::{
     ChannelDescriptor, FlashManifest, FlashPart, FlashPartKind, ManifestError,

--- a/release/flash/boards.json
+++ b/release/flash/boards.json
@@ -157,7 +157,8 @@
         "rust_target": "thumbv7em-none-eabihf",
         "family_id": "0xADA52840",
         "base_address": "0x27000",
-        "mount_label": "TECHOBOOT"
+        "mount_label": "TECHOBOOT",
+        "board_id_prefix": "nrf52840-techo-v"
       }
     }
   ]


### PR DESCRIPTION
Two commits. The first is a refactor with no behavior change for the T-Echo, and the second closes a gap the first one makes reachable.

I'm bringing up a second nRF52840 UF2 board and ran into both of these in the first hour, so I pulled them out on their own rather than bury them in a firmware change.

**The bootloader volume label.** `prns-flash-manifest/src/catalog.rs` validated every UF2 entry with `build.mount_label != "TECHOBOOT"`, which is a per-board catalog value checked against a hardcoded copy of itself. That's now a non-empty check. The strict label shape already lives where it needs to, at the untrusted bridge boundary in `docs/website/web-flasher/src/core.js`, and a second copy of that rule in Rust with nothing tying the two together is how they drift.

**The bootloader Board-ID prefix.** The flasher found the target drive by requiring `INFO_UF2.TXT`'s Board-ID to start with the literal `nrf52840-techo-v`. `Uf2Build` gains `board_id_prefix`, and a new `Uf2BoardIdPrefix` domain value owns the folding rule (lowercase, underscores to hyphens) and requires the catalog to store the already-folded form, so the trusted side of the comparison is never normalized at runtime. It's validated alongside `ChipFamily` and the reset strategies.

Detection has two named entry points now, and the difference is a safety property. `flash` narrows to the selected board's prefix. `doctor` with no board argument scans everything cataloged, because it has nothing to narrow to. The revision-shape rule is unchanged: the text after the prefix still has to be a non-empty alphanumeric-or-dot token, so a bare prefix, a generic UF2 drive, or a coincidental mount label still fails identity.

**The second commit.** While checking that narrowing claim I found it isn't airtight. Nothing compares prefixes across boards, and since detection strips a prefix and then requires a revision token after it, one board's prefix beginning with another's means a single mounted drive satisfies both boards' checks. Each prefix is individually well formed, so catalog validation is the only place to catch it. There's a new `OverlappingUf2BoardIdPrefixes` error and a test that clones the T-Echo entry with a longer overlapping prefix and expects a refusal. It can't bite today with one UF2 board cataloged, and it's exactly what a second one would spring.

What this deliberately doesn't touch: `PreparationProfile::TechoUf2`, since the wire spelling is baked into the minisign-signed 0.2.6 browser fixture; the `techo_mounts` field in schema-1 `doctor --json`, which is a public contract that should move with a schema bump; `HOPSPOT_TECHOBOOT`, which is an operator escape hatch; and `SHIPPING_BOARD_SLUGS`, because adding a board should stay a conscious edit.

Tested both ways, since I have a Windows box:

- Linux (WSL): `cargo test -p prns-flash-manifest -p hopspot-flash`, 126 tests across five binaries, 0 failed. `cargo clippy -p prns-flash-manifest -p hopspot-flash --all-targets -- -D warnings`, clean.
- Windows (x86_64-pc-windows-msvc): `cargo test -p prns-flash-manifest`, 38 passed, 0 failed.
- `python validation/run.py verify` and `./tools/prns verify` both green.

One thing I noticed from running it on both: `validate-flasher-candidate` runs 9 tests on Linux and 5 on Windows. The four that don't run are the symlink rejection ones, and they're Unix-gated. Nothing to do with this change, but it means those protections aren't exercised on Windows at all. Happy to open that separately if it's worth a look.
