### PR TITLE
desktop: move the label test module below the items it precedes

### DIFF
--- a/personal-hopspot/desktop/src/desktop/runtime.rs
+++ b/personal-hopspot/desktop/src/desktop/runtime.rs
@@ -73,34 +73,6 @@ pub(super) fn classify(
     }
 }
 
-#[cfg(test)]
-mod label_tests {
-    use super::*;
-
-    #[test]
-    fn every_desktop_interface_label_fits_its_card() {
-        let wifi_id = InterfaceId::from_channel_tag(InterfaceKind::AutoWifi, b"wifi");
-        let tcp_id = InterfaceId::from_channel_tag(InterfaceKind::TcpClient, b"tcp");
-        let ids = [
-            USB_INTERFACE_ID,
-            wifi_id,
-            tcp_id,
-            InterfaceId::from_channel_tag(InterfaceKind::BluetoothAuto, b"ble"),
-            InterfaceId::from_channel_tag(InterfaceKind::WifiDirect, b"direct"),
-            InterfaceId::from_channel_tag(InterfaceKind::BluetoothPeer, b"ble-peer"),
-            InterfaceId::from_channel_tag(InterfaceKind::WifiDirectPeer, b"direct-peer"),
-        ];
-        for id in ids {
-            let (kind, label) = classify(id, wifi_id, Some(tcp_id), Some("rns.michmesh.net"))
-                .expect("known interface has a card");
-            assert!(
-                label.chars().count() <= screen::card_label_max_chars(kind),
-                "{label:?} exceeds its card"
-            );
-        }
-    }
-}
-
 pub(super) struct WindowHandles {
     pub(super) handle: PrnsNodeHandle,
     pub(super) usb_status: TokioInterfaceStatus,
@@ -413,6 +385,34 @@ async fn watch_hotplug(rescan: Arc<Notify>) {
     while let Some(event) = events.next().await {
         if event.is_ok() {
             rescan.notify_one();
+        }
+    }
+}
+
+#[cfg(test)]
+mod label_tests {
+    use super::*;
+
+    #[test]
+    fn every_desktop_interface_label_fits_its_card() {
+        let wifi_id = InterfaceId::from_channel_tag(InterfaceKind::AutoWifi, b"wifi");
+        let tcp_id = InterfaceId::from_channel_tag(InterfaceKind::TcpClient, b"tcp");
+        let ids = [
+            USB_INTERFACE_ID,
+            wifi_id,
+            tcp_id,
+            InterfaceId::from_channel_tag(InterfaceKind::BluetoothAuto, b"ble"),
+            InterfaceId::from_channel_tag(InterfaceKind::WifiDirect, b"direct"),
+            InterfaceId::from_channel_tag(InterfaceKind::BluetoothPeer, b"ble-peer"),
+            InterfaceId::from_channel_tag(InterfaceKind::WifiDirectPeer, b"direct-peer"),
+        ];
+        for id in ids {
+            let (kind, label) = classify(id, wifi_id, Some(tcp_id), Some("rns.michmesh.net"))
+                .expect("known interface has a card");
+            assert!(
+                label.chars().count() <= screen::card_label_max_chars(kind),
+                "{label:?} exceeds its card"
+            );
         }
     }
 }


### PR DESCRIPTION
The feature-configs and windows-desktop lanes have been red since a965d067 because clippy's items_after_test_module fires in personal-hopspot/desktop/src/desktop/runtime.rs: the #[cfg(test)] mod label_tests block sits at line 76, ahead of WindowHandles, run(), and the rest of the file. With -D warnings that's an error.

This moves the module to the end of the file. Pure relocation, 28 lines out and the same 28 back in, no change to the test itself.

Verified by diff that the module content is byte-identical before and after. I attempted a local clippy run to confirm the lane goes green, but this host lacks the SDL2 build environment the CI job provisions, so sdl2-sys fails before clippy gets to the crate. The lint is positional by definition, so the relocation resolves it; CI on this PR will be the confirming run.