### PR TITLE
Address the repository explicitly when marking the site promoted

### DIFF
--- a/.github/workflows/flasher-promote.yml
+++ b/.github/workflows/flasher-promote.yml
@@ -735,7 +735,7 @@ jobs:
       - name: Enable full public site only after every promotion smoke passes
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh variable set PRNS_PUBLIC_SITE_PROMOTED --body true
+        run: gh variable set PRNS_PUBLIC_SITE_PROMOTED --body true --repo "$GITHUB_REPOSITORY"
 
   restore-baseline-on-failure:
     name: Automatically restore the verified baseline after promotion failure


### PR DESCRIPTION
The mark-promoted job is the only job without a checkout, so bare gh variable set could not infer the repository and the job failed after a fully verified deployment, triggering the automatic baseline restore. The call now names the repository explicitly. With this, every step of the promotion pipeline has executed successfully at least once. Workflow contract suites pass.