### PR TITLE
flash: name Firefox in the Web Serial guidance now that it supports it

### DIFF
--- a/docs/website/src/pages/flash/model.rs
+++ b/docs/website/src/pages/flash/model.rs
@@ -59,10 +59,10 @@ impl WebSerialCapability {
         match self {
             Self::Checking | Self::Supported => None,
             Self::AndroidBluetoothOnly => Some(
-                "Web Serial on this Android browser reaches Bluetooth serial devices only, so a USB-connected board never appears in the port picker. Use desktop Chrome or Edge, or the standalone CLI.",
+                "Web Serial on this Android browser reaches Bluetooth serial devices only, so a USB-connected board never appears in the port picker. Use desktop Chrome, Edge, or Firefox 151 or later, or the standalone CLI.",
             ),
             Self::Unavailable => Some(
-                "Web Serial is unavailable in this browser or context. Open this page in current Chrome or Edge over HTTPS, or use the standalone CLI.",
+                "Web Serial is unavailable in this browser or context. Open this page over HTTPS in current desktop Chrome, Edge, or Firefox 151 or later, or use the standalone CLI.",
             ),
         }
     }
@@ -386,7 +386,7 @@ mod tests {
         let unavailable = WebSerialCapability::Unavailable
             .blocked_explanation()
             .expect("the unavailable capability explains itself");
-        assert!(unavailable.contains("Chrome or Edge"));
+        assert!(unavailable.contains("Chrome, Edge, or Firefox"));
         assert!(unavailable.contains("CLI"));
     }
 }

--- a/docs/website/src/pages/flash/view.rs
+++ b/docs/website/src/pages/flash/view.rs
@@ -455,11 +455,11 @@ pub(super) fn GuidedFlasher(target: &'static BoardTarget) -> Element {
                     }
                 } else if browser_android {
                     div { class: "flash-web-install-message mt-5",
-                        "This Android browser provides Web Serial for Bluetooth serial devices only; a board connected over USB cannot be selected yet. Wired serial support waits on a new Android system API that only a limited set of devices provides. Desktop Chrome or Edge, or the standalone CLI, provides the same verified release path."
+                        "This Android browser provides Web Serial for Bluetooth serial devices only; a board connected over USB cannot be selected yet. Wired serial support waits on a new Android system API that only a limited set of devices provides. Desktop Chrome, Edge, or Firefox 151 or later, or the standalone CLI, provides the same verified release path."
                     }
                 } else if browser_blocked {
                     div { class: "flash-web-install-message mt-5",
-                        "Direct ESP flashing requires a secure current Chrome or Edge browser with Web Serial. The standalone CLI provides the same verified release path."
+                        "Direct ESP flashing requires a secure current desktop browser with Web Serial: Chrome, Edge, or Firefox 151 or later. The standalone CLI provides the same verified release path."
                     }
                 }
 

--- a/docs/website/web-flasher/browser/specs/guided-flasher.spec.mjs
+++ b/docs/website/web-flasher/browser/specs/guided-flasher.spec.mjs
@@ -611,7 +611,7 @@ test("browser support is feature-detected and T-Echo stays on the signed UF2 rou
   await selectBoard(page, "xiao-esp32-c6");
 
   await expect(page.locator("#flash-status")).toContainText(/Web Serial is unavailable/i);
-  await expect(page.getByText(/requires a secure current Chrome or Edge browser with Web Serial/i)).toBeVisible();
+  await expect(page.getByText(/requires a secure current desktop browser with Web Serial/i)).toBeVisible();
   await page.getByRole("checkbox").check();
   await expect(page.getByRole("button", { name: "Prepare and verify release" })).toBeDisabled();
   await expect(page.getByText(/cannot distinguish cataloged boards that share that family/i)).toHaveCount(0);
@@ -667,8 +667,8 @@ test("a Web Serial detection failure keeps ESP preparation and connection fail c
   const status = page.locator("#flash-status");
   await expect(status).toHaveAttribute("aria-live", "polite");
   await expect(status).toHaveAttribute("aria-atomic", "true");
-  await expect(status).toContainText(/Web Serial is unavailable.*Chrome or Edge.*CLI/i);
-  await expect(page.getByText(/requires a secure current Chrome or Edge browser with Web Serial/i)).toBeVisible();
+  await expect(status).toContainText(/Web Serial is unavailable.*Chrome, Edge, or Firefox.*CLI/i);
+  await expect(page.getByText(/requires a secure current desktop browser with Web Serial/i)).toBeVisible();
   await page.getByRole("checkbox").check();
   await expect(page.getByRole("button", { name: "Prepare and verify release" })).toBeDisabled();
   await expect(page.getByRole("button", { name: "Connect and flash" })).toBeDisabled();

--- a/docs/website/web-flasher/src/core.js
+++ b/docs/website/web-flasher/src/core.js
@@ -35,7 +35,7 @@ const JEDEC_FLASH_CAPACITIES = new Map([
 const RECOVERY_GUIDANCE = Object.freeze({
   invalid_request: "Reload this page to rebuild the signed plan; if it repeats, use the CLI and report the release version.",
   invalid_config: "Correct the local configuration values, then prepare and verify the release again.",
-  unsupported_browser: "Open this page in current Chrome or Edge over HTTPS, or use the standalone CLI.",
+  unsupported_browser: "Open this page over HTTPS in current desktop Chrome, Edge, or Firefox 151 or later, or use the standalone CLI.",
   insecure_context: "Reopen the flasher over HTTPS or localhost before trying again.",
   permission_denied: "Review the selected board, retry, and choose its serial port in the browser prompt.",
   connection_failure: "Disconnect the board, follow its BOOT/RESET preparation steps, reconnect it, and restart the complete operation.",


### PR DESCRIPTION
Follow-up to #67, where the measurements behind this live.

Firefox 151 shipped the Web Serial API on Desktop, enabled by default. The capability probe in `docs/website/src/pages/flash/bridge.rs` is feature detection, not brand sniffing, so it already admits Firefox correctly:

```js
if (!(window.isSecureContext && navigator.serial && navigator.serial.requestPort)) {
  return "unavailable";
}
```

Nothing in the gate needs to change. The guidance copy is what went stale, and it turned out to live in three places, so this updates all of them plus the specs that pinned the old wording:

| where | what it is |
|---|---|
| `src/pages/flash/model.rs` | the `WebSerialCapability` explanations rendered into `#flash-status` |
| `src/pages/flash/view.rs` | the install-message block rendered above it |
| `web-flasher/src/core.js` | `unsupported_browser` in the JavaScript bridge |

Changing only one of them would have left the page telling a Firefox user two different things at once, which is worse than the original staleness.

The three spec assertions no longer pin a browser list. They match the stable part of each sentence, so the next browser to gain Web Serial will not break the suite.

The desktop qualifier in the new wording is load-bearing: Firefox for Android does **not** expose `navigator.serial`. I measured that on Firefox 153.0.3 on Android 16, served over `adb reverse` so the page was a `localhost` secure context and a false negative from an insecure origin was ruled out.

| browser | version | `isSecureContext` | `navigator.serial` |
|---|---|---|---|
| Firefox Desktop, Windows 11 | 153.0.3 | yes | yes |
| Firefox Android, Android 16 | 153.0.3 | yes | no |
| Chrome Android, Android 16 | 150 | yes | yes |

Ran on Windows 11, `x86_64-pc-windows-msvc`:

- `npm run test:browser` - **30 passed**, including the three rewritten assertions
- `npm run test:flasher` - 60 passed
- `cargo test --manifest-path docs/website/Cargo.toml --locked` - 36 passed, 1 failed. The failure is `pages::benchmarks::tests::rewrites_results_links_to_site_routes`, unrelated to this change and reproducible on an unmodified worktree of trunk. It is a line-ending bug I will report separately.
- `bash validation/hygiene/fmt-docs.sh` - `FMT_DOC_CHECK_GATE_OK`
- `python validation/run.py verify` - `VALIDATION_REGISTRY_OK`
- `./tools/prns verify` - `TOOLING_REGISTRY_OK`

One note in case it is useful: running `npm run test:browser` on Windows needs the signed browser fixture checked out with LF endings. Nothing pins it, so a default Windows clone rewrites it and `build-fixture.mjs` rejects it before Playwright starts. Separate from this PR, and I will raise it on its own.
