### PR TITLE
validation: stop treating vendored crates as first-party in the unsafe audit

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -2361,7 +2361,7 @@ SOFTWARE.
 
 License: MIT License
 
-Used by: `bitfield-macros 0.19.4`, `block2 0.5.1`, `block2 0.6.2`, `bluez-async 0.8.2`, `bluez-generated 0.4.0`, `btleplug 0.12.0`, `btuuid 0.1.1`, `cesu8 1.1.0`, `const-serialize 0.7.2`, `const-serialize 0.8.0-alpha.0`, `const-serialize-macro 0.7.2`, `const-serialize-macro 0.8.0-alpha.0`, `cortex-m-rt 0.7.5`, `cortex-m-rt-macros 0.7.5`, `custom_debug 0.6.2`, `custom_debug_derive 0.6.2`, `deku_derive 0.18.1`, `delegate 0.13.5`, `dioxus 0.7.5`, `dioxus-asset-resolver 0.7.9`, `dioxus-cli-config 0.7.9`, `dioxus-config-macro 0.7.9`, `dioxus-config-macros 0.7.9`, `dioxus-core 0.7.9`, `dioxus-core-macro 0.7.9`, `dioxus-core-types 0.7.9`, `dioxus-devtools 0.7.9`, `dioxus-devtools-types 0.7.9`, `dioxus-document 0.7.9`, `dioxus-history 0.7.9`, `dioxus-hooks 0.7.9`, `dioxus-html 0.7.9`, `dioxus-html-internal-macro 0.7.9`, `dioxus-interpreter-js 0.7.9`, `dioxus-logger 0.7.9`, `dioxus-router 0.7.9`, `dioxus-router-macro 0.7.9`, `dioxus-rsx 0.7.9`, `dioxus-signals 0.7.9`, `dioxus-stores 0.7.9`, `dioxus-stores-macro 0.7.9`, `dioxus-web 0.7.9`, `dispatch 0.2.0`, `dispatch2 0.3.1`, `dlopen2 0.8.2`, `docs 0.1.0`, `docsplay-macros 0.1.2`, `dpi 0.1.2`, `embassy-embedded-hal 0.6.0`, `embassy-executor 0.10.0`, `embassy-executor-macros 0.8.0`, `embassy-executor-timer-queue 0.1.0`, `embassy-futures 0.1.2`, `embassy-hal-internal 0.4.0`, `embassy-hal-internal 0.5.0`, `embassy-net 0.9.1`, `embassy-net-driver 0.2.0`, `embassy-net-driver-channel 0.4.0`, `embassy-nrf 0.10.0`, `embassy-sync 0.6.2`, `embassy-sync 0.7.2`, `embassy-sync 0.8.0`, `embassy-time 0.5.1`, `embassy-time-driver 0.2.2`, `embassy-time-queue-utils 0.3.2`, `embassy-usb 0.6.0`, `embassy-usb-driver 0.2.2`, `embassy-usb-synopsys-otg 0.3.3`, `embedded-graphics-core 0.4.1`, `embedded-nal-async 0.9.0`, `esp-alloc 0.10.0`, `esp-backtrace 0.19.0`, `esp-bootloader-esp-idf 0.5.0`, `esp-config 0.7.0`, `esp-hal 1.1.1`, `esp-hal-procmacros 0.22.0`, `esp-metadata-generated 0.4.0`, `esp-phy 0.2.0`, `esp-println 0.17.0`, `esp-radio 0.18.0`, `esp-radio-rtos-driver 0.3.0`, `esp-riscv-rt 0.14.0`, `esp-rom-sys 0.1.4`, `esp-rtos 0.3.0`, `esp-sync 0.2.1`, `esp-wifi-sys-esp32c6 0.2.0`, `esp-wifi-sys-esp32s3 0.2.0`, `esp32c6 0.23.2`, `esp32s3 0.35.2`, `fluent-langneg 0.13.1`, `generational-box 0.7.9`, `gloo-timers 0.3.0`, `hopspot-flash 0.3.3`, `hopspot-heltec-v4 0.1.0`, `hopspot-heltec-v4-r8 0.1.0`, `hopspot-t-beam-supreme 0.1.0`, `hopspot-xiao-esp32-c6 0.1.0`, `intl_pluralrules 7.0.2`, `jni-sys-macros 0.4.1`, `lazy-js-bundle 0.7.9`, `macaddr 1.0.1`, `manganis 0.7.9`, `manganis-core 0.7.9`, `manganis-macro 0.7.9`, `minisign-verify 0.2.5`, `napi 3.11.0`, `napi-build 2.3.2`, `napi-derive 3.6.0`, `napi-derive-backend 6.0.0`, `napi-sys 3.3.0`, `ndk-context 0.1.1`, `netlink-packet-core 0.8.1`, `netlink-sys 0.8.8`, `nrf-softdevice 0.1.0`, `nrf-softdevice-macro 0.1.0`, `objc-sys 0.3.5`, `objc2 0.5.2`, `objc2 0.6.4`, `objc2-app-kit 0.2.2`, `objc2-app-kit 0.3.2`, `objc2-core-bluetooth 0.2.2`, `objc2-core-bluetooth 0.3.2`, `objc2-core-foundation 0.3.2`, `objc2-core-graphics 0.3.2`, `objc2-core-wlan 0.3.2`, `objc2-encode 4.1.0`, `objc2-foundation 0.2.2`, `objc2-foundation 0.3.2`, `objc2-io-kit 0.3.2`, `objc2-security 0.3.2`, `objc2-security-foundation 0.3.2`, `objc2-system-configuration 0.3.2`, `ouroboros 0.18.5`, `ouroboros_macro 0.18.5`, `parse_int 0.9.0`, `personal-hopspot-android 0.1.0`, `personal-hopspot-core 0.1.0`, `personal-hopspot-desktop 0.1.0`, `personal-hopspot-esp32 0.1.0`, `personal-hopspot-ios 0.1.0`, `personal-rns 0.3.3`, `portable_atomic_enum 0.3.1`, `portable_atomic_enum_macros 0.2.1`, `prns-config 0.3.3`, `prns-core 0.3.3`, `prns-ffi 0.3.3`, `prns-flash-manifest 0.1.0`, `prns-host 0.3.3`, `prns-host-cooperative 0.3.3`, `prns-host-native 0.3.3`, `prns-interfaces-embassy 0.3.3`, `prns-interfaces-tokio 0.3.3`, `prns-runtime 0.3.3`, `prns-runtime-embassy 0.3.3`, `prns-runtime-tokio 0.3.3`, `prns-tools-command 0.1.0`, `prns-wasm 0.3.3`, `prnsd 0.3.3`, `prnsd-control 0.1.0`, `reticulum-site 0.1.0`, `riscv-macros 0.3.0`, `riscv-rt-macros 0.6.1`, `rlsf 0.2.2`, `sledgehammer_bindgen 0.6.0`, `sledgehammer_bindgen_macro 0.6.5`, `sledgehammer_utils 0.3.1`, `subsecond 0.7.9`, `subsecond-types 0.7.9`, `t-echo 0.1.0`, `tokio-udev 0.9.1`, `trouble-host 0.6.0`, `trouble-host-macros 0.4.0`, `type-map 0.5.1`, `ufmt-write 0.1.0`, `usbd-hid-descriptors 0.10.0`, `usbd-hid-macros 0.10.0`, `void 1.0.2`, `warnings 0.2.1`, `warnings-macro 0.2.0`, `windows 0.58.0`, `windows 0.62.2`, `windows-collections 0.3.2`, `windows-core 0.58.0`, `windows-core 0.62.2`, `windows-future 0.3.2`, `windows-implement 0.58.0`, `windows-implement 0.60.2`, `windows-interface 0.58.0`, `windows-interface 0.59.3`, `windows-link 0.2.1`, `windows-numerics 0.3.1`, `windows-result 0.2.0`, `windows-result 0.4.1`, `windows-strings 0.1.0`, `windows-strings 0.5.1`, `windows-sys 0.52.0`, `windows-sys 0.59.0`, `windows-sys 0.61.2`, `windows-targets 0.52.6`, `windows-threading 0.2.1`, `windows_x86_64_msvc 0.52.6`, `xtensa-lx 0.13.0`, `xtensa-lx-rt 0.22.0`, `xtensa-lx-rt-proc-macros 0.5.0`
+Used by: `bitfield-macros 0.19.4`, `block2 0.5.1`, `block2 0.6.2`, `bluez-async 0.8.2`, `bluez-generated 0.4.0`, `btleplug 0.12.0`, `btuuid 0.1.1`, `cesu8 1.1.0`, `const-serialize 0.7.2`, `const-serialize 0.8.0-alpha.0`, `const-serialize-macro 0.7.2`, `const-serialize-macro 0.8.0-alpha.0`, `cortex-m-rt 0.7.5`, `cortex-m-rt-macros 0.7.5`, `custom_debug 0.6.2`, `custom_debug_derive 0.6.2`, `deku_derive 0.18.1`, `delegate 0.13.5`, `dioxus 0.7.5`, `dioxus-asset-resolver 0.7.9`, `dioxus-cli-config 0.7.9`, `dioxus-config-macro 0.7.9`, `dioxus-config-macros 0.7.9`, `dioxus-core 0.7.9`, `dioxus-core-macro 0.7.9`, `dioxus-core-types 0.7.9`, `dioxus-devtools 0.7.9`, `dioxus-devtools-types 0.7.9`, `dioxus-document 0.7.9`, `dioxus-history 0.7.9`, `dioxus-hooks 0.7.9`, `dioxus-html 0.7.9`, `dioxus-html-internal-macro 0.7.9`, `dioxus-interpreter-js 0.7.9`, `dioxus-logger 0.7.9`, `dioxus-router 0.7.9`, `dioxus-router-macro 0.7.9`, `dioxus-rsx 0.7.9`, `dioxus-signals 0.7.9`, `dioxus-stores 0.7.9`, `dioxus-stores-macro 0.7.9`, `dioxus-web 0.7.9`, `dispatch 0.2.0`, `dispatch2 0.3.1`, `dlopen2 0.8.2`, `docs 0.1.0`, `docsplay-macros 0.1.2`, `dpi 0.1.2`, `embassy-embedded-hal 0.6.0`, `embassy-executor 0.10.0`, `embassy-executor-macros 0.8.0`, `embassy-executor-timer-queue 0.1.0`, `embassy-futures 0.1.2`, `embassy-hal-internal 0.4.0`, `embassy-hal-internal 0.5.0`, `embassy-net 0.9.1`, `embassy-net-driver 0.2.0`, `embassy-net-driver-channel 0.4.0`, `embassy-nrf 0.10.0`, `embassy-sync 0.6.2`, `embassy-sync 0.7.2`, `embassy-sync 0.8.0`, `embassy-time 0.5.1`, `embassy-time-driver 0.2.2`, `embassy-time-queue-utils 0.3.2`, `embassy-usb 0.6.0`, `embassy-usb-driver 0.2.2`, `embassy-usb-synopsys-otg 0.3.3`, `embedded-graphics-core 0.4.1`, `embedded-nal-async 0.9.0`, `esp-alloc 0.10.0`, `esp-backtrace 0.19.0`, `esp-bootloader-esp-idf 0.5.0`, `esp-config 0.7.0`, `esp-hal 1.1.1`, `esp-hal-procmacros 0.22.0`, `esp-metadata-generated 0.4.0`, `esp-phy 0.2.0`, `esp-println 0.17.0`, `esp-radio-rtos-driver 0.3.0`, `esp-riscv-rt 0.14.0`, `esp-rom-sys 0.1.4`, `esp-rtos 0.3.0`, `esp-sync 0.2.1`, `esp-wifi-sys-esp32c6 0.2.0`, `esp-wifi-sys-esp32s3 0.2.0`, `esp32c6 0.23.2`, `esp32s3 0.35.2`, `fluent-langneg 0.13.1`, `generational-box 0.7.9`, `gloo-timers 0.3.0`, `hopspot-flash 0.3.3`, `hopspot-heltec-v4 0.1.0`, `hopspot-heltec-v4-r8 0.1.0`, `hopspot-t-beam-supreme 0.1.0`, `hopspot-xiao-esp32-c6 0.1.0`, `intl_pluralrules 7.0.2`, `jni-sys-macros 0.4.1`, `lazy-js-bundle 0.7.9`, `macaddr 1.0.1`, `manganis 0.7.9`, `manganis-core 0.7.9`, `manganis-macro 0.7.9`, `minisign-verify 0.2.5`, `napi 3.11.0`, `napi-build 2.3.2`, `napi-derive 3.6.0`, `napi-derive-backend 6.0.0`, `napi-sys 3.3.0`, `ndk-context 0.1.1`, `netlink-packet-core 0.8.1`, `netlink-sys 0.8.8`, `nrf-softdevice 0.1.0`, `nrf-softdevice-macro 0.1.0`, `objc-sys 0.3.5`, `objc2 0.5.2`, `objc2 0.6.4`, `objc2-app-kit 0.2.2`, `objc2-app-kit 0.3.2`, `objc2-core-bluetooth 0.2.2`, `objc2-core-bluetooth 0.3.2`, `objc2-core-foundation 0.3.2`, `objc2-core-graphics 0.3.2`, `objc2-core-wlan 0.3.2`, `objc2-encode 4.1.0`, `objc2-foundation 0.2.2`, `objc2-foundation 0.3.2`, `objc2-io-kit 0.3.2`, `objc2-security 0.3.2`, `objc2-security-foundation 0.3.2`, `objc2-system-configuration 0.3.2`, `ouroboros 0.18.5`, `ouroboros_macro 0.18.5`, `parse_int 0.9.0`, `personal-hopspot-android 0.1.0`, `personal-hopspot-core 0.1.0`, `personal-hopspot-desktop 0.1.0`, `personal-hopspot-ios 0.1.0`, `personal-rns 0.3.3`, `portable_atomic_enum 0.3.1`, `portable_atomic_enum_macros 0.2.1`, `prns-config 0.3.3`, `prns-core 0.3.3`, `prns-ffi 0.3.3`, `prns-flash-manifest 0.1.0`, `prns-host 0.3.3`, `prns-host-cooperative 0.3.3`, `prns-host-native 0.3.3`, `prns-interfaces-embassy 0.3.3`, `prns-interfaces-tokio 0.3.3`, `prns-runtime 0.3.3`, `prns-runtime-embassy 0.3.3`, `prns-runtime-tokio 0.3.3`, `prns-tools-command 0.1.0`, `prns-wasm 0.3.3`, `prnsd 0.3.3`, `prnsd-control 0.1.0`, `reticulum-site 0.1.0`, `riscv-macros 0.3.0`, `riscv-rt-macros 0.6.1`, `rlsf 0.2.2`, `sledgehammer_bindgen 0.6.0`, `sledgehammer_bindgen_macro 0.6.5`, `sledgehammer_utils 0.3.1`, `subsecond 0.7.9`, `subsecond-types 0.7.9`, `t-echo 0.1.0`, `tokio-udev 0.9.1`, `trouble-host 0.6.0`, `trouble-host-macros 0.4.0`, `type-map 0.5.1`, `ufmt-write 0.1.0`, `usbd-hid-descriptors 0.10.0`, `usbd-hid-macros 0.10.0`, `void 1.0.2`, `warnings 0.2.1`, `warnings-macro 0.2.0`, `windows 0.58.0`, `windows 0.62.2`, `windows-collections 0.3.2`, `windows-core 0.58.0`, `windows-core 0.62.2`, `windows-future 0.3.2`, `windows-implement 0.58.0`, `windows-implement 0.60.2`, `windows-interface 0.58.0`, `windows-interface 0.59.3`, `windows-link 0.2.1`, `windows-numerics 0.3.1`, `windows-result 0.2.0`, `windows-result 0.4.1`, `windows-strings 0.1.0`, `windows-strings 0.5.1`, `windows-sys 0.52.0`, `windows-sys 0.59.0`, `windows-sys 0.61.2`, `windows-targets 0.52.6`, `windows-threading 0.2.1`, `windows_x86_64_msvc 0.52.6`, `xtensa-lx 0.13.0`, `xtensa-lx-rt 0.22.0`, `xtensa-lx-rt-proc-macros 0.5.0`
 
 Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS, nRF52840, website Rust/WASM
 
@@ -2983,7 +2983,7 @@ License: MIT License
 
 Used by: `flate2 1.1.9`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
+Release graphs: daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
 
 ```text
 Copyright (c) 2014-2026 Alex Crichton
@@ -5014,7 +5014,7 @@ License: MIT License
 
 Used by: `simd-adler32 0.3.10`, `simd-adler32 0.3.9`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
+Release graphs: daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
 
 ```text
 MIT License
@@ -6477,6 +6477,38 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
+### MIT (907ffda4d70d)
+
+License: MIT License
+
+Used by: `esp-radio 0.18.0`, `personal-hopspot-esp32 0.1.0`
+
+Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam
+
+```text
+MIT License
+
+Copyright (c) 2026 The Prns Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
 ### MIT (917d5dc3470e)
 
 License: MIT License
@@ -6660,7 +6692,7 @@ License: MIT License
 
 Used by: `crc32fast 1.5.0`
 
-Release graphs: Android, ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS
+Release graphs: Android, Host SDK native, Node addon Linux, Node addon Windows, Node addon macOS, WASM, daemon Linux, daemon Windows, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64, iOS
 
 ```text
 MIT License
@@ -7414,7 +7446,7 @@ License: MIT License
 
 Used by: `miniz_oxide 0.8.9`
 
-Release graphs: ESP32-C6, ESP32-S3 Heltec, ESP32-S3 Heltec R8, ESP32-S3 T-Beam, daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
+Release graphs: daemon macOS, desktop Linux, desktop Windows, desktop macOS, engine, flasher Linux arm64, flasher Linux x86_64, flasher Windows x86_64, flasher macOS arm64, flasher macOS x86_64
 
 ```text
 MIT License

--- a/audits/unsafe-snapshot.json
+++ b/audits/unsafe-snapshot.json
@@ -1157,6 +1157,32 @@
     },
     {
       "graphs": {
+        "esp32-c6": [
+          "uuid"
+        ],
+        "esp32-s3-heltec": [
+          "uuid"
+        ],
+        "esp32-s3-heltec-r8": [
+          "uuid"
+        ],
+        "esp32-s3-tbeam": [
+          "uuid"
+        ]
+      },
+      "name": "bt-hci",
+      "source": "git+https://github.com/embassy-rs/bt-hci?rev=adae58af86d241237ba52ed27d0d9dc9588155ee#adae58af86d241237ba52ed27d0d9dc9588155ee",
+      "unsafe": {
+        "blocks": 11,
+        "externs": 0,
+        "functions": 1,
+        "impls": 35,
+        "tokens": 49
+      },
+      "version": "0.8.1"
+    },
+    {
+      "graphs": {
         "android": [
           "uuid"
         ],
@@ -1176,18 +1202,6 @@
           "uuid"
         ],
         "desktop-windows": [
-          "uuid"
-        ],
-        "esp32-c6": [
-          "uuid"
-        ],
-        "esp32-s3-heltec": [
-          "uuid"
-        ],
-        "esp32-s3-heltec-r8": [
-          "uuid"
-        ],
-        "esp32-s3-tbeam": [
           "uuid"
         ]
       },
@@ -5958,13 +5972,13 @@
         ]
       },
       "name": "esp-phy",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "source": "personal-hopspot/embedded/esp32/vendor/esp-phy-0.2.0",
       "unsafe": {
-        "blocks": 23,
+        "blocks": 25,
         "externs": 6,
         "functions": 0,
         "impls": 0,
-        "tokens": 33
+        "tokens": 35
       },
       "version": "0.2.0"
     },
@@ -6060,11 +6074,11 @@
       "name": "esp-radio",
       "source": "personal-hopspot/embedded/esp32/vendor/esp-radio-0.18.0",
       "unsafe": {
-        "blocks": 431,
-        "externs": 508,
+        "blocks": 439,
+        "externs": 511,
         "functions": 12,
         "impls": 3,
-        "tokens": 1012
+        "tokens": 1023
       },
       "version": "0.18.0"
     },
@@ -13901,11 +13915,11 @@
       "name": "personal-hopspot-esp32",
       "source": "personal-hopspot/embedded/esp32",
       "unsafe": {
-        "blocks": 449,
-        "externs": 508,
+        "blocks": 482,
+        "externs": 517,
         "functions": 14,
         "impls": 5,
-        "tokens": 1034
+        "tokens": 1080
       },
       "version": "0.1.0"
     },

--- a/audits/unsafe-snapshot.json
+++ b/audits/unsafe-snapshot.json
@@ -113,11 +113,7 @@
         "daemon-macos": [],
         "desktop-linux": [],
         "desktop-macos": [],
-        "desktop-windows": [],
-        "esp32-c6": [],
-        "esp32-s3-heltec": [],
-        "esp32-s3-heltec-r8": [],
-        "esp32-s3-tbeam": []
+        "desktop-windows": []
       },
       "name": "adler2",
       "source": "registry+https://github.com/rust-lang/crates.io-index",
@@ -4445,6 +4441,7 @@
         "android": [
           "medium-ethernet",
           "multicast",
+          "proto-ipv4",
           "proto-ipv6",
           "tcp",
           "udp"
@@ -4452,6 +4449,7 @@
         "daemon-linux": [
           "medium-ethernet",
           "multicast",
+          "proto-ipv4",
           "proto-ipv6",
           "tcp",
           "udp"
@@ -4459,6 +4457,7 @@
         "daemon-macos": [
           "medium-ethernet",
           "multicast",
+          "proto-ipv4",
           "proto-ipv6",
           "tcp",
           "udp"
@@ -4466,6 +4465,7 @@
         "daemon-windows": [
           "medium-ethernet",
           "multicast",
+          "proto-ipv4",
           "proto-ipv6",
           "tcp",
           "udp"
@@ -4473,6 +4473,7 @@
         "desktop-linux": [
           "medium-ethernet",
           "multicast",
+          "proto-ipv4",
           "proto-ipv6",
           "tcp",
           "udp"
@@ -4480,6 +4481,7 @@
         "desktop-macos": [
           "medium-ethernet",
           "multicast",
+          "proto-ipv4",
           "proto-ipv6",
           "tcp",
           "udp"
@@ -4487,6 +4489,7 @@
         "desktop-windows": [
           "medium-ethernet",
           "multicast",
+          "proto-ipv4",
           "proto-ipv6",
           "tcp",
           "udp"
@@ -4534,6 +4537,7 @@
         "host-c-linux": [
           "medium-ethernet",
           "multicast",
+          "proto-ipv4",
           "proto-ipv6",
           "tcp",
           "udp"
@@ -4541,6 +4545,7 @@
         "host-c-macos": [
           "medium-ethernet",
           "multicast",
+          "proto-ipv4",
           "proto-ipv6",
           "tcp",
           "udp"
@@ -4548,6 +4553,7 @@
         "host-c-windows": [
           "medium-ethernet",
           "multicast",
+          "proto-ipv4",
           "proto-ipv6",
           "tcp",
           "udp"
@@ -4555,6 +4561,7 @@
         "ios": [
           "medium-ethernet",
           "multicast",
+          "proto-ipv4",
           "proto-ipv6",
           "tcp",
           "udp"
@@ -6051,7 +6058,7 @@
         ]
       },
       "name": "esp-radio",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "source": "personal-hopspot/embedded/esp32/vendor/esp-radio-0.18.0",
       "unsafe": {
         "blocks": 431,
         "externs": 508,
@@ -6740,26 +6747,6 @@
         "desktop-windows": [
           "any_impl",
           "default",
-          "miniz_oxide",
-          "rust_backend"
-        ],
-        "esp32-c6": [
-          "any_impl",
-          "miniz_oxide",
-          "rust_backend"
-        ],
-        "esp32-s3-heltec": [
-          "any_impl",
-          "miniz_oxide",
-          "rust_backend"
-        ],
-        "esp32-s3-heltec-r8": [
-          "any_impl",
-          "miniz_oxide",
-          "rust_backend"
-        ],
-        "esp32-s3-tbeam": [
-          "any_impl",
           "miniz_oxide",
           "rust_backend"
         ]
@@ -10843,26 +10830,6 @@
           "simd",
           "simd-adler32",
           "with-alloc"
-        ],
-        "esp32-c6": [
-          "simd",
-          "simd-adler32",
-          "with-alloc"
-        ],
-        "esp32-s3-heltec": [
-          "simd",
-          "simd-adler32",
-          "with-alloc"
-        ],
-        "esp32-s3-heltec-r8": [
-          "simd",
-          "simd-adler32",
-          "with-alloc"
-        ],
-        "esp32-s3-tbeam": [
-          "simd",
-          "simd-adler32",
-          "with-alloc"
         ]
       },
       "name": "miniz_oxide",
@@ -13934,11 +13901,11 @@
       "name": "personal-hopspot-esp32",
       "source": "personal-hopspot/embedded/esp32",
       "unsafe": {
-        "blocks": 18,
-        "externs": 0,
-        "functions": 2,
-        "impls": 2,
-        "tokens": 22
+        "blocks": 449,
+        "externs": 508,
+        "functions": 14,
+        "impls": 5,
+        "tokens": 1034
       },
       "version": "0.1.0"
     },
@@ -18319,11 +18286,7 @@
           "const-generics",
           "default",
           "std"
-        ],
-        "esp32-c6": [],
-        "esp32-s3-heltec": [],
-        "esp32-s3-heltec-r8": [],
-        "esp32-s3-tbeam": []
+        ]
       },
       "name": "simd-adler32",
       "source": "registry+https://github.com/rust-lang/crates.io-index",
@@ -18488,6 +18451,7 @@
           "async",
           "medium-ethernet",
           "multicast",
+          "proto-ipv4",
           "proto-ipv6",
           "socket",
           "socket-tcp",
@@ -18497,6 +18461,7 @@
           "async",
           "medium-ethernet",
           "multicast",
+          "proto-ipv4",
           "proto-ipv6",
           "socket",
           "socket-tcp",
@@ -18506,6 +18471,7 @@
           "async",
           "medium-ethernet",
           "multicast",
+          "proto-ipv4",
           "proto-ipv6",
           "socket",
           "socket-tcp",
@@ -18515,6 +18481,7 @@
           "async",
           "medium-ethernet",
           "multicast",
+          "proto-ipv4",
           "proto-ipv6",
           "socket",
           "socket-tcp",
@@ -18524,6 +18491,7 @@
           "async",
           "medium-ethernet",
           "multicast",
+          "proto-ipv4",
           "proto-ipv6",
           "socket",
           "socket-tcp",
@@ -18533,6 +18501,7 @@
           "async",
           "medium-ethernet",
           "multicast",
+          "proto-ipv4",
           "proto-ipv6",
           "socket",
           "socket-tcp",
@@ -18542,6 +18511,7 @@
           "async",
           "medium-ethernet",
           "multicast",
+          "proto-ipv4",
           "proto-ipv6",
           "socket",
           "socket-tcp",
@@ -18607,6 +18577,7 @@
           "async",
           "medium-ethernet",
           "multicast",
+          "proto-ipv4",
           "proto-ipv6",
           "socket",
           "socket-tcp",
@@ -18616,6 +18587,7 @@
           "async",
           "medium-ethernet",
           "multicast",
+          "proto-ipv4",
           "proto-ipv6",
           "socket",
           "socket-tcp",
@@ -18625,6 +18597,7 @@
           "async",
           "medium-ethernet",
           "multicast",
+          "proto-ipv4",
           "proto-ipv6",
           "socket",
           "socket-tcp",
@@ -18634,6 +18607,7 @@
           "async",
           "medium-ethernet",
           "multicast",
+          "proto-ipv4",
           "proto-ipv6",
           "socket",
           "socket-tcp",

--- a/validation/security/unsafe-audit.py
+++ b/validation/security/unsafe-audit.py
@@ -78,6 +78,7 @@ UNSAFE_EXCEPTIONS = {
     "personal-hopspot-esp32",
 }
 UNDOCUMENTED_UNSAFE_POLICY_EXCEPTIONS = {"prns-host-c"}
+VENDOR_DIR_NAME = "vendor"
 
 
 def run_metadata(manifest: str, target: str) -> dict:
@@ -217,10 +218,16 @@ def display_source(package: dict, manifest_path: Path) -> str:
 
 def assert_first_party_policy(package: dict, manifest_path: Path) -> None:
     try:
-        manifest_path.relative_to(ROOT)
+        relative_manifest = manifest_path.relative_to(ROOT)
     except ValueError:
         return
     if package.get("source") is not None:
+        return
+    # A vendored upstream crate is patched in by path, so cargo reports no source
+    # and the checks above cannot tell it apart from our own code. Vendoring a
+    # dependency does not make us its author, and the forbid(unsafe_code) rule
+    # below is about code we write. Its unsafe is still counted into the snapshot.
+    if VENDOR_DIR_NAME in relative_manifest.parts:
         return
     name = package["name"]
     targets = [target for target in package["targets"] if target["kind"][0] in {"lib", "bin", "cdylib", "staticlib"}]


### PR DESCRIPTION
The deny lane fails on trunk since 27c72282 vendored esp-radio 0.18.0 under a [patch.crates-io] path override. Cargo reports source: null for path dependencies, the same shape as our own crates, so assert_first_party_policy swept the vendored crate into the first-party set and demanded #![forbid(unsafe_code)] on a crate with about a thousand unsafe sites across 63 files. The UNSAFE_EXCEPTIONS path doesn't work either: it then requires denying undocumented_unsafe_blocks across all of them.

Vendoring a dependency doesn't make us its author. The audit now skips the first-party policy assertions for any in-repo manifest under a vendor/ directory. Two exist now — esp-radio 0.18.0 and, since 558c6217, esp-phy 0.2.0 — and the regenerated baseline covers both. Their unsafe still counts into the snapshot, so the surface stays visible: the baseline records esp-radio at 1,012 unsafe tokens and esp-phy alongside it, each under its vendor path as the source.

Clearing that hard failure exposed a second latent one: the committed unsafe-snapshot.json predates the vendoring, so the audit then fails on snapshot drift. Regenerated via --write as the tool instructs. The baseline diff also picks up unrelated dependency-graph changes from recent trunk work (entries leaving the embedded graphs, proto-ipv4 feature additions) that were masked behind the hard failure.

Since the overnight bt-hci git pin, the deny job dies even earlier, at cargo-deny's sources check, before this audit code runs. With a one-line allow-git entry for that pin applied first, the lane advances exactly to the failure this PR fixes — `unsafe audit failed: shipped first-party target lacks forbid(unsafe_code): personal-hopspot/embedded/esp32/vendor/esp-phy-0.2.0/src/lib.rs` — and with both applied together the deny job runs green end to end on a fork run of ci.yml against current trunk: https://github.com/jackspace/Prns/actions/runs/31272372199

Verified: python validation/security/unsafe-audit.py exits 0 on this branch. Run on Windows, Python 3.13.