### PR TITLE
ci: drop the website lint step for the build mode that was removed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,8 +214,6 @@ jobs:
         run: cargo fmt --manifest-path docs/website/Cargo.toml -- --check
       - name: Website Rust contract tests
         run: cargo test --manifest-path docs/website/Cargo.toml --locked
-      - name: Compact embedded website shell
-        run: cargo clippy --manifest-path docs/website/Cargo.toml --locked --all-targets --features embedded-site -- -D warnings
       - name: Exact JavaScript graph and fake-serial suite
         working-directory: docs/website
         run: |


### PR DESCRIPTION
`flasher-contracts` has been red on trunk since `a965d067`. The failing step is the last one that still knows about the embedded build mode:

```
error: the package 'reticulum-site' does not contain this feature: embedded-site
Process completed with exit code 101.
```

`a965d067 website: remove embedded build mode` took out `docs/website/src/embedded.rs`, the `site_mode` plumbing, and the `embedded-site` feature itself. `docs/website/Cargo.toml` now offers `default`, `browser-test-fixture` and `local-dev-flasher`. The workflow step was the one caller left behind, so it can only fail: there's no feature left for it to enable.

It's also redundant now. `Website Rust shell`, a few lines above it, already runs

```
cargo clippy --manifest-path docs/website/Cargo.toml --locked --all-targets -- -D warnings
```

which is the same command minus the feature that no longer exists, and it passes on the same run that the compact step fails on. So deleting the step loses no coverage.

Checked with `git grep embedded-site` at `91098021`: that workflow line was the only reference left anywhere in the tree. After this change there are none. I also swept every other `--features` in the workflows against the manifest that would have to define it, and this was the only stale one.

Verified on Windows 11: `bash validation/hygiene/fmt-docs.sh` gives `FMT_DOC_CHECK_GATE_OK`, `python validation/run.py verify` gives `VALIDATION_REGISTRY_OK`, `./tools/prns verify` gives `TOOLING_REGISTRY_OK`, and the workflow still parses to 14 jobs.

I left the other red lanes alone. `deny` is failing separately on `unsafe dependency snapshot drifted`, and `test` and `android-service` fail on the `node_pages` copy assertions, which is #75.
