### PR TITLE
hopspot: match the source page assertions to the reworded copy

### DIFF
--- a/personal-hopspot/core/src/node_pages.rs
+++ b/personal-hopspot/core/src/node_pages.rs
@@ -345,7 +345,7 @@ mod tests {
             SERVES_SOURCE_ARCHIVE
         );
         assert_eq!(
-            source_page.contains("This compact build doesn't carry the source archive"),
+            source_page.contains("does not carry the multi-megabyte source archive"),
             !SERVES_SOURCE_ARCHIVE
         );
         assert_eq!(
@@ -385,7 +385,7 @@ mod tests {
             SERVES_SOURCE_ARCHIVE
         );
         assert_eq!(
-            source_page.contains("This compact build doesn't carry the source archive"),
+            source_page.contains("does not carry the multi-megabyte source archive"),
             !SERVES_SOURCE_ARCHIVE
         );
         assert_eq!(


### PR DESCRIPTION
The `ci` workflow is red on trunk at `98820b6f`. Both `node_pages` tests fail:

```
node_pages::tests::route_registration_and_page_language_share_one_capability ... FAILED
node_pages::tests::the_browser_face_carries_the_shared_nav_and_pages ... FAILED
test result: FAILED. 114 passed; 2 failed
```

`6c7bb4c7` reworded `source_missing.mu`:

```
-Every Prns node can host its own source code and serve it right over this connection. This compact build doesn't carry the source archive.
+Embedded release firmware does not carry the multi-megabyte source archive. The exact release source remains available from the hosted project and release pages.
```

`node_pages.rs` still asserts the old sentence, in the two blocks that panic at lines 347 and 387. That one stale string is what fails those two tests.

I matched the assertions to the new copy, trimmed to `does not carry the multi-megabyte source archive`, which is the part actually carrying the meaning. A further copy edit around it then won't turn the build red for a wording change.

Verified on Ubuntu 24.04. On clean trunk, `cargo test -p personal-hopspot-core node_pages` gives 4 passed / 2 failed, panicking at exactly those two lines. With this change it's 6 passed / 0 failed, and the whole package is 116 passed / 0 failed. `bash validation/hygiene/fmt-docs.sh`, `python validation/run.py verify` and `./tools/prns verify` are green on Windows.

One thing I left alone: those two tests assert the same three things about `SOURCE_PAGE` in two separate blocks, which is why a single copy edit broke two tests. Happy to fold them into one shared helper as a follow-up if you'd like, but that felt like a different change than getting trunk green.
