### PR TITLE
deny: allow the pinned bt-hci git source

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -84,4 +84,7 @@ deny = []
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = ["https://github.com/embassy-rs/nrf-softdevice"]
+allow-git = [
+    "https://github.com/embassy-rs/bt-hci",
+    "https://github.com/embassy-rs/nrf-softdevice",
+]


### PR DESCRIPTION
Since fd8da2df pinned bt-hci to an embassy-rs git rev in `[patch.crates-io]`, the deny job dies at cargo-deny's sources check — `deny.toml` has `unknown-git = "deny"` and the allowlist only knows nrf-softdevice, so the pin the workspace itself asked for is refused:

```
error[source-not-allowed]: detected 'git' source not explicitly allowed
  bt-hci 0.8.1 git+https://github.com/embassy-rs/bt-hci?rev=adae58af...
advisories ok, bans ok, licenses ok, sources FAILED
```

One entry in `allow-git` fixes it. Verified on a fork run of your ci.yml against current trunk plus this change: `advisories ok, bans ok, licenses ok, sources ok`.

Two things worth knowing while you're in this lane:

1. With sources passing, the audit script gets further and surfaces the next layer: the unsafe audit still fails on `vendor/esp-phy-0.2.0/src/lib.rs` lacking `forbid(unsafe_code)` — the registration commits alone don't clear it, since the first-party test keys off a missing cargo source rather than the manifest registry. #79 covers that; with both applied the deny job runs green end to end, verified on a fork run of ci.yml against current trunk: https://github.com/jackspace/Prns/actions/runs/31272372199
2. The existing nrf-softdevice `allow-git` entry now warns `unmatched-source` (nothing resolves from it anymore). Left it alone — pruning it is your call.