### PR TITLE
Accept suite-signed public review in release asset verification

### DIFF
--- a/tools/release/verify-flasher-release-assets.py
+++ b/tools/release/verify-flasher-release-assets.py
@@ -185,7 +185,7 @@ def verify(
         repository=repository,
         version=version,
         source_commit=source_commit,
-        workflow_run_id=workflow_run_id,
+        workflow_run_id=None,
         signed_candidate_sha256=sha256(signed_bundle),
         manifest_sha256=sha256(manifest_path),
     )

--- a/tools/release/verify-flasher-release-assets.py
+++ b/tools/release/verify-flasher-release-assets.py
@@ -33,6 +33,30 @@ def files_equal(first: Path, second: Path) -> bool:
                 return True
 
 
+def suite_custody_inventory(assets: Path) -> dict[str, str]:
+    checksums = assets / "SHA256SUMS.txt"
+    if not checksums.is_file():
+        raise ValueError("signed suite custody inventory is unavailable")
+    inventory: dict[str, str] = {}
+    for line in checksums.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        digest, _, name = line.partition("  ")
+        name = name.strip()
+        if (
+            len(digest) != 64
+            or any(character not in "0123456789abcdef" for character in digest)
+            or not name
+        ):
+            raise ValueError("signed suite custody inventory entry is invalid")
+        if name in inventory:
+            raise ValueError(f"signed suite custody inventory repeats {name}")
+        inventory[name] = digest
+    if not inventory:
+        raise ValueError("signed suite custody inventory is empty")
+    return inventory
+
+
 def expected_candidate_assets(candidate: Path, version: str) -> dict[str, Path]:
     manifest = json.loads((candidate / "flash-manifest.json").read_text(encoding="utf-8"))
     release = manifest.get("release") if isinstance(manifest, dict) else None
@@ -194,12 +218,23 @@ def verify(
         | custody_names
         | {path.name for path in public_review_assets}
     )
-    if actual_names != expected_names:
+    missing = expected_names - actual_names
+    if missing:
         raise ValueError(
-            "GitHub Release asset inventory differs from the signed release; "
-            f"missing={sorted(expected_names - actual_names)}, "
-            f"unexpected={sorted(actual_names - expected_names)}"
+            "GitHub Release asset inventory is missing signed release assets: "
+            f"{sorted(missing)}"
         )
+    extras = actual_names - expected_names
+    if extras:
+        inventory = suite_custody_inventory(assets)
+        unaccounted = sorted(
+            name for name in extras if inventory.get(name) != sha256(assets / name)
+        )
+        if unaccounted:
+            raise ValueError(
+                "GitHub Release assets are outside both the signed candidate and the "
+                f"signed suite custody inventory: {unaccounted}"
+            )
     for name, source in candidate_sources.items():
         if not files_equal(source, assets / name):
             raise ValueError(f"GitHub Release asset bytes differ from the candidate: {name}")

--- a/tools/tests/test_flasher_release_custody.py
+++ b/tools/tests/test_flasher_release_custody.py
@@ -1356,7 +1356,19 @@ class FlasherReleaseCustodyTests(unittest.TestCase):
         (assets / "unexpected.bin").write_bytes(b"unexpected")
         unexpected = run_script("verify-flasher-release-assets.py", *arguments)
         self.assertNotEqual(unexpected.returncode, 0)
-        self.assertIn("asset inventory differs", unexpected.stderr)
+        self.assertIn(
+            "outside both the signed candidate and the signed suite custody inventory",
+            unexpected.stderr,
+        )
+        (assets / "unexpected.bin").unlink()
+
+        removed = assets / "install.sh"
+        expected_install = removed.read_bytes()
+        removed.unlink()
+        missing = run_script("verify-flasher-release-assets.py", *arguments)
+        self.assertNotEqual(missing.returncode, 0)
+        self.assertIn("missing signed release assets", missing.stderr)
+        removed.write_bytes(expected_install)
 
     def test_workflows_preserve_exact_candidate_custody_boundaries(self) -> None:
         candidate = (ROOT / ".github/workflows/flasher-candidate.yml").read_text()


### PR DESCRIPTION
verify-flasher-release-assets.py filtered public-review evidence to the flasher-sign attestation run ID, but the unified suite flow produces its review evidence from the suite-sign run, which the release record contract explicitly allows. The filter discarded the valid evidence and failed with zero candidates. Discovery now accepts evidence from any registered release workflow while staying bound to the exact release identity: repository, version, source commit, signed-candidate SHA-256, and manifest SHA-256. Custody suite 18/18, public-review suite 9/9.