### PR TITLE
Verify the release owner's promoted-site flag instead of writing it

### DIFF
--- a/.github/workflows/flasher-promote.yml
+++ b/.github/workflows/flasher-promote.yml
@@ -724,18 +724,17 @@ jobs:
             "hopspot-flash ${RELEASE_VERSION}"
 
   mark-promoted:
-    name: Enable future full-site deployments
+    name: Confirm future full-site deployments are enabled
     needs: post-promotion-smoke
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
-      actions: write
       contents: read
     steps:
-      - name: Enable full public site only after every promotion smoke passes
+      - name: Require the release owner's promoted-site flag after every promotion smoke passes
         env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh variable set PRNS_PUBLIC_SITE_PROMOTED --body true --repo "$GITHUB_REPOSITORY"
+          PRNS_PUBLIC_SITE_PROMOTED: ${{ vars.PRNS_PUBLIC_SITE_PROMOTED }}
+        run: test "$PRNS_PUBLIC_SITE_PROMOTED" = true
 
   restore-baseline-on-failure:
     name: Automatically restore the verified baseline after promotion failure


### PR DESCRIPTION
GitHub does not permit the built-in workflow token to write repository variables, so the mark-promoted job returned 403 on every run that reached it and the automatic restore rolled back each fully verified deployment. The flag is now set by the release owner, and the job verifies it through the vars context after every promotion smoke passes, which needs no API call and no write permission. The rollback deploy path carries the same latent 403 and is queued for a PAT-based fix. Workflow contract suites pass.