### PR TITLE
test: wait out ETXTBSY when a publication fixture is re-run

### DIFF
--- a/prnsd/src/interface_discovery/publication/tests.rs
+++ b/prnsd/src/interface_discovery/publication/tests.rs
@@ -263,6 +263,33 @@ fn duplicate_attached_interface_ids_are_rejected() {
     ));
 }
 
+/// Resolve a fixture executable this test just wrote, waiting out a transient `ETXTBSY`.
+///
+/// Linux refuses to execute a file that any process still holds open for writing. These tests
+/// write the script they then run, and a sibling test thread that forks for its own unrelated
+/// child inherits the open write descriptor for the moment before its `exec` drops it. Measured on
+/// Ubuntu 24.04: with no sibling forker, 300 write-then-exec rounds gave 0 failures; with one,
+/// 49 of 300 failed this way. Production never writes the operator's `reachable-on` script, so the
+/// window belongs to the fixture and the wait belongs here rather than in `resolve_reachable_on`.
+#[cfg(unix)]
+async fn resolve_reachable_on_settled(
+    path: &str,
+    interface: InterfaceId,
+    interface_name: &str,
+) -> Result<String, DiscoveryAdvertisementResolutionError> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let outcome = resolve_reachable_on(path, interface, interface_name).await;
+        match &outcome {
+            Err(DiscoveryAdvertisementResolutionError::Execute { source, .. })
+                if source.kind() == std::io::ErrorKind::ExecutableFileBusy
+                    && std::time::Instant::now() < deadline => {}
+            _ => return outcome,
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn executable_reachable_on_is_re_evaluated_for_each_advertisement() {
@@ -281,7 +308,7 @@ async fn executable_reachable_on_is_re_evaluated_for_each_advertisement() {
     let id = interface_id(0x51);
 
     assert_eq!(
-        resolve_reachable_on(
+        resolve_reachable_on_settled(
             executable.to_str().expect("the fixture path is UTF-8"),
             id,
             "Public TCP",
@@ -300,7 +327,7 @@ async fn executable_reachable_on_is_re_evaluated_for_each_advertisement() {
     fs::set_permissions(&replacement, permissions).expect("the replacement can be made executable");
     fs::rename(&replacement, &executable).expect("the fixture executable can change");
     assert_eq!(
-        resolve_reachable_on(
+        resolve_reachable_on_settled(
             executable.to_str().expect("the fixture path is UTF-8"),
             id,
             "Public TCP",
@@ -327,7 +354,7 @@ async fn failed_reachable_on_executable_is_typed() {
     fs::set_permissions(&executable, permissions).expect("the fixture can be made executable");
 
     assert!(matches!(
-        resolve_reachable_on(
+        resolve_reachable_on_settled(
             executable.to_str().expect("the fixture path is UTF-8"),
             interface_id(0x51),
             "Public TCP",

--- a/prnsd/src/interface_discovery/publication/tests.rs
+++ b/prnsd/src/interface_discovery/publication/tests.rs
@@ -265,12 +265,12 @@ fn duplicate_attached_interface_ids_are_rejected() {
 
 /// Resolve a fixture executable this test just wrote, waiting out a transient `ETXTBSY`.
 ///
-/// Linux refuses to execute a file that any process still holds open for writing. These tests
-/// write the script they then run, and a sibling test thread that forks for its own unrelated
-/// child inherits the open write descriptor for the moment before its `exec` drops it. Measured on
-/// Ubuntu 24.04: with no sibling forker, 300 write-then-exec rounds gave 0 failures; with one,
-/// 49 of 300 failed this way. Production never writes the operator's `reachable-on` script, so the
-/// window belongs to the fixture and the wait belongs here rather than in `resolve_reachable_on`.
+/// Linux refuses to execute a file that any process still holds open for writing.
+/// These tests write the script they then run, and a sibling test thread that forks for its own unrelated child inherits the open write descriptor for the moment before its `exec` drops it.
+///
+/// Measured on Ubuntu 24.04: with no sibling forker, 300 write-then-exec rounds gave 0 failures; with one, 49 of 300 failed this way.
+///
+/// Production never writes the operator's `reachable-on` script, so the window belongs to the fixture and the wait belongs here rather than in `resolve_reachable_on`.
 #[cfg(unix)]
 async fn resolve_reachable_on_settled(
     path: &str,


### PR DESCRIPTION
Three tests in `interface_discovery::publication::tests` write a shell script and then execute it.
Linux refuses to exec a file that any process still holds open for writing, so they occasionally
fail like this:

```
the second execution succeeds: Execute {
  path: "/tmp/prnsd-discovery-publication-.../reachable-on",
  source: Os { code: 26, kind: ExecutableFileBusy, message: "Text file busy" } }
```

`fs::write` has already closed its descriptor by the time the exec happens, so the writing thread
isn't the problem. The problem is a sibling. `fork` copies the whole descriptor table, so any other
test thread that spawns a child inside that window inherits the write descriptor and holds it until
its own `exec` drops it. That sibling doesn't have to be doing anything related. This is what turned
CI red on a change that touched none of this code.

I measured it rather than assume it. 300 write-then-exec rounds, descriptor held 2ms:

```
no sibling forker, no retry           300 ok,  0 ETXTBSY
sibling forking /bin/true, no retry    248 ok, 52 ETXTBSY
sibling forker, bounded retry          300 ok,  0 ETXTBSY
```

The control line is the one that matters: with nothing else forking, the same loop never fails. So
it really is the sibling's inherited descriptor and not the write itself.

I left `resolve_reachable_on` alone. Production runs the operator's `reachable_on` script and never
writes it, so it has no write descriptor of its own to race, and swallowing ETXTBSY there would
paper over a real condition on the operator's file that they would want reported. The window is the
fixture's own making, so the wait belongs in a test helper.

All three call sites use it now, not just the one that failed. The helper returns the `Result`
unchanged rather than unwrapping, so `failed_reachable_on_executable_is_typed` still asserts on its
non-zero exit exactly as before.

This is not hypothetical. It failed again in CI on #71 while I was writing this, in the
`feature-configs` lane, at the second of the three sites:

```
panicked at src/interface_discovery/publication/tests.rs:309:10:
the second execution succeeds: Execute {
  path: "/tmp/prnsd-discovery-publication-35041-.../reachable-on",
  source: Os { code: 26, kind: ExecutableFileBusy, message: "Text file busy" } }
test result: FAILED. 183 passed; 1 failed
```

That was the only failing test in the run, and `Release critical` went red purely because it
requires every lane. So one flake in a fixture is currently the whole reason that PR is red.

Ran on Ubuntu 24.04 under WSL against trunk `98820b6f`: `cargo test` from `prnsd/` green at
181 + 7 + 1 + 12 + 3 + 3 + 4, `cargo clippy --all-targets -- -D warnings` clean, and the unit
binary 40/40 green at `--test-threads=64`. `bash validation/hygiene/fmt-docs.sh`,
`python validation/run.py verify` and `./tools/prns verify` green on Windows.