### PR TITLE
release: bind the documented acceptance counts to the contract

### DIFF
--- a/tools/tests/test_acceptance_doc_contracts.py
+++ b/tools/tests/test_acceptance_doc_contracts.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "validation" / "release" / "acceptance-doc-contracts.py"
+
+
+def load_checker():
+    spec = importlib.util.spec_from_file_location("acceptance_doc_contracts", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not import {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+CHECKER = load_checker()
+
+
+class AcceptanceDocContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.path = self.root / "acceptance.md"
+        self.contracts = (
+            CHECKER.CountContract(
+                "acceptance.md",
+                "Acceptance requires ",
+                "physical",
+                " physical rows.",
+            ),
+        )
+        self.derived = {"physical": 12}
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def check(self) -> list[str]:
+        return CHECKER.check(self.root, self.derived, self.contracts)
+
+    def test_accepts_spelled_and_decimal_counts(self) -> None:
+        for count in ("twelve", "12"):
+            with self.subTest(count=count):
+                self.path.write_text(
+                    f"Acceptance requires {count} physical rows.\n",
+                    encoding="utf-8",
+                )
+                self.assertEqual(self.check(), [])
+
+    def test_rejects_wrong_count_at_source_line(self) -> None:
+        self.path.write_text(
+            "# Acceptance\n\nAcceptance requires eleven physical rows.\n",
+            encoding="utf-8",
+        )
+        self.assertEqual(
+            self.check(),
+            [
+                "acceptance.md:3: expected derived physical count 12, found eleven",
+            ],
+        )
+
+    def test_rejects_missing_registered_anchor(self) -> None:
+        self.path.write_text(
+            "Acceptance needs twelve physical rows.\n",
+            encoding="utf-8",
+        )
+        self.assertEqual(
+            self.check(),
+            [
+                "acceptance.md: cannot find the registered physical count between "
+                "'Acceptance requires ' and ' physical rows.'",
+            ],
+        )
+
+    def test_rejects_duplicate_registered_count(self) -> None:
+        self.path.write_text(
+            "Acceptance requires twelve physical rows.\n"
+            "Acceptance requires twelve physical rows.\n",
+            encoding="utf-8",
+        )
+        self.assertEqual(
+            self.check(),
+            [
+                "acceptance.md:2: the registered physical count occurs more than once",
+            ],
+        )
+
+    def test_reports_missing_document(self) -> None:
+        errors = self.check()
+        self.assertEqual(len(errors), 1)
+        self.assertTrue(errors[0].startswith("acceptance.md: cannot read governed document:"))
+
+    def test_repository_documents_match_derived_counts(self) -> None:
+        self.assertEqual(
+            CHECKER.check(
+                ROOT,
+                CHECKER.derived_counts(ROOT),
+                CHECKER.COUNT_CONTRACTS,
+            ),
+            [],
+        )
+
+    def test_installer_roster_count_tracks_published_targets(self) -> None:
+        targets = dict(CHECKER.CLI_TARGETS)
+        targets["second-x86_64-linux"] = ("linux", "x86_64")
+        with patch.object(CHECKER, "CLI_TARGETS", targets):
+            derived = CHECKER.derived_counts(ROOT)
+        self.assertEqual(derived["installer_roster"], len(targets))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validation/manifest.toml
+++ b/validation/manifest.toml
@@ -485,7 +485,7 @@ platform = "linux"
 toolchain = "python"
 timeout_seconds = 600
 command = ["bash", "validation/release/contracts.sh"]
-inputs = ["tools/tests", "tools/release", "prnsd/Cargo.toml", "validation/release/contracts.sh", "validation/release/prnsd-feature-contracts.py", "validation/release/workflow-contracts.py"]
+inputs = ["tools/tests", "tools/release", "prnsd/Cargo.toml", "validation/release/contracts.sh", "validation/release/prnsd-feature-contracts.py", "validation/release/workflow-contracts.py", "validation/release/acceptance-doc-contracts.py", "release/acceptance/README.md", "release/acceptance/QUALIFICATION.md", "release/acceptance/rosters/README.md", "release/flash/README.md", "release/flash/boards.json", "docs/release-dependency-audit.md"]
 artifacts = "validation-artifacts/results/release-contracts"
 
 [[suite]]

--- a/validation/release/acceptance-doc-contracts.py
+++ b/validation/release/acceptance-doc-contracts.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Mapping, NamedTuple
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RELEASE_TOOLS = ROOT / "tools" / "release"
+if str(RELEASE_TOOLS) not in sys.path:
+    sys.path.insert(0, str(RELEASE_TOOLS))
+
+from flasher_acceptance_contract import (  # noqa: E402
+    CLI_TARGETS,
+    FALLBACK_SCENARIOS,
+    REQUIRED_FALLBACKS,
+    SHIPPING_BOARDS,
+    SURFACES,
+    T_ECHO_COMPATIBILITY_VARIANTS,
+)
+
+
+class CountContract(NamedTuple):
+    path: str
+    before: str
+    derived: str
+    after: str
+
+
+class FlattenedDocument(NamedTuple):
+    text: str
+    source_lines: tuple[int, ...]
+
+
+NUMBER_WORDS = (
+    "zero",
+    "one",
+    "two",
+    "three",
+    "four",
+    "five",
+    "six",
+    "seven",
+    "eight",
+    "nine",
+    "ten",
+    "eleven",
+    "twelve",
+    "thirteen",
+    "fourteen",
+    "fifteen",
+    "sixteen",
+    "seventeen",
+    "eighteen",
+    "nineteen",
+    "twenty",
+)
+COUNT_TOKEN = r"(?P<count>[0-9]+|(?i:" + "|".join(NUMBER_WORDS) + r"))"
+
+COUNT_CONTRACTS = (
+    CountContract(
+        "release/acceptance/README.md",
+        "produces ",
+        "physical",
+        " physical rows",
+    ),
+    CountContract(
+        "release/acceptance/README.md",
+        "physical rows, ",
+        "fallback",
+        " unsupported-browser rows",
+    ),
+    CountContract(
+        "release/acceptance/README.md",
+        "unsupported-browser rows, and ",
+        "installer",
+        " native installer rows",
+    ),
+    CountContract(
+        "release/acceptance/README.md",
+        "both surfaces: ",
+        "physical",
+        " rows.",
+    ),
+    CountContract(
+        "release/acceptance/README.md",
+        "Every row must prove all ",
+        "fallback_scenarios",
+        " points:",
+    ),
+    CountContract(
+        "release/acceptance/rosters/README.md",
+        "It must contain ",
+        "physical_assignments",
+        " physical board/surface assignments",
+    ),
+    CountContract(
+        "release/acceptance/rosters/README.md",
+        "physical board/surface assignments, ",
+        "fallback",
+        " Firefox/Safari fallback assignments",
+    ),
+    CountContract(
+        "release/acceptance/rosters/README.md",
+        "Firefox/Safari fallback assignments, and ",
+        "installer_roster",
+        " published-archive installer assignments.",
+    ),
+    CountContract(
+        "release/acceptance/QUALIFICATION.md",
+        "The ",
+        "installer",
+        " native installation rows are separate archive checks.",
+    ),
+    CountContract(
+        "release/acceptance/QUALIFICATION.md",
+        "Its ",
+        "installer",
+        " target-matched jobs re-fetch the public assets",
+    ),
+    CountContract(
+        "release/flash/README.md",
+        "assign the ",
+        "physical_assignments",
+        " physical",
+    ),
+    CountContract(
+        "release/flash/README.md",
+        "physical, ",
+        "fallback",
+        " fallback",
+    ),
+    CountContract(
+        "release/flash/README.md",
+        "fallback, and ",
+        "installer_roster",
+        " archive-installation coverage slots",
+    ),
+    CountContract(
+        "release/flash/README.md",
+        "validates ",
+        "physical",
+        " full transport-aware physical rows",
+    ),
+    CountContract(
+        "release/flash/README.md",
+        "physical rows, ",
+        "fallback",
+        " browser fallbacks",
+    ),
+    CountContract(
+        "release/flash/README.md",
+        "browser fallbacks, and all ",
+        "installer",
+        " installer/exact-version smokes",
+    ),
+    CountContract(
+        "docs/release-dependency-audit.md",
+        "complete web/CLI ",
+        "boards",
+        "-board matrix",
+    ),
+)
+
+
+def physical_row_count(root: Path) -> int:
+    boards = json.loads((root / "release" / "flash" / "boards.json").read_text(encoding="utf-8"))
+    transports = {board["slug"]: board["transport"] for board in boards["boards"]}
+    if set(transports) != set(SHIPPING_BOARDS):
+        raise ValueError(
+            "release/flash/boards.json does not state exactly the shipping board set"
+        )
+    return sum(
+        len(SURFACES)
+        * (
+            len(T_ECHO_COMPATIBILITY_VARIANTS)
+            if transports[board] == "uf2-mass-storage"
+            else 1
+        )
+        for board in SHIPPING_BOARDS
+    )
+
+
+def derived_counts(root: Path) -> dict[str, int]:
+    return {
+        "physical": physical_row_count(root),
+        "physical_assignments": len(SHIPPING_BOARDS) * len(SURFACES),
+        "boards": len(SHIPPING_BOARDS),
+        "fallback": len(REQUIRED_FALLBACKS),
+        "fallback_scenarios": len(FALLBACK_SCENARIOS),
+        "installer": len(CLI_TARGETS),
+        "installer_roster": len(CLI_TARGETS),
+    }
+
+
+def parse_count(token: str) -> int:
+    if token.isdecimal():
+        return int(token)
+    return NUMBER_WORDS.index(token.lower())
+
+
+def flatten(text: str) -> FlattenedDocument:
+    parts: list[str] = []
+    source_lines: list[int] = []
+    for line_number, raw in enumerate(text.splitlines(), start=1):
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        if parts:
+            parts.append(" ")
+            source_lines.append(line_number)
+        parts.append(stripped)
+        source_lines.extend([line_number] * len(stripped))
+    return FlattenedDocument("".join(parts), tuple(source_lines))
+
+
+def check(
+    root: Path,
+    derived: Mapping[str, int],
+    contracts: tuple[CountContract, ...],
+) -> list[str]:
+    errors: list[str] = []
+    documents: dict[str, FlattenedDocument] = {}
+    for path in sorted({contract.path for contract in contracts}):
+        try:
+            documents[path] = flatten((root / path).read_text(encoding="utf-8"))
+        except OSError as error:
+            errors.append(f"{path}: cannot read governed document: {error}")
+    if errors:
+        return errors
+
+    for contract in contracts:
+        document = documents[contract.path]
+        pattern = re.compile(
+            re.escape(contract.before) + COUNT_TOKEN + re.escape(contract.after)
+        )
+        matches = list(pattern.finditer(document.text))
+        if not matches:
+            errors.append(
+                f"{contract.path}: cannot find the registered {contract.derived} count between "
+                f"{contract.before!r} and {contract.after!r}"
+            )
+            continue
+        if len(matches) > 1:
+            duplicate = matches[1]
+            errors.append(
+                f"{contract.path}:{document.source_lines[duplicate.start('count')]}: "
+                f"the registered {contract.derived} count occurs more than once"
+            )
+            continue
+        match = matches[0]
+        observed_token = match.group("count")
+        observed = parse_count(observed_token)
+        expected = derived[contract.derived]
+        if observed != expected:
+            errors.append(
+                f"{contract.path}:{document.source_lines[match.start('count')]}: "
+                f"expected derived {contract.derived} count {expected}, found {observed_token}"
+            )
+    return errors
+
+
+def main() -> int:
+    try:
+        derived = derived_counts(ROOT)
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as error:
+        print(f"acceptance doc contract: cannot derive counts: {error}", file=sys.stderr)
+        return 1
+    errors = check(ROOT, derived, COUNT_CONTRACTS)
+    for error in errors:
+        print(f"acceptance doc contract: {error}", file=sys.stderr)
+    if errors:
+        return 1
+    print(
+        f"acceptance documents state the derived {derived['physical']} physical,"
+        f" {derived['fallback']} fallback, and {derived['installer']} installer counts"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/validation/release/contracts.sh
+++ b/validation/release/contracts.sh
@@ -12,6 +12,7 @@ uvx --from ruff==0.15.22 ruff check \
     validation/release
 "$validation_python" validation/release/workflow-contracts.py
 "$validation_python" validation/release/prnsd-feature-contracts.py
+"$validation_python" validation/release/acceptance-doc-contracts.py
 PYTHONDONTWRITEBYTECODE=1 "$validation_python" -m unittest discover \
     -s tools/tests \
     -p 'test_*.py' \


### PR DESCRIPTION
Follow-up to #61, where you said pointing these at a single source of truth would be welcome.

`flasher_acceptance_contract.py` derives the qualification matrix. Five documents restate its sizes in prose, so a reader knows what they owe without reading Python. Those restatements do not update themselves: the four-board era's "eight rows" survived in two separate documents, and the T-Echo foundations change has since shown the same pattern again, with three more sentences going stale the moment the arithmetic changed.

This adds `validation/release/acceptance-doc-contracts.py`, which stores no count of its own. It derives every number from the contract and requires each governed sentence to state exactly that:

| quantity | derivation |
|---|---|
| physical rows | one per board/surface pair, times the S140 compatibility variants a UF2 target owes (transport from `release/flash/boards.json`, which must match `SHIPPING_BOARDS` exactly or the check refuses to vouch for the arithmetic) |
| roster assignments | `len(SHIPPING_BOARDS) * len(SURFACES)`, a smaller number than the rows since the T-Echo's two foundations share one assignment |
| browser fallbacks | `len(REQUIRED_FALLBACKS)` |
| fallback checkpoints | `len(FALLBACK_SCENARIOS)` |
| installer rows | `len(CLI_TARGETS)`, `len(OS_ARCHITECTURES)` |
| board matrix | `len(SHIPPING_BOARDS)` |

Adding a sixth board to `SHIPPING_BOARDS` turns every affected sentence red at once, across four documents, each naming the file and the exact sentence it expected:

```
acceptance doc contract: release/acceptance/README.md: expected the contract-derived sentence
"produces fourteen physical rows, four unsupported-browser rows, and five native installer rows".
```

A second pass then rejects any *unregistered* count in the same documents, so a new restatement cannot be added without being bound here too. It recognizes the subjects these documents already use; genuinely new phrasing for a new quantity still needs an entry, and the check says so.

Sentences are matched against whitespace-flattened text so a soft-wrapped sentence still matches, and errors still report the original line.

It runs inside the existing `release-contracts` suite, so there is no new suite or workflow. The five governed documents join that suite's declared inputs, so a docs-only edit reruns the check instead of hitting a cached pass.

Ran on Windows 11, `x86_64-pc-windows-msvc`:

- `python validation/run.py verify` - `VALIDATION_REGISTRY_OK`
- `bash validation/hygiene/fmt-docs.sh` - `FMT_DOC_CHECK_GATE_OK`
- `bash validation/release/contracts.sh` - the new check passes inside the suite. The `tools/tests` phase reports 2 failures and 5 errors on this host; an unmodified worktree of trunk reports the same set, so they are pre-existing here and not from this change.
- Fail-closed verified three ways: a drifted governed count exits 1, an unregistered count exits 1, a `boards.json` that disagrees with the shipping set exits 1; the committed tree exits 0.

Rebased onto trunk `cf277157`, single commit.
