### PR TITLE
usb_auto: derive the handshake test's read window from the liveness interval

### DIFF
--- a/prns-interfaces/impls/tokio/src/usb_auto/mod.rs
+++ b/prns-interfaces/impls/tokio/src/usb_auto/mod.rs
@@ -561,9 +561,13 @@ mod tests {
     where
         R: AsyncRead + Unpin,
     {
+        // The slowest frame this helper waits for is the next liveness Hello, one LIVENESS_PROBE_INTERVAL away.
+        // Matching that interval exactly leaves only a few milliseconds of slack, so keep whole periods of headroom.
+        const WINDOW: Duration = LIVENESS_PROBE_INTERVAL.saturating_mul(3);
+
         let mut buf = [0u8; 64];
         loop {
-            let n = tokio::time::timeout(Duration::from_secs(2), wire.read(&mut buf))
+            let n = tokio::time::timeout(WINDOW, wire.read(&mut buf))
                 .await
                 .expect("a frame arrives within the window")
                 .expect("the device wire stays open");


### PR DESCRIPTION
The `usb_auto` handshake test has been failing intermittently on trunk, most recently in run 31288636135 where it took the release-critical lane down with it. I had it written off as a busy runner, and that turned out to be wrong, so here is what is actually going on.

There are two constants doing the same 2 seconds. `LIVENESS_PROBE_INTERVAL` at `prns-interfaces/impls/tokio/src/usb_auto/mod.rs:37` is how often a confirmed host sends its liveness Hello. The `read_until` helper further down the same file wrapped each read in `tokio::time::timeout(Duration::from_secs(2), ...)`.

The last thing the test does is wait for the next liveness Hello. The one before it went out the instant `confirmed` flipped, because a tokio interval's first tick fires immediately, and it got eaten by the intermediate `read_until` that is filtering for `Message::Data`. So the frame the test is waiting for is due exactly one interval after the task started, and the test gives up one interval after the data exchange finished. The entire margin is however long that exchange took, which is a few milliseconds.

You can see it in the timings. Passing runs finish in 2.03 seconds and the failures land at 2.04. There is about ten milliseconds between working and not.

That is why it is not really a runner problem. I ran the test 15 times with no load at all on WSL2 with 4 cores and it failed twice, then 15 more times under 8 busy loops and it failed twice again. Load barely moves it, which is what you would expect from a fixed tiny margin rather than from CPU starvation.

The fix derives the window from the interval instead of restating it, with whole periods of headroom:

```rust
const WINDOW: Duration = LIVENESS_PROBE_INTERVAL.saturating_mul(3);
```

Same 30 runs, loaded and unloaded, now pass 30 out of 30. They still finish in 2.03 seconds, because the window is an upper bound and not a sleep, so nothing in the suite gets slower.

I deliberately left the plain `Duration::from_secs(2)` alone everywhere else. It is the convention across this crate and it is fine in `ax25_kiss`, `backbone`, `serial`, `udp` and the rest, because those all wait on something that happens immediately. This call site is the only one waiting on a periodic event, so it is the only one where the deadline and the period could line up.

One caveat on my numbers. My WSL box has no `libdbus-1-dev` and `bluetooth-auto` pulls `bluer` which needs it, so my 60 runs used `--features usb` rather than CI's `--all-features`. That is the feature that compiles the `usb_auto` module, and the change is a test-only constant, but it is a difference and I would rather say so than let it pass as full coverage.
