### PR TITLE
Create the deploy job workspace before the inventory recheck

### DIFF
--- a/.github/workflows/flasher-promote.yml
+++ b/.github/workflows/flasher-promote.yml
@@ -496,6 +496,7 @@ jobs:
           EXPECTED_ASSET_INVENTORY_SHA256: ${{ needs.verify.outputs.release_asset_inventory_sha256 }}
           GH_TOKEN: ${{ github.token }}
         run: |
+          mkdir -p target
           gh release view "v${RELEASE_VERSION}" --json assets \
             --jq '[.assets[] | {name, size, digest}] | sort_by(.name)' \
             > target/assets-before-deployment.json


### PR DESCRIPTION
The deploy job's first step redirects the release inventory into target/ on a fresh checkout where that directory does not exist, so the job failed before performing any deployment. Every later step already creates its own directories. This adds the missing mkdir; the rest of the never-before-executed deploy path was audited for the same class of bug and is clean. Workflow contract suites pass.