### PR TITLE
Give the promote inventory verify step its Minisign path

### DIFF
--- a/.github/workflows/flasher-promote.yml
+++ b/.github/workflows/flasher-promote.yml
@@ -216,6 +216,8 @@ jobs:
             --source-commit "$source_commit" \
             --allow-promoted
       - name: Verify the complete prerelease asset inventory before deployment
+        env:
+          PRNS_MINISIGN_BIN: ${{ runner.temp }}/prns-release-bin/minisign
         run: |
           ./tools/prns release assets verify -- \
             --candidate target/signed-candidate \


### PR DESCRIPTION
The prerelease inventory verification step in flasher-promote.yml was the only assets-verify call site without PRNS_MINISIGN_BIN in its environment, so the suite custody inventory signature check failed closed on a missing signer. Minisign is already installed earlier in the job; this points the step at it, matching the other three call sites. Workflow contract suites pass.