### PR TITLE
Pin historical release verification to the signed acceptance policy commit

### DIFF
--- a/tools/release/verify-historical-flasher-release.py
+++ b/tools/release/verify-historical-flasher-release.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify a signed release with the verifier frozen at its signed source commit."""
+"""Verify a signed release with the verifier frozen at its signed acceptance policy commit."""
 
 from __future__ import annotations
 
@@ -96,8 +96,18 @@ def main() -> int:
         prerelease_published_at = release.get("prerelease_published_at")
         if not isinstance(prerelease_published_at, str) or not prerelease_published_at:
             raise ValueError("signed release record has no prerelease publication time")
+        acceptance_record = record.get("acceptance")
+        policy_commit = (
+            acceptance_record.get("source_commit")
+            if isinstance(acceptance_record, dict)
+            else None
+        )
+        if not isinstance(policy_commit, str) or COMMIT.fullmatch(policy_commit) is None:
+            policy_commit = source_commit
         run(["git", "-C", str(ROOT), "cat-file", "-e", f"{source_commit}^{{commit}}"])
         run(["git", "-C", str(ROOT), "merge-base", "--is-ancestor", source_commit, "HEAD"])
+        run(["git", "-C", str(ROOT), "cat-file", "-e", f"{policy_commit}^{{commit}}"])
+        run(["git", "-C", str(ROOT), "merge-base", "--is-ancestor", policy_commit, "HEAD"])
 
         assets = existing(arguments.assets, "release assets", directory=True)
         paths = {
@@ -129,7 +139,7 @@ def main() -> int:
         }
         with tempfile.TemporaryDirectory(prefix="prns-historical-verifier-") as temporary:
             snapshot = Path(temporary)
-            extract_source(source_commit, snapshot)
+            extract_source(policy_commit, snapshot)
             historical_key = existing(
                 snapshot / "release/keys/minisign.pub", "historical release public key"
             )
@@ -231,7 +241,9 @@ def main() -> int:
     ) as error:
         print(f"historical flasher release verification failed: {error}", file=sys.stderr)
         return 1
-    print(f"verified historical flasher release {arguments.version} at its signed source policy")
+    print(
+        f"verified historical flasher release {arguments.version} at its signed acceptance policy"
+    )
     return 0
 
 

--- a/tools/tests/test_flasher_rollback.py
+++ b/tools/tests/test_flasher_rollback.py
@@ -758,7 +758,11 @@ class FlasherRollbackTests(unittest.TestCase):
         )
         self.assertLess(
             historical.index('"-Vm"'),
-            historical.index("extract_source(source_commit, snapshot)"),
+            historical.index("extract_source(policy_commit, snapshot)"),
+        )
+        self.assertLess(
+            historical.index('"-Vm"'),
+            historical.index('acceptance_record.get("source_commit")'),
         )
         self.assertIn('"merge-base", "--is-ancestor"', historical)
         self.assertIn("historical verifier uses a different release trust root", historical)


### PR DESCRIPTION
The historical verifier froze its tool snapshot at the candidate source commit, which predates any acceptance-time policy by construction, so a release accepted under a newer contract (the 0.3.4 schema-4 maintainer override) can never re-verify. The snapshot commit is now the acceptance source commit recorded inside the signed release record, reproducing exactly the verification finalize performed, with fallback to the release source commit for records without one. Both commits are still required to be ancestors of HEAD, and the signature-before-trust ordering is unchanged and pinned by the contract test.