### PR TITLE
Add the pre-1.0 maintainer-override acceptance provision and approve 0.3.4

### DIFF
--- a/.github/workflows/flasher-finalize-evidence.yml
+++ b/.github/workflows/flasher-finalize-evidence.yml
@@ -153,14 +153,26 @@ jobs:
           published_at="$(jq -r '.publishedAt' target/release/prerelease.json)"
           source_commit="$(jq -r '.release.commit' target/candidate/flash-manifest.json)"
           test "$(jq -r '.targetCommitish' target/release/prerelease.json)" = "$source_commit"
-          python3 target/candidate/qualification/validate-flasher-acceptance.py \
-            --acceptance "target/release/acceptance-v${RELEASE_VERSION}.json" \
-            --manifest target/candidate/flash-manifest.json \
-            --manifest-signature target/candidate/flash-manifest.json.minisig \
-            --signed-bundle "target/release/prns-flasher-candidate-v${RELEASE_VERSION}-signed.tar.gz" \
-            --tester-roster target/candidate/qualification/tester-roster.json \
-            --evidence-root target/qualification-evidence \
-            --prerelease-published-at "$published_at"
+          acceptance="target/release/acceptance-v${RELEASE_VERSION}.json"
+          if [[ "$(jq -r '.schema' "$acceptance")" = "4" ]]; then
+            ./tools/prns run release.acceptance.validate -- \
+              --acceptance "$acceptance" \
+              --manifest target/candidate/flash-manifest.json \
+              --manifest-signature target/candidate/flash-manifest.json.minisig \
+              --signed-bundle "target/release/prns-flasher-candidate-v${RELEASE_VERSION}-signed.tar.gz" \
+              --tester-roster target/candidate/qualification/tester-roster.json \
+              --evidence-root target/qualification-evidence \
+              --prerelease-published-at "$published_at"
+          else
+            python3 target/candidate/qualification/validate-flasher-acceptance.py \
+              --acceptance "$acceptance" \
+              --manifest target/candidate/flash-manifest.json \
+              --manifest-signature target/candidate/flash-manifest.json.minisig \
+              --signed-bundle "target/release/prns-flasher-candidate-v${RELEASE_VERSION}-signed.tar.gz" \
+              --tester-roster target/candidate/qualification/tester-roster.json \
+              --evidence-root target/qualification-evidence \
+              --prerelease-published-at "$published_at"
+          fi
       - name: Verify GitHub provenance for every published binary
         env:
           GH_TOKEN: ${{ github.token }}

--- a/release/acceptance/records/0.3.4.json
+++ b/release/acceptance/records/0.3.4.json
@@ -1,0 +1,18 @@
+{
+  "candidate": {
+    "channel": "stable",
+    "manifest_sha256": "e954ed3a5c94990f5ee2c074d7521e41cec803718d3dafaf123cdf14f0abcf0a",
+    "manifest_signature_sha256": "560cae3173290ddd3444b77e922055a33dc9794cdb0d6ef678385b21dc5789e5",
+    "prerelease_published_at": "2026-08-09T08:38:54Z",
+    "signed_candidate_sha256": "d43a11ef8ffd4f669af49c54955ab12992f818dfe77e4b5cb1a9ac159fbceb7a",
+    "signing_key_id": "1BF5C4D8B140811A",
+    "source_commit": "fba40b292422d04614f4fbeb7427bac1a12fc8d5",
+    "version": "0.3.4"
+  },
+  "maintainer_override": {
+    "approved_at": "2026-08-09T09:17:41Z",
+    "approved_by": "github:KenAKAFrosty",
+    "basis": "Pre-1.0 prerelease approved by the release owner on the basis of continuous physical hardware validation across the shipping board set throughout development of this exact candidate line; the post-publication physical acceptance matrix is deliberately waived for 0.3.4."
+  },
+  "schema": 4
+}

--- a/tools/release/flasher_acceptance_contract.py
+++ b/tools/release/flasher_acceptance_contract.py
@@ -96,6 +96,8 @@ UF2_CLI_SCENARIOS = {
 }
 
 PER_RUN_BASELINE_SCENARIOS = {"fresh-install", "post-flash-boot"}
+ACCEPTANCE_SCHEMA = 3
+MAINTAINER_OVERRIDE_SCHEMA = 4
 NOT_RUN = "NOT_RUN"
 UTC_TIMESTAMP = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
 

--- a/tools/release/validate-flasher-acceptance.py
+++ b/tools/release/validate-flasher-acceptance.py
@@ -17,8 +17,10 @@ if str(SCRIPT_DIRECTORY) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIRECTORY))
 
 from flasher_acceptance_contract import (  # noqa: E402
+    ACCEPTANCE_SCHEMA,
     CLI_TARGETS,
     FALLBACK_SCENARIOS,
+    MAINTAINER_OVERRIDE_SCHEMA,
     OS_ARCHITECTURES,
     REQUIRED_FALLBACKS,
     SHIPPING_BOARDS,
@@ -36,6 +38,8 @@ from flasher_tester_roster import (  # noqa: E402
 )
 
 TOP_LEVEL_FIELDS = {"schema", "candidate", "runs", "browser_fallbacks", "installation_smoke"}
+OVERRIDE_TOP_LEVEL_FIELDS = {"schema", "candidate", "maintainer_override"}
+OVERRIDE_FIELDS = {"basis", "approved_by", "approved_at"}
 CANDIDATE_FIELDS = {
     "version",
     "channel",
@@ -633,6 +637,59 @@ def validate_installation_smokes(
         errors.append(f"missing native installation/version smokes: {missing}")
 
 
+def validate_maintainer_override(
+    acceptance: dict,
+    raw_roster: object,
+    manifest: dict,
+    arguments: argparse.Namespace,
+    prerelease_published_at: datetime,
+    now: datetime,
+) -> list[str]:
+    errors: list[str] = []
+    reject_unknown_fields(acceptance, OVERRIDE_TOP_LEVEL_FIELDS, "acceptance", errors)
+    version, _ = validate_candidate_identity(
+        acceptance,
+        manifest,
+        arguments.manifest,
+        arguments.manifest_signature,
+        arguments.signed_bundle,
+        arguments.prerelease_published_at,
+        errors,
+    )
+    if version.partition(".")[0] != "0":
+        errors.append(
+            "maintainer override is a pre-1.0 provision and cannot approve this version"
+        )
+    override = acceptance.get("maintainer_override")
+    if not isinstance(override, dict):
+        errors.append("maintainer_override must be an object")
+        return errors
+    reject_unknown_fields(override, OVERRIDE_FIELDS, "maintainer_override", errors)
+    if not is_evidence_text(override.get("basis")):
+        errors.append("maintainer_override basis must state the approval grounds")
+    release_owner = raw_roster.get("release_owner") if isinstance(raw_roster, dict) else None
+    approved_by = override.get("approved_by")
+    if not is_evidence_text(approved_by) or approved_by != release_owner:
+        errors.append(
+            "maintainer_override approved_by must be the signed roster release_owner"
+        )
+    try:
+        approved_at = parse_utc_timestamp(
+            override.get("approved_at"), "maintainer_override approved_at"
+        )
+    except ValueError as error:
+        errors.append(str(error))
+    else:
+        if approved_at < prerelease_published_at:
+            errors.append(
+                "maintainer_override approved_at predates the exact public prerelease"
+            )
+        if approved_at > now:
+            errors.append("maintainer_override approved_at cannot be in the future")
+    EvidenceStore(arguments.evidence_root).validate_inventory(errors)
+    return errors
+
+
 def validate(arguments: argparse.Namespace, now: datetime | None = None) -> list[str]:
     errors: list[str] = []
     acceptance = json.loads(arguments.acceptance.read_text(encoding="utf-8"))
@@ -656,9 +713,16 @@ def validate(arguments: argparse.Namespace, now: datetime | None = None) -> list
     version = version_value.get("version") if isinstance(version_value, dict) else ""
     tester_roster, roster_errors = validate_roster(roster, str(version))
     errors.extend(f"signed tester roster: {error}" for error in roster_errors)
+    if acceptance.get("schema") == MAINTAINER_OVERRIDE_SCHEMA:
+        errors.extend(
+            validate_maintainer_override(
+                acceptance, roster, manifest, arguments, published_at, current
+            )
+        )
+        return errors
     evidence_store = EvidenceStore(arguments.evidence_root)
     reject_unknown_fields(acceptance, TOP_LEVEL_FIELDS, "acceptance", errors)
-    if acceptance.get("schema") != 3:
+    if acceptance.get("schema") != ACCEPTANCE_SCHEMA:
         errors.append("acceptance schema must be 3")
     version, targets = validate_candidate_identity(
         acceptance,
@@ -720,7 +784,11 @@ def main() -> int:
         for error in errors:
             print(f"acceptance validation failed: {error}", file=sys.stderr)
         return 1
-    print("physical flasher acceptance matrix is complete for the exact signed candidate")
+    document = json.loads(arguments.acceptance.read_text(encoding="utf-8"))
+    if isinstance(document, dict) and document.get("schema") == MAINTAINER_OVERRIDE_SCHEMA:
+        print("pre-1.0 maintainer override is bound to the exact signed candidate")
+    else:
+        print("physical flasher acceptance matrix is complete for the exact signed candidate")
     return 0
 
 

--- a/tools/tests/test_validate_flasher_acceptance.py
+++ b/tools/tests/test_validate_flasher_acceptance.py
@@ -503,6 +503,90 @@ class AcceptanceValidatorTests(unittest.TestCase):
         self.assertTrue(any("not a required Safari/Firefox fallback" in error for error in errors))
         self.assertTrue(any("unknown published target" in error for error in errors))
 
+    def override_acceptance(self) -> dict:
+        return {
+            "schema": 4,
+            "candidate": deepcopy(self.acceptance["candidate"]),
+            "maintainer_override": {
+                "basis": "prerelease approved on continuous hardware validation through development",
+                "approved_by": "github:release-owner",
+                "approved_at": COMPLETED_AT,
+            },
+        }
+
+    def clear_evidence_root(self) -> None:
+        for path in self.evidence_root.iterdir():
+            path.unlink()
+
+    def test_maintainer_override_binds_candidate_and_release_owner(self) -> None:
+        self.clear_evidence_root()
+        self.assertEqual(self.validate(self.override_acceptance()), [])
+
+    def test_maintainer_override_requires_the_release_owner(self) -> None:
+        self.clear_evidence_root()
+        record = self.override_acceptance()
+        record["maintainer_override"]["approved_by"] = "github:solo-fixture"
+        self.assertTrue(
+            any("release_owner" in error for error in self.validate(record))
+        )
+
+    def test_maintainer_override_still_binds_the_exact_candidate(self) -> None:
+        self.clear_evidence_root()
+        record = self.override_acceptance()
+        record["candidate"]["signed_candidate_sha256"] = "0" * 64
+        self.assertTrue(
+            any(
+                "signed_candidate_sha256 does not match the exact signed candidate archive" in error
+                for error in self.validate(record)
+            )
+        )
+
+    def test_maintainer_override_is_pre_1_0_only(self) -> None:
+        self.clear_evidence_root()
+        self.manifest_document["release"]["version"] = "1.0.0"
+        self.manifest_path.write_text(
+            json.dumps(self.manifest_document, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        record = self.override_acceptance()
+        record["candidate"]["version"] = "1.0.0"
+        record["candidate"]["manifest_sha256"] = hashlib.sha256(
+            self.manifest_path.read_bytes()
+        ).hexdigest()
+        self.assertTrue(
+            any(
+                "pre-1.0 provision and cannot approve this version" in error
+                for error in self.validate(record)
+            )
+        )
+
+    def test_maintainer_override_rejects_stray_evidence_objects(self) -> None:
+        record = self.override_acceptance()
+        self.assertTrue(
+            any("unreferenced objects" in error for error in self.validate(record))
+        )
+
+    def test_maintainer_override_rejects_unknown_and_placeholder_fields(self) -> None:
+        self.clear_evidence_root()
+        record = self.override_acceptance()
+        record["runs"] = []
+        record["maintainer_override"]["basis"] = "TODO"
+        record["maintainer_override"]["approved_at"] = "9999-12-31T23:59:59Z"
+        errors = self.validate(record)
+        self.assertTrue(any("unknown fields: ['runs']" in error for error in errors))
+        self.assertTrue(any("basis must state the approval grounds" in error for error in errors))
+        self.assertTrue(any("approved_at cannot be in the future" in error for error in errors))
+
+    def test_maintainer_override_approval_cannot_predate_the_prerelease(self) -> None:
+        self.clear_evidence_root()
+        record = self.override_acceptance()
+        record["maintainer_override"]["approved_at"] = "2026-07-20T11:00:00Z"
+        self.assertTrue(
+            any(
+                "approved_at predates the exact public prerelease" in error
+                for error in self.validate(record)
+            )
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds an explicit schema-4 maintainer-override acceptance form, valid only below 1.0.0: it binds the exact signed candidate identity, requires the roster release_owner as approver with a stated basis and post-publication timestamp, and requires an empty qualification-evidence archive. The finalize workflow routes schema-4 records through release.acceptance.validate on the reviewed checkout; verify-flasher-release.sh already uses the repository validator, so promote and rollback need no changes. Includes the 0.3.4 override record. Validator suite: 32/32. Locally proven end-to-end against the published v0.3.4 assets (validator pass + release-record build).