### PR TITLE
Trust the signed suite custody inventory for the release checksum pair

### DIFF
--- a/tools/release/verify-flasher-release-assets.py
+++ b/tools/release/verify-flasher-release-assets.py
@@ -5,11 +5,16 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
+import shutil
+import subprocess
 import sys
 
 from flasher_public_review import discover_evidence, sha256
 
+
+SUITE_INVENTORY_ASSETS = ("SHA256SUMS.txt", "SHA256SUMS.txt.minisig")
 
 CLI_TARGETS = {
     "aarch64-apple-darwin": ".tar.gz",
@@ -31,6 +36,27 @@ def files_equal(first: Path, second: Path) -> bool:
                 return False
             if not left_chunk:
                 return True
+
+
+def verify_suite_inventory_signature(assets: Path, public_key: Path) -> None:
+    signer = os.environ.get("PRNS_MINISIGN_BIN", "minisign")
+    signer_path = shutil.which(signer)
+    if signer_path is None:
+        raise ValueError(f"configured Minisign executable is unavailable: {signer}")
+    verification = subprocess.run(
+        [
+            signer_path,
+            "-Vm",
+            str(assets / "SHA256SUMS.txt"),
+            "-x",
+            str(assets / "SHA256SUMS.txt.minisig"),
+            "-p",
+            str(public_key),
+        ],
+        capture_output=True,
+    )
+    if verification.returncode != 0:
+        raise ValueError("suite custody inventory signature verification failed")
 
 
 def suite_custody_inventory(assets: Path) -> dict[str, str]:
@@ -224,9 +250,30 @@ def verify(
             "GitHub Release asset inventory is missing signed release assets: "
             f"{sorted(missing)}"
         )
+    suite_inventory_replaces_candidate_copy = any(
+        not files_equal(candidate_sources[name], assets / name)
+        for name in SUITE_INVENTORY_ASSETS
+    )
+    inventory = None
+    if suite_inventory_replaces_candidate_copy:
+        verify_suite_inventory_signature(assets, candidate_sources["minisign.pub"])
+        inventory = suite_custody_inventory(assets)
+        contradictions = sorted(
+            name
+            for name, source in candidate_sources.items()
+            if name not in SUITE_INVENTORY_ASSETS
+            and name in inventory
+            and inventory[name] != sha256(source)
+        )
+        if contradictions:
+            raise ValueError(
+                "signed suite custody inventory contradicts the signed candidate: "
+                f"{contradictions}"
+            )
     extras = actual_names - expected_names
     if extras:
-        inventory = suite_custody_inventory(assets)
+        if inventory is None:
+            inventory = suite_custody_inventory(assets)
         unaccounted = sorted(
             name for name in extras if inventory.get(name) != sha256(assets / name)
         )
@@ -236,6 +283,8 @@ def verify(
                 f"signed suite custody inventory: {unaccounted}"
             )
     for name, source in candidate_sources.items():
+        if suite_inventory_replaces_candidate_copy and name in SUITE_INVENTORY_ASSETS:
+            continue
         if not files_equal(source, assets / name):
             raise ValueError(f"GitHub Release asset bytes differ from the candidate: {name}")
     if remote_inventory is not None:

--- a/tools/tests/test_flasher_release_custody.py
+++ b/tools/tests/test_flasher_release_custody.py
@@ -1370,6 +1370,70 @@ class FlasherReleaseCustodyTests(unittest.TestCase):
         self.assertIn("missing signed release assets", missing.stderr)
         removed.write_bytes(expected_install)
 
+        suite_sums = assets / "SHA256SUMS.txt"
+        suite_signature = assets / "SHA256SUMS.txt.minisig"
+        candidate_sums = suite_sums.read_bytes()
+        candidate_signature = suite_signature.read_bytes()
+        suite_extra = assets / f"prns-host-sdk-v{VERSION}.tar.gz"
+        suite_extra.write_bytes(b"suite asset")
+
+        def sign_suite_inventory(lines: list[str]) -> None:
+            suite_sums.write_text("".join(lines), encoding="utf-8")
+            signed = subprocess.run(
+                [str(self.signer), "-S", "-m", str(suite_sums), "-x", str(suite_signature)],
+                capture_output=True,
+            )
+            self.assertEqual(signed.returncode, 0)
+
+        inventory_lines = [
+            f"{sha256(suite_extra)}  {suite_extra.name}\n",
+            f"{sha256(assets / 'install.sh')}  install.sh\n",
+            f"{sha256(assets / 'flash-manifest.json')}  flash-manifest.json\n",
+        ]
+        sign_suite_inventory(inventory_lines)
+        suite_verified = run_script(
+            "verify-flasher-release-assets.py", *arguments, environment=self.environment
+        )
+        self.assertEqual(suite_verified.returncode, 0, suite_verified.stderr)
+
+        contradicting_lines = list(inventory_lines)
+        contradicting_lines[1] = f"{'0' * 64}  install.sh\n"
+        sign_suite_inventory(contradicting_lines)
+        contradicted = run_script(
+            "verify-flasher-release-assets.py", *arguments, environment=self.environment
+        )
+        self.assertNotEqual(contradicted.returncode, 0)
+        self.assertIn("contradicts the signed candidate", contradicted.stderr)
+
+        sign_suite_inventory(inventory_lines)
+        suite_extra.write_bytes(b"tampered suite asset")
+        tampered_extra = run_script(
+            "verify-flasher-release-assets.py", *arguments, environment=self.environment
+        )
+        self.assertNotEqual(tampered_extra.returncode, 0)
+        self.assertIn(
+            "outside both the signed candidate and the signed suite custody inventory",
+            tampered_extra.stderr,
+        )
+
+        refusing_signer = self.workspace / "refusing-minisign"
+        refusing_signer.write_text("#!/usr/bin/env bash\nexit 1\n", encoding="utf-8")
+        refusing_signer.chmod(refusing_signer.stat().st_mode | stat.S_IXUSR)
+        refusing_environment = dict(self.environment)
+        refusing_environment["PRNS_MINISIGN_BIN"] = str(refusing_signer)
+        rejected_signature = run_script(
+            "verify-flasher-release-assets.py", *arguments, environment=refusing_environment
+        )
+        self.assertNotEqual(rejected_signature.returncode, 0)
+        self.assertIn(
+            "suite custody inventory signature verification failed",
+            rejected_signature.stderr,
+        )
+
+        suite_extra.unlink()
+        suite_sums.write_bytes(candidate_sums)
+        suite_signature.write_bytes(candidate_signature)
+
     def test_workflows_preserve_exact_candidate_custody_boundaries(self) -> None:
         candidate = (ROOT / ".github/workflows/flasher-candidate.yml").read_text()
         signing = (ROOT / ".github/workflows/flasher-sign.yml").read_text()


### PR DESCRIPTION
The unified suite publishes its own SHA256SUMS.txt at the release level, replacing the flasher candidate's copy, so the strict byte-compare failed the rollback dry-run. When the release-level checksum pair differs from the candidate's copy, the verifier now requires it to be the signed suite inventory: the minisign signature must verify against the candidate's pinned public key, every candidate asset it lists must carry the candidate's exact digest, and extras must still match their inventory digests. All other candidate assets stay byte-exact and a flasher-only release keeps the original strict path. Custody suite 18/18; the fixed verifier passed against the real 74-asset v0.3.4 release locally, including live minisign verification.