### PR TITLE
fixtures: keep the signed browser fixture byte-exact on every platform

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,11 @@
 *.mu -text
 *.sh text eol=lf
+
+# The signed browser fixture is byte-exact: a minisign key ID parsed from a fixed
+# line, a channel document whose manifest_sha256 must equal the manifest bytes, and
+# per-artifact size and sha256 checks. Line-ending translation rewrites those bytes
+# and invalidates every one of those checks, so keep it verbatim on every platform.
+docs/website/web-flasher/browser/fixtures/signed-candidate/** -text
 .githooks/* text eol=lf
 tools/prns text eol=lf
 tools/prns.cmd text eol=crlf


### PR DESCRIPTION
`npm run test:browser` cannot run on Windows. Not "fails a test" — it dies before Playwright starts, and I think the cause is worth fixing at the root rather than in the script.

The fixture under `docs/website/web-flasher/browser/fixtures/signed-candidate` is byte-exact by design. `build-fixture.mjs` parses a minisign key ID from a fixed line, requires the channel document's `manifest_sha256` to equal the manifest bytes, and checks every artifact's `size` and `sha256`.

Nothing pins its line endings:

```
git check-attr text -- <any fixture file>
  text: unspecified
```

So with `core.autocrlf=true`, which is the default on a Windows install, all 15 files are rewritten on checkout and none of those checks can pass:

```
claimed        : df6f429fa9ec7555be420647ad039d7d62808bf76fb71daa92a073348dccc423
as checked out : 24f56b8421e0cfda364e3ff50effe8c106ea8c0ec021acd3084731640567b51a  <- mismatch
LF-normalised  : df6f429fa9ec7555be420647ad039d7d62808bf76fb71daa92a073348dccc423  <- match
```

The first failure is earlier and less obvious than the hash: the key ID line arrives with a trailing `\r`, the `$`-anchored regex cannot match, and the run stops at *"the browser fixture public key has no canonical key ID"*.

I started patching that regex, then realised it was the wrong fix. Reverting the patch and normalising only the fixture proves it:

```
staged signed browser fixture 0.2.6 (de81281d26467f670d61d80bb66f1484597267686ab67b4a5eb438310b11aa59)
30 passed (56.9s)
```

The whole lane passes on Windows with **no source change at all**. One `.gitattributes` rule repairs the key-ID parse, the manifest hash, and every artifact hash together, which patching the parser would not have done. It matches how `*.mu` is already handled.

One practical note: this fixes fresh clones. An existing working tree keeps whatever it already has until those paths are re-checked-out or renormalised.

Ran on Windows 11, `x86_64-pc-windows-msvc`, with `dioxus-cli` 0.7.5 and the pinned Playwright 1.61.1:

- `npm run test:browser` - **30 passed**, with `.gitattributes` as the only change in the tree
- `bash validation/hygiene/fmt-docs.sh` - `FMT_DOC_CHECK_GATE_OK`
- `python validation/run.py verify` - `VALIDATION_REGISTRY_OK`
- `./tools/prns verify` - `TOOLING_REGISTRY_OK`

Found while setting this lane up locally for the first time, to verify #68.
