### PR TITLE
prnsd: reserve an 8 MiB stack on Windows so debug builds can start

### DIFF
--- a/prnsd/build.rs
+++ b/prnsd/build.rs
@@ -1,0 +1,13 @@
+use std::env;
+
+fn main() {
+    // Windows gives the main thread 1 MiB of stack where Linux and macOS give 8 MiB,
+    // and the unoptimized poll frame of run_command needs most of a MiB by itself,
+    // so debug binaries overflow at startup for every real subcommand. Reserve the
+    // same headroom the other platforms already assume.
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows")
+        && env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc")
+    {
+        println!("cargo:rustc-link-arg-bins=/STACK:8388608");
+    }
+}


### PR DESCRIPTION
Debug builds of prnsd can't run any real subcommand on Windows. Every one dies at startup with STATUS_STACK_OVERFLOW before the command's own code runs. cargo test on prnsd currently fails 11 of 12 tests in interfaces_cli this way, which is invisible in CI because no workflow runs cargo test on a Windows runner.

The mechanism, measured with stack pointer probes on a shielded thread: the unoptimized poll frame of run_command reserves about 927 KB, since a debug build keeps locals for the largest match arms whether or not they run. Windows gives the main thread 1 MiB where Linux and macOS give 8 MiB, and with the tray feature enabled (the default) main block_ons the command future on that 1 MiB thread. The future itself is only 64 KB and everything below interfaces::run uses under 12 KB, so the poll frame is the whole story. A release build's frame is about 89 KB, which is why shipped binaries are unaffected.

Bracketing the requirement by relinking: 1 MiB crashes, 2 MiB and up pass, and a default-stack rebuild still crashes as the control.

The fix reserves 8 MiB at link time for MSVC binaries via a build script, matching what the other platforms already provide. Verified on Windows 11 with MSVC: dumpbin reports the 0x800000 reserve, the repro command exits 0, and interfaces_cli goes from 1 passed 11 failed to 12 passed.