### PR TITLE
benchmarks: strip the index title whatever newlines the checkout used

### DIFF
--- a/docs/website/src/pages/benchmarks.rs
+++ b/docs/website/src/pages/benchmarks.rs
@@ -82,8 +82,19 @@ pub fn BenchmarksHostPage(host: String) -> Element {
 }
 
 fn index_markup() -> String {
-    let mut out = String::with_capacity(INDEX_MD.len());
-    let mut rest = INDEX_MD;
+    rewrite_index(INDEX_MD)
+}
+
+/// Repoint the index's result links at site routes and drop its own title, which the page
+/// supplies itself.
+///
+/// The source is `include_str!`d from a checkout, so its newlines are whatever Git wrote: `\n`
+/// on Linux and macOS, `\r\n` on a default Windows clone. Normalise once here rather than
+/// spelling both forms into every pattern below.
+fn rewrite_index(source: &str) -> String {
+    let source = source.replace("\r\n", "\n");
+    let mut out = String::with_capacity(source.len());
+    let mut rest = source.as_str();
     const PREFIX: &str = "](RESULTS-";
     const SUFFIX: &str = ".md)";
 
@@ -127,6 +138,29 @@ mod tests {
         assert!(md.contains("](/benchmarks/x86_64-unknown-linux-gnu)"));
         assert!(!md.contains("](RESULTS-aarch64-apple-darwin.md)"));
         assert!(!md.contains("# Benchmark results"));
+    }
+
+    /// A Windows checkout hands `include_str!` CRLF newlines, which used to defeat the title
+    /// strip and leave the page rendering its heading twice. Assert it directly so the guarantee
+    /// does not depend on which platform ran the suite.
+    #[test]
+    fn rewrites_the_index_whatever_newlines_the_checkout_used() {
+        const SOURCE: &str = "<!-- generated -->\n# Benchmark results\n\nSee [macOS](RESULTS-aarch64-apple-darwin.md).\n";
+
+        for (label, source) in [
+            ("lf", SOURCE.to_string()),
+            ("crlf", SOURCE.replace('\n', "\r\n")),
+        ] {
+            let md = rewrite_index(&source);
+            assert!(
+                !md.contains("# Benchmark results"),
+                "{label}: the page supplies its own title, so the document's must be removed"
+            );
+            assert!(
+                md.contains("](/benchmarks/aarch64-apple-darwin)"),
+                "{label}: result links must point at site routes"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
`index_markup` removes the index's own `# Benchmark results` heading, because the page supplies its own title. It did that by matching a literal:

```rust
out.replacen("# Benchmark results\n\n", "", 1)
```

and `benchmarks/RESULTS.md` is `include_str!`d straight from a checkout. On a default Windows clone it arrives CRLF, the pattern never matches, and the heading survives into the rendered page, which then shows its title twice.

`rewrites_results_links_to_site_routes` already catches it. It just never runs anywhere that reproduces it: the `flasher-web` suite that owns this test is `platform = "linux"`, so the assertion has only ever been evaluated against LF content.

Two changes:

**Normalise once instead of spelling both forms everywhere.** A single `replace("\r\n", "\n")` at the top of the rewrite, rather than teaching each pattern about CRLF.

**Make it provable off Windows.** The rewrite is now a function taking `&str`, so a test can hand it CRLF directly instead of depending on how Git happened to check the file out. Without the fix that new test fails on Linux as well:

```
crlf: the page supplies its own title, so the document's must be removed
```

Ran on Windows 11, `x86_64-pc-windows-msvc`:

- `cargo test --manifest-path docs/website/Cargo.toml --locked` - **38 passed, 0 failed**. Before this change the same command failed `rewrites_results_links_to_site_routes` on this host.
- `bash validation/hygiene/fmt-docs.sh` - `FMT_DOC_CHECK_GATE_OK`
- `python validation/run.py verify` - `VALIDATION_REGISTRY_OK`
- `./tools/prns verify` - `TOOLING_REGISTRY_OK`

Independent of the signed browser fixture fix that landed in 293fc81f, which is a different instance of the same class. This one is a rendering bug rather than a test-harness one.

