### PR TITLE
release: keep the pinned Minisign public key byte-exact on Windows checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 *.mu -text
+*.pub -text
 *.sh text eol=lf
 
 docs/website/web-flasher/browser/fixtures/signed-candidate/** -text

--- a/prns-flash-manifest/src/trust.rs
+++ b/prns-flash-manifest/src/trust.rs
@@ -101,6 +101,17 @@ mod tests {
     }
 
     #[test]
+    fn pinned_public_key_is_stored_with_line_feed_endings() {
+        assert!(
+            !PINNED_MINISIGN_PUBLIC_KEY.contains('\r'),
+            "release/keys/minisign.pub must be checked out with line-feed endings. `include_str!` \
+             bakes the working-tree bytes into every release binary, and a signed candidate always \
+             ships its key with line-feed endings, so a carriage return here makes the byte-exact \
+             candidate key comparison reject the correct key."
+        );
+    }
+
+    #[test]
     fn tampering_is_rejected() {
         assert!(matches!(
             verify_minisign(b"tampered", TEST_SIGNATURE, TEST_PUBLIC_KEY),


### PR DESCRIPTION
The published 0.3.3 Windows CLI can't verify any signed release. Every flash attempt fails at validating_manifest with "the Minisign signature is invalid: Invalid encoding in minisign data", error_code release_trust. I hit this today running the Windows acceptance rows against the signed candidate.

Root cause: PINNED_MINISIGN_PUBLIC_KEY is include_str!("../../release/keys/minisign.pub"), so every release binary carries whatever bytes its build checkout produced. Nothing in .gitattributes covered that path, and the Windows CLI is the only target built on a Windows runner, where the default core.autocrlf rewrites the key to CRLF at checkout. Reading the shipped hopspot-flash.exe confirms it: the embedded key at offset 4902208 contains CRLF line endings. The release's own minisign.pub asset is LF and verifies the same manifest and signature fine with standalone minisign on the same host, so the key material is right and only the embedded copy is mangled.

The fix pins the key path to LF in .gitattributes so every checkout produces identical bytes regardless of platform autocrlf settings.

Practical impact until this lands in a release: hopspot-flash on Windows is unusable for its core purpose, while the web flasher works fine on the same host since its verification ships in the website bundle built on a Linux runner.