### PR TITLE
tools/tests: run on Windows

### DIFF
--- a/tools/tests/script_launcher.py
+++ b/tools/tests/script_launcher.py
@@ -1,0 +1,57 @@
+"""Resolve the interpreter a release script needs, so this suite runs on Windows too.
+
+Only Unix runs a script through its shebang, so every caller has to name the interpreter.
+Naming the shell is the part with a trap in it, and it is worth stating once here rather than
+in each caller.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import sys
+
+
+def _windows_bash() -> str:
+    """Locate the Git for Windows bash that can actually run a repository script.
+
+    `shutil.which("bash")` is not safe on Windows. Where WSL is installed it resolves to
+    `C:\\Windows\\System32\\bash.exe`, the WSL launcher, which cannot see a `C:` path at all and
+    fails with 127 no matter how the path is spelled.
+
+    Git ships two bash binaries and only one of them is usable. `Git\\bin\\bash.exe` puts the
+    MSYS coreutils on PATH; `Git\\usr\\bin\\bash.exe` starts but cannot find `dirname`, so a
+    script dies on its first pipeline instead of at its entry point.
+
+    Prefer the bash that sits beside the `git` already on PATH, so a portable or non-default Git
+    install is honoured, and fall back to the well-known locations.
+    """
+    roots: list[Path] = []
+    git = shutil.which("git")
+    if git is not None:
+        roots.append(Path(git).resolve().parents[1])
+    for variable in ("ProgramFiles", "ProgramW6432", "ProgramFiles(x86)"):
+        base = os.environ.get(variable)
+        if base:
+            roots.append(Path(base) / "Git")
+    for root in roots:
+        candidate = root / "bin" / "bash.exe"
+        if candidate.is_file():
+            return str(candidate)
+    raise RuntimeError(
+        "Git for Windows bash is required to run the release shell scripts; "
+        "looked beside git and under " + ", ".join(str(root) for root in roots)
+    )
+
+
+def script_launcher(target: Path) -> list[str]:
+    """Return the argv prefix that runs `target`."""
+    if target.suffix != ".sh":
+        return [sys.executable]
+    if os.name == "nt":
+        return [_windows_bash()]
+    bash = shutil.which("bash")
+    if bash is None:
+        raise RuntimeError("bash is required to run the release shell scripts")
+    return [bash]

--- a/tools/tests/test_flasher_release_custody.py
+++ b/tools/tests/test_flasher_release_custody.py
@@ -49,8 +49,24 @@ def sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def script_launcher(target: Path) -> list[str]:
+    """Return the interpreter to run `target` with.
+
+    Only Unix executes a script through its shebang, so name the interpreter explicitly. Shell
+    scripts additionally need bash resolved to an absolute path: on Windows a bare "bash" can
+    reach the WSL launcher instead of the Git one, and WSL cannot see a `C:` path.
+    """
+    if target.suffix != ".sh":
+        return [sys.executable]
+    bash = shutil.which("bash")
+    if bash is None:
+        raise RuntimeError("bash is required to run the release shell scripts")
+    return [bash]
+
+
 def run_script(script: str, *arguments: object, environment: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
-    command = [sys.executable, str(SCRIPTS / script), *(str(argument) for argument in arguments)]
+    target = SCRIPTS / script
+    command = [*script_launcher(target), str(target), *(str(argument) for argument in arguments)]
     return subprocess.run(
         command,
         cwd=ROOT,
@@ -601,9 +617,12 @@ class FlasherReleaseCustodyTests(unittest.TestCase):
         archive = self.fixture.root / "website" / "source.zip"
         archive.write_bytes(archive.read_bytes() + b"tampered")
         checksum = self.fixture.root / "website" / "source.zip.sha256"
+        # The validator compares these bytes exactly against an LF-built expectation, so keep the
+        # newline out of Windows text-mode translation.
         checksum.write_text(
             f"{sha256(archive)}  source.zip\n",
             encoding="utf-8",
+            newline="",
         )
         report_path = self.fixture.root / "metadata" / "reproducibility.json"
         report = json.loads(report_path.read_text(encoding="utf-8"))

--- a/tools/tests/test_flasher_release_custody.py
+++ b/tools/tests/test_flasher_release_custody.py
@@ -19,6 +19,9 @@ import unittest
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS = ROOT / "tools" / "release"
 sys.path.insert(0, str(SCRIPTS))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from script_launcher import script_launcher
 
 from flasher_build_metadata import EXPECTED_TOOLS, EXPECTED_WEB_PACKAGES
 from flasher_reproducibility import SEPARATE_ENVELOPES, payload_identity, payload_manifest
@@ -47,21 +50,6 @@ CLI_TARGETS = {
 }
 def sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
-
-
-def script_launcher(target: Path) -> list[str]:
-    """Return the interpreter to run `target` with.
-
-    Only Unix executes a script through its shebang, so name the interpreter explicitly. Shell
-    scripts additionally need bash resolved to an absolute path: on Windows a bare "bash" can
-    reach the WSL launcher instead of the Git one, and WSL cannot see a `C:` path.
-    """
-    if target.suffix != ".sh":
-        return [sys.executable]
-    bash = shutil.which("bash")
-    if bash is None:
-        raise RuntimeError("bash is required to run the release shell scripts")
-    return [bash]
 
 
 def run_script(script: str, *arguments: object, environment: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:

--- a/tools/tests/test_flasher_release_custody.py
+++ b/tools/tests/test_flasher_release_custody.py
@@ -50,7 +50,7 @@ def sha256(path: Path) -> str:
 
 
 def run_script(script: str, *arguments: object, environment: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
-    command = [str(SCRIPTS / script), *(str(argument) for argument in arguments)]
+    command = [sys.executable, str(SCRIPTS / script), *(str(argument) for argument in arguments)]
     return subprocess.run(
         command,
         cwd=ROOT,
@@ -63,7 +63,7 @@ def run_script(script: str, *arguments: object, environment: dict[str, str] | No
 
 def run_task(*arguments: object) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        [str(ROOT / "tools" / "prns"), *(str(argument) for argument in arguments)],
+        [sys.executable, str(ROOT / "tools" / "prns"), *(str(argument) for argument in arguments)],
         cwd=ROOT,
         text=True,
         capture_output=True,

--- a/tools/tests/test_flasher_reproducibility.py
+++ b/tools/tests/test_flasher_reproducibility.py
@@ -505,7 +505,11 @@ class FlasherReproducibilityTests(unittest.TestCase):
             Path("target/flasher-candidate"),
             cwd=repository,
         )
-        self.assertEqual(resolved, repository / "target" / "flasher-candidate")
+        # resolve_output resolves its result, and resolving a driveless path on Windows adds the
+        # current drive. Compare against the same resolution, not the literal fixture path.
+        self.assertEqual(
+            resolved, repository.resolve() / "target" / "flasher-candidate"
+        )
         with self.assertRaisesRegex(ValueError, "beneath target"):
             resolve_output(
                 repository,

--- a/tools/tests/test_prnsd_distribution.py
+++ b/tools/tests/test_prnsd_distribution.py
@@ -158,9 +158,12 @@ class PrnsdDistributionTests(unittest.TestCase):
             source = root / "source.zip"
             source.write_bytes(b"exact source")
             source_checksum = root / "source.zip.sha256"
+            # Compared byte for byte against an LF-built expectation, so keep the newline out of
+            # Windows text-mode translation.
             source_checksum.write_text(
                 f"{hashlib.sha256(source.read_bytes()).hexdigest()}  source.zip\n",
                 encoding="utf-8",
+                newline="",
             )
             first = root / "first" / f"prnsd-{VERSION}-x86_64-unknown-linux-gnu.tar.gz"
             second = root / "second" / first.name

--- a/tools/tests/test_release_audit_evidence.py
+++ b/tools/tests/test_release_audit_evidence.py
@@ -4,9 +4,14 @@ import os
 from pathlib import Path
 import stat
 import subprocess
+import sys
 import tempfile
 import unittest
 
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from script_launcher import script_launcher
 
 ROOT = Path(__file__).resolve().parents[2]
 WRITER = ROOT / "tools" / "release" / "write-release-audit-evidence.sh"
@@ -36,7 +41,7 @@ esac
             environment["PATH"] = f"{tools}{os.pathsep}{environment['PATH']}"
 
             result = subprocess.run(
-                (WRITER, output),
+                [*script_launcher(WRITER), str(WRITER), str(output)],
                 cwd=ROOT,
                 env=environment,
                 text=True,

--- a/tools/tests/test_serve_flasher_candidate.py
+++ b/tools/tests/test_serve_flasher_candidate.py
@@ -21,8 +21,12 @@ class CandidateServerTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory()
         self.root = Path(self.temporary.name)
-        (self.root / "index.html").write_text("candidate shell\n", encoding="utf-8")
-        (self.root / "app.js").write_text("candidate asset\n", encoding="utf-8")
+        # newline="" keeps the bytes on disk exactly as written. Without it Windows translates
+        # the trailing \n to \r\n, and these tests compare the served bytes exactly.
+        (self.root / "index.html").write_text(
+            "candidate shell\n", encoding="utf-8", newline=""
+        )
+        (self.root / "app.js").write_text("candidate asset\n", encoding="utf-8", newline="")
         self.server = SERVER.create_server(self.root, 0)
         self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
         self.thread.start()


### PR DESCRIPTION
`tools/tests` has never run on Windows. Not "some tests fail": the majority never executed at all, so their assertions have never been evaluated on a platform Prns ships a CLI target for.

Three commits, re-measured on current trunk `98820b6f`:

```
trunk 98820b6f     failures=5    errors=22     27 problems
after commit 1     failures=13   errors=5      18
after commit 2     failures=9    errors=4      13
after commit 3     failures=9    errors=4      13   (count unchanged, cause changed)
```

**Commit 1: launch scripts through an interpreter.** `run_script` and `run_task` built commands whose first element was a path to a `.py` file or to `tools/prns`. That works on Unix through the shebang; `CreateProcess` cannot do it, so all 18 tests in `test_flasher_release_custody` raised `[WinError 193] %1 is not a valid Win32 application` before the script under test started. The repo already does this correctly elsewhere. `test_flasher_reproducibility.py` uses `sys.executable`, and `tools/prns.cmd` is literally `@python "%~dp0prns"`.

**Commit 2: four fixture writes and one path comparison.** Four tests wrote fixtures with `Path.write_text(..., encoding="utf-8")` and no `newline=""`, so Windows turned the trailing `\n` into `\r\n`, then compared those bytes against an expectation built with plain `str.encode()`, which is LF only. That is the tests' own doing, and `newline=""` is a no-op everywhere else. One test compared `resolve_output`'s result against an unresolved driveless path; resolving a driveless path on Windows supplies the current drive, so the two could only agree where resolving does nothing.

**Commit 3 corrects commit 1.** Commit 1 resolved bash with `shutil.which` and I said that avoided the WSL launcher. It does not. On a machine with WSL installed, `shutil.which("bash")` *returns* the WSL launcher:

```
shutil.which("bash") -> C:\Windows\System32\bash.exe   uname=Linux     rc=127
C:\Program Files\Git\usr\bin\bash.exe                  no coreutils    dirname: command not found
C:\Program Files\Git\bin\bash.exe                      uname=MINGW64   runs
```

WSL cannot see a `C:` path in either slash form, and Git ships two bash binaries where only `Git\bin\bash.exe` puts the MSYS coreutils on PATH. Commit 3 resolves the bash beside the `git` already on PATH and falls back to the well-known locations. It also lifts that into a shared module, because `test_release_audit_evidence` invokes a `.sh` the same way and needs the same answer.

**Why the count does not move.** Commit 3 is a prerequisite, not a reduction. Before it, those scripts never started. After it they start and hit the next thing:

```
/c/agents/Prns/tools/release/sign-flasher-document.sh: line 32: shasum: command not found
```

**Git for Windows ships `sha256sum` but no `shasum`.** `finalize-flasher-candidate.py:133` already handles exactly this, with `if command -v shasum ... else sha256sum`. `sign-flasher-document.sh:32` and `write-release-audit-evidence.sh:11-12` call `shasum` bare, and `tools/tasks.toml:786` declares `requires = ["bash", "git", "shasum"]`. I have not touched those, because making release signing portable is your call rather than something to slip into a test patch. Say the word and I will do it the way `finalize-flasher-candidate.py` already does.

**What the remaining 13 actually are**, each confirmed rather than assumed:

| n | tests | cause |
|---|---|---|
| 7 | `test_flasher_release_custody` | scripts now run, then `shasum` is missing |
| 1 | `test_release_audit_evidence` | same, `shasum` missing |
| 3 | `MinisignWorkflowTests` | the fixture writes a shell-script fake minisign and the code under test execs it |
| 1 | `..._temporary_directory_is_private...` | asserts a POSIX mode; Windows reports `511`, not `448` |
| 1 | `test_head_and_executable_identity_are_hashed` | expects `chmod +x` to change a digest; Windows has no executable bit |

The last two are things Windows cannot express, so they want a skip with a reason rather than a fix. The middle three are a fixture choice. The first eight are the `shasum` question above.

Ran:

- Windows 11, `x86_64-pc-windows-msvc`, Python 3.13.6 - `python -m unittest discover -s tools/tests`, 27 problems to 13
- Ubuntu 24.04.2, Python 3.12.3, this branch on `98820b6f` - **`Ran 199 tests` / `OK`**, measured against a control run of the branch without commit 3 which is also `OK`, so the shared module changes nothing there
- `bash validation/hygiene/fmt-docs.sh` - `FMT_DOC_CHECK_GATE_OK`
- `python validation/run.py verify` - `VALIDATION_REGISTRY_OK`
- `./tools/prns verify` - `TOOLING_REGISTRY_OK`

I originally reported this PR as 29 problems down to 7. Trunk moved and so did both ends of that measurement; the table above is the current honest version.



---

**Re-measured 2026-08-08 on trunk `5b63de39`**, after today's Windows work landed upstream (`f0ecdb72` fixes the python front door in `tools/prns.cmd` and the task runner; `e5e59f0f` and `5b63de39` gate the Rust-side tests). Those are complementary to this branch rather than overlapping: the front door now resolves python correctly, and the per-test launcher here is still what lets the suite's own scripts start.

```
trunk 5b63de39     26 problems
this branch        13 problems   12 fixed, 0 regressions
```

The remaining 13 decompose exactly as the table above already says: 8 on the missing `shasum` (your call, offer stands), 3 on the shell-script fake minisign fixture, 2 on POSIX-only assertions that want skips. Rebased onto `5b63de39` with no content changes.
