### PR TITLE
hopspot: make the SX1262 optional in the S3 firmware tree

### DIFF
--- a/personal-hopspot/embedded/esp32/src/lib.rs
+++ b/personal-hopspot/embedded/esp32/src/lib.rs
@@ -8,14 +8,13 @@ extern crate alloc;
     not(all(
         feature = "bluetooth-auto",
         feature = "esp-now",
-        feature = "lora",
         feature = "tcp",
         feature = "usb",
         feature = "wifi-auto"
     ))
 ))]
 compile_error!(
-    "ESP32-S3 firmware is built through a board package, which selects bluetooth-auto, esp-now, lora, tcp, usb, and wifi-auto"
+    "ESP32-S3 firmware is built through a board package, which selects bluetooth-auto, esp-now, tcp, usb, and wifi-auto (plus lora on boards with an SX1262)"
 );
 
 #[cfg(all(
@@ -58,7 +57,6 @@ mod persistence;
     target_arch = "xtensa",
     feature = "bluetooth-auto",
     feature = "esp-now",
-    feature = "lora",
     feature = "tcp",
     feature = "usb",
     feature = "wifi-auto"

--- a/personal-hopspot/embedded/esp32/src/s3/board.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/board.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+#[cfg(feature = "lora")]
 pub(crate) type LoraRadio = Sx126x<
     ExclusiveDevice<Spi<'static, esp_hal::Async>, Output<'static>, Delay>,
     Input<'static>,

--- a/personal-hopspot/embedded/esp32/src/s3/boards/mod.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/boards/mod.rs
@@ -1,8 +1,15 @@
+// The SX1262 boards only exist in a lora build: a board module must never have to invent a
+// radio its hardware does not carry.
+#[cfg(feature = "lora")]
 pub mod heltec_v4;
+#[cfg(feature = "lora")]
 pub mod heltec_v4_r8;
+#[cfg(feature = "lora")]
 pub mod t_beam_supreme;
 
 // Both Heltec V4 front-end variants amplify the receive path before the SX1262. These typical
 // gains are removed from its RSSI reports so channel access and diagnostics remain antenna-referred.
+#[cfg(feature = "lora")]
 pub(super) const HELTEC_GC1109_RX_GAIN_DB: u8 = 17;
+#[cfg(feature = "lora")]
 pub(super) const HELTEC_KCT8103L_RX_GAIN_DB: u8 = 23;

--- a/personal-hopspot/embedded/esp32/src/s3/display.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/display.rs
@@ -7,12 +7,12 @@ fn classify_card(
     tcp_id: Option<InterfaceId>,
     tcp_client: Option<&HopspotTcpClientConfig>,
     wifi_kind: screen::CardKind,
-    lora_id: InterfaceId,
+    lora_id: Option<InterfaceId>,
     espnow_id: Option<InterfaceId>,
 ) -> Option<(screen::CardKind, screen::CardLabel)> {
     if id == usb_id {
         Some((screen::CardKind::Usb, screen::card_label("USB")))
-    } else if id == lora_id {
+    } else if Some(id) == lora_id {
         Some((screen::CardKind::LoRa, screen::card_label("LoRa")))
     } else if Some(id) == wifi_id {
         Some((wifi_kind, screen::card_label("LAN")))
@@ -72,14 +72,16 @@ pub(super) fn build_snapshots(
     usb: &EmbassyInterfaceStatus,
     wifi: Option<&AutoWifiStatus<MEMBERS>>,
     tcp: Option<&EmbassyInterfaceStatus>,
-    lora: &EmbassyInterfaceStatus,
+    lora: Option<&EmbassyInterfaceStatus>,
     espnow: Option<&EmbassyInterfaceStatus>,
 ) -> HVec<InterfaceSnapshot, 8> {
     use personal_rns::interfaces::InterfaceStatus;
     #[cfg(feature = "bluetooth-auto")]
     let ble = BluetoothAutoStatus::new(&BLE_SHARED);
     let mut entries: HVec<(&dyn InterfaceStatus, Membership), 8> = HVec::new();
-    let _ = entries.push((lora, Membership::Independent));
+    if let Some(lora) = lora {
+        let _ = entries.push((lora, Membership::Independent));
+    }
     #[cfg(feature = "bluetooth-auto")]
     {
         let _ = entries.push((&ble, Membership::Independent));
@@ -149,7 +151,7 @@ pub(super) fn build_cards(
     tcp_client: Option<&HopspotTcpClientConfig>,
     wifi: Option<&AutoWifiStatus<MEMBERS>>,
     wifi_config: &HopspotWifiConfig,
-    lora_id: InterfaceId,
+    lora_id: Option<InterfaceId>,
     espnow_id: Option<InterfaceId>,
 ) -> HVec<screen::Card, 8> {
     let wifi_kind = if !wifi_config.has_station() {
@@ -173,6 +175,7 @@ fn egress_pressure_events(id: InterfaceId) -> u32 {
         Some(InterfaceKind::AutoWifi | InterfaceKind::WifiPeer | InterfaceKind::TcpServerPeer) => {
             WIFI_MANIFOLD_LANE.egress_pressure_events()
         }
+        #[cfg(feature = "lora")]
         Some(InterfaceKind::LoRa) => LORA_MANIFOLD_LANE.egress_pressure_events(),
         #[cfg(feature = "bluetooth-auto")]
         Some(InterfaceKind::BluetoothAuto | InterfaceKind::BluetoothPeer) => {
@@ -191,6 +194,7 @@ fn ingress_pressure_events(id: InterfaceId) -> u32 {
         Some(InterfaceKind::AutoWifi | InterfaceKind::WifiPeer | InterfaceKind::TcpServerPeer) => {
             WIFI_MANIFOLD_LANE.ingress_pressure_events()
         }
+        #[cfg(feature = "lora")]
         Some(InterfaceKind::LoRa) => LORA_MANIFOLD_LANE.ingress_pressure_events(),
         #[cfg(feature = "bluetooth-auto")]
         Some(InterfaceKind::BluetoothAuto | InterfaceKind::BluetoothPeer) => BLE_MANIFOLD_LANE
@@ -227,6 +231,7 @@ pub(super) fn add_manifold_pressure(
     }
 }
 
+#[cfg(feature = "lora")]
 pub(super) fn add_lora_spectrum(
     details: &mut screen::InterfaceMenuDetails,
     selected_card: Option<&screen::Card>,
@@ -254,7 +259,7 @@ pub(super) fn build_interface_menu_details(
     selected_card: Option<&screen::Card>,
     snapshots: &[InterfaceSnapshot],
     usb: &EmbassyInterfaceStatus,
-    lora_spectrum: &LoRaSpectrumStatus,
+    #[cfg(feature = "lora")] lora_spectrum: &LoRaSpectrumStatus,
     wifi: Option<&AutoWifiStatus<MEMBERS>>,
     wifi_config: &HopspotWifiConfig,
     ap_ssid: Option<&str>,
@@ -310,6 +315,7 @@ pub(super) fn build_interface_menu_details(
         }
         _ => screen::InterfaceMenuDetails::empty(),
     };
+    #[cfg(feature = "lora")]
     add_lora_spectrum(&mut details, selected_card, lora_spectrum);
     add_manifold_pressure(&mut details, selected_card);
     details

--- a/personal-hopspot/embedded/esp32/src/s3/firmware.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/firmware.rs
@@ -66,14 +66,11 @@ pub(super) async fn run_core<B: Esp32S3Board>(
 
     let mut manifold_lanes = ManifoldLanes::new();
 
-    #[cfg(feature = "lora")]
     static FLASH: StaticCell<Mutex<CriticalSectionRawMutex, crate::flash::EspRomFlash>> =
         StaticCell::new();
-    #[cfg(feature = "lora")]
     let flash = FLASH.init(Mutex::new(crate::flash::EspRomFlash::new(
         B::FLASH_LAYOUT.flash_capacity,
     )));
-    #[cfg(feature = "lora")]
     let shared_flash = SharedNorFlash::new(flash, B::FLASH_LAYOUT.flash_capacity);
     #[cfg(feature = "lora")]
     let mut lora_profile_store =
@@ -97,6 +94,9 @@ pub(super) async fn run_core<B: Esp32S3Board>(
         screen::RadioProfileLoadNotice::Recovered => screen::UiNotice::ProfileRecovered,
         screen::RadioProfileLoadNotice::Reset => screen::UiNotice::ProfileReset,
     });
+    #[cfg(not(feature = "lora"))]
+    let profile_startup_notice: Option<screen::UiNotice> = None;
+    #[cfg(feature = "lora")]
     let lora_id = LoRaInterface::<
         ExclusiveDevice<Spi<'static, esp_hal::Async>, Output<'static>, Delay>,
         Input<'static>,
@@ -104,12 +104,26 @@ pub(super) async fn run_core<B: Esp32S3Board>(
         Output<'static>,
         Delay,
     >::interface_id(&lora_profile);
+    #[cfg(feature = "lora")]
     let lora_status: &'static EmbassyInterfaceStatus = mk_static!(
         EmbassyInterfaceStatus,
         EmbassyInterfaceStatus::new(lora_id, ConnectionState::Initializing)
     );
+    #[cfg(feature = "lora")]
     let lora_spectrum: &'static LoRaSpectrumStatus =
         mk_static!(LoRaSpectrumStatus, LoRaSpectrumStatus::new());
+    // The Option shims mirror ESP-NOW's: boards without an SX1262 keep every downstream card,
+    // toggle, and sleep path compiling against `None` instead of forking the render loop.
+    #[cfg(feature = "lora")]
+    let (lora_card_id, lora_card_status): (
+        Option<InterfaceId>,
+        Option<&'static EmbassyInterfaceStatus>,
+    ) = (Some(lora_id), Some(lora_status));
+    #[cfg(not(feature = "lora"))]
+    let (lora_card_id, lora_card_status): (
+        Option<InterfaceId>,
+        Option<&'static EmbassyInterfaceStatus>,
+    ) = (None, None);
     // Reclaim the private R8 probe allocation before placing the live LoRa queue in PSRAM.
     // This is a no-op on boards whose PSRAM belongs to the global heap.
     #[cfg(feature = "lora")]
@@ -403,6 +417,7 @@ pub(super) async fn run_core<B: Esp32S3Board>(
         if let Some(notice) = startup_notice {
             ui_state.show_notice(notice);
         }
+        #[cfg(feature = "lora")]
         let mut working_lora_profile = lora_profile;
         let mut battery_state = screen::BatteryState::Unknown;
         let mut battery_gauge = screen::BatteryGauge::lipo();
@@ -438,7 +453,7 @@ pub(super) async fn run_core<B: Esp32S3Board>(
                 usb_status,
                 wifi_status.as_ref(),
                 tcp_status,
-                lora_status,
+                lora_card_status,
                 espnow_card_status,
             );
             #[cfg(feature = "wifi-auto")]
@@ -453,7 +468,7 @@ pub(super) async fn run_core<B: Esp32S3Board>(
                 tcp_card_config,
                 wifi_status.as_ref(),
                 &wifi_config,
-                lora_status.id(),
+                lora_card_id,
                 espnow_card_id,
             );
             let now_ms = embassy_time::Instant::now().as_millis();
@@ -465,7 +480,7 @@ pub(super) async fn run_core<B: Esp32S3Board>(
             };
             #[cfg(feature = "wifi-auto")]
             let menu_ap_ssid = active_ap_ssid.as_deref();
-            #[cfg(feature = "wifi-auto")]
+            #[cfg(all(feature = "wifi-auto", feature = "lora"))]
             let interface_menu_details = build_interface_menu_details(
                 ui_state.selected_card(content.cards),
                 &snapshots,
@@ -475,9 +490,19 @@ pub(super) async fn run_core<B: Esp32S3Board>(
                 &wifi_config,
                 menu_ap_ssid,
             );
+            #[cfg(all(feature = "wifi-auto", not(feature = "lora")))]
+            let interface_menu_details = build_interface_menu_details(
+                ui_state.selected_card(content.cards),
+                &snapshots,
+                usb_status,
+                wifi_status.as_ref(),
+                &wifi_config,
+                menu_ap_ssid,
+            );
             #[cfg(not(feature = "wifi-auto"))]
             let interface_menu_details = {
                 let mut details = screen::InterfaceMenuDetails::empty();
+                #[cfg(feature = "lora")]
                 add_lora_spectrum(
                     &mut details,
                     ui_state.selected_card(content.cards),
@@ -588,7 +613,9 @@ pub(super) async fn run_core<B: Esp32S3Board>(
                                 Some((now_ms + NOTICE_MS, screen::UiNotice::Sleeping));
                             oled_sleep_at_ms = Some(now_ms + OLED_SLEEP_DELAY_MS);
                             usb_status.disable();
-                            lora_status.disable();
+                            if let Some(status) = lora_card_status {
+                                status.disable();
+                            }
                             if let Some(status) = wifi_status.as_ref() {
                                 status.disable();
                                 status.disable_station_uplink();
@@ -615,7 +642,9 @@ pub(super) async fn run_core<B: Esp32S3Board>(
                             ui_state.show_notice(screen::UiNotice::Awake);
                             notice_until_ms = Some((now_ms + NOTICE_MS, screen::UiNotice::Awake));
                             usb_status.enable();
-                            lora_status.enable();
+                            if let Some(status) = lora_card_status {
+                                status.enable();
+                            }
                             if let Some(status) = wifi_status.as_ref() {
                                 status.enable_station_uplink();
                                 status.enable();
@@ -670,10 +699,12 @@ pub(super) async fn run_core<B: Esp32S3Board>(
                                     usb_status.toggle_enabled();
                                     handled = true;
                                 }
-                                if !handled && card.id() == lora_status.id() {
-                                    show_toggle_notice(lora_status.is_enabled());
-                                    lora_status.toggle_enabled();
-                                    handled = true;
+                                if !handled && Some(card.id()) == lora_card_id {
+                                    if let Some(status) = lora_card_status {
+                                        show_toggle_notice(status.is_enabled());
+                                        status.toggle_enabled();
+                                        handled = true;
+                                    }
                                 }
                                 if !handled {
                                     if let Some(status) = wifi_status.as_ref() {
@@ -727,8 +758,13 @@ pub(super) async fn run_core<B: Esp32S3Board>(
                             }
                         }
                         screen::UiAction::OpenLoRaEditor => {
+                            #[cfg(feature = "lora")]
                             ui_state.open_lora_editor(working_lora_profile);
                         }
+                        #[cfg(not(feature = "lora"))]
+                        screen::UiAction::SetLoRaProfile(_)
+                        | screen::UiAction::ResetLoRaProfile => {}
+                        #[cfg(feature = "lora")]
                         screen::UiAction::SetLoRaProfile(profile) => {
                             let result = screen::apply_and_persist_radio_profile(
                                 async {
@@ -755,6 +791,7 @@ pub(super) async fn run_core<B: Esp32S3Board>(
                                 notice,
                             ));
                         }
+                        #[cfg(feature = "lora")]
                         screen::UiAction::ResetLoRaProfile => {
                             let result = screen::apply_and_persist_radio_profile(
                                 async {
@@ -828,7 +865,10 @@ pub(super) async fn run_core<B: Esp32S3Board>(
     }
     #[cfg(all(feature = "wifi-auto", not(feature = "bluetooth-auto")))]
     {
+        #[cfg(feature = "lora")]
         let lora_run = lora.run(lora_seam);
+        #[cfg(not(feature = "lora"))]
+        let lora_run = async {};
         let espnow_run = async {
             if let Some((interface, seam)) = espnow {
                 interface.run(seam).await;
@@ -845,6 +885,7 @@ pub(super) async fn run_core<B: Esp32S3Board>(
     }
     #[cfg(all(feature = "bluetooth-auto", feature = "wifi-auto"))]
     {
+        #[cfg(feature = "lora")]
         spawner.spawn(lora_task(lora, lora_seam).expect("LoRa task fits"));
         if let Some((interface, seam)) = espnow {
             spawner.spawn(espnow_task(interface, seam).expect("ESP-NOW task fits"));

--- a/personal-hopspot/embedded/esp32/src/s3/mod.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/mod.rs
@@ -8,11 +8,14 @@ use esp_backtrace as _;
 use esp_bootloader_esp_idf::esp_app_desc;
 use esp_hal::clock::CpuClock;
 use esp_hal::efuse::base_mac_address;
-use esp_hal::gpio::{Input, Output};
+use esp_hal::gpio::Input;
+#[cfg(feature = "lora")]
+use esp_hal::gpio::Output;
 use esp_hal::peripherals::USB_DEVICE;
 use esp_hal::rng::Rng;
 #[cfg(feature = "wifi-auto")]
 use esp_hal::rom::spiflash::esp_rom_spiflash_read;
+#[cfg(feature = "lora")]
 use esp_hal::spi::master::Spi;
 use esp_hal::system::Stack as CpuStack;
 #[cfg(feature = "wifi-auto")]
@@ -37,9 +40,12 @@ use embassy_sync::mutex::Mutex;
 use embassy_sync::signal::Signal;
 #[cfg(feature = "wifi-auto")]
 use embassy_time::with_timeout;
-use embassy_time::{Delay, Duration, Ticker, Timer};
+#[cfg(feature = "lora")]
+use embassy_time::Delay;
+use embassy_time::{Duration, Ticker, Timer};
 use embedded_graphics::draw_target::DrawTarget;
 use embedded_graphics::pixelcolor::BinaryColor;
+#[cfg(feature = "lora")]
 use embedded_hal_bus::spi::ExclusiveDevice;
 use heapless::Vec as HVec;
 #[cfg(feature = "wifi-auto")]
@@ -74,6 +80,7 @@ use personal_rns::interfaces::bluetooth_auto::{BleIdentity, BLE_HW_MTU};
 use personal_rns::interfaces::esp_now::{
     self as espnow_core, Channel as EspNowChannel, ChannelPolicy, ESP_NOW_V2_AIR_MTU,
 };
+#[cfg(feature = "lora")]
 use personal_rns::interfaces::lora::{AirtimePolicy, DEFAULT_915_PROFILE, LORA_MAX_PAYLOAD};
 use personal_rns::interfaces::usb_auto::device_descriptor;
 use personal_rns::interfaces::wifi_auto as wifi_auto_contract;
@@ -82,6 +89,7 @@ use personal_rns::interfaces::{
     ConnectionState, InterfaceId, InterfaceKind, InterfaceSnapshot, InterfaceStatus, MacAddress,
     Membership,
 };
+#[cfg(feature = "lora")]
 use personal_rns::lora::{
     LoRaApplyOutcome, LoRaControl, LoRaInterface, LoRaInterfaceInput, LoRaSpectrumStatus,
 };
@@ -90,6 +98,7 @@ use personal_rns::manifold::embassy::{
 };
 use personal_rns::manifold::interface_seam::{Interface, EMBEDDED_MAX_WIRE_FRAME_LEN};
 use personal_rns::manifold::reconnect::ReconnectPolicy;
+#[cfg(feature = "lora")]
 use personal_rns::radios::sx126x::Sx126x;
 use personal_rns::runtime::{
     minimum_interface_store_capacity, minimum_manifold_notification_capacity, CompletionPool,
@@ -179,8 +188,10 @@ const HOPSPOT_TCP_TARGET: &str = match option_env!("HOPSPOT_TCP_TARGET") {
 const TCP_BITRATE_BPS: BitrateBps = wifi_auto_contract::WIFI_EMBEDDED_BITRATE_CEILING_BPS;
 const TCP_SOCKET_BUFFER_BYTES: usize = 4 * 1_024;
 
-const LANE_COUNT: usize =
-    4 + cfg!(feature = "bluetooth-auto") as usize + cfg!(feature = "esp-now") as usize;
+const LANE_COUNT: usize = 3
+    + cfg!(feature = "lora") as usize
+    + cfg!(feature = "bluetooth-auto") as usize
+    + cfg!(feature = "esp-now") as usize;
 const MEMBERS: usize = 24;
 #[cfg(feature = "bluetooth-auto")]
 pub const BLE_PEER_CAPACITY: usize = EMBEDDED_BLE_PEER_CAPACITY;
@@ -282,10 +293,12 @@ use configuration::{HopspotTcpClientConfig, HopspotTcpClientHost};
 use connectivity::build_tcp;
 #[cfg(feature = "wifi-auto")]
 use connectivity::{build_wifi, espnow_channel_policy, EspNowAdapter, ESPNOW_PHY};
+#[cfg(all(not(feature = "wifi-auto"), feature = "lora"))]
+use display::add_lora_spectrum;
+#[cfg(not(feature = "wifi-auto"))]
+use display::add_manifold_pressure;
 #[cfg(feature = "wifi-auto")]
 use display::build_interface_menu_details;
-#[cfg(not(feature = "wifi-auto"))]
-use display::{add_lora_spectrum, add_manifold_pressure};
 use display::{build_cards, build_snapshots, button_task};
 
 static WIFI_SHARED: AutoWifiShared<MEMBERS> = AutoWifiShared::new(WIFI_SUPERVISOR_ID);
@@ -296,6 +309,7 @@ const BLE_SUPERVISOR_ID: InterfaceId =
 #[cfg(feature = "bluetooth-auto")]
 static BLE_SHARED: BluetoothAutoShared<BLE_PEER_CAPACITY> =
     BluetoothAutoShared::new(BLE_SUPERVISOR_ID);
+#[cfg(feature = "lora")]
 static LORA_CONTROL: LoRaControl = LoRaControl::new();
 static USB_MANIFOLD_LANE: StaticManifoldLane<Mtx, EMBEDDED_MAX_WIRE_FRAME_LEN, LANE_DEPTH, 0> =
     StaticManifoldLane::new();
@@ -307,6 +321,7 @@ static WIFI_MANIFOLD_LANE: StaticManifoldLane<
     LANE_DEPTH,
     0,
 > = StaticManifoldLane::new();
+#[cfg(feature = "lora")]
 static LORA_MANIFOLD_LANE: StaticManifoldLane<Mtx, LORA_MAX_PAYLOAD, LANE_DEPTH, 0> =
     StaticManifoldLane::new();
 #[cfg(feature = "bluetooth-auto")]
@@ -350,8 +365,12 @@ const BOOT_PHASE_MAGIC: u32 = 0x5052_0000;
 
 #[derive(Clone, Copy)]
 pub(crate) enum BootPhase {
+    // Only boards with a panel emit the OLED stages; a headless-only build constructs none of them.
+    #[allow(dead_code)]
     OledBegin = 1,
+    #[allow(dead_code)]
     OledReady = 2,
+    #[allow(dead_code)]
     OledFailed = 3,
     WifiBegin = 4,
     WifiReady = 5,
@@ -513,6 +532,9 @@ macro_rules! boot_common {
 }
 pub(crate) use boot_common;
 
+// Only the global-heap boards expand this arm; a build whose board set is all split-heap
+// leaves it unexpanded.
+#[allow(unused_macros)]
 macro_rules! boot_add_psram_global {
     ($p:ident, $psram_config:expr) => {{
         let psram = ::esp_hal::psram::Psram::new($p.PSRAM, $psram_config);
@@ -528,6 +550,7 @@ macro_rules! boot_add_psram_global {
         }
     }};
 }
+#[allow(unused_imports)]
 pub(crate) use boot_add_psram_global;
 
 /// Split a board's PSRAM into two disjoint windows: a private low half owned solely by [`crate::storage::PsramAlloc`] for engine construction, and a high half handed to `esp_alloc`.

--- a/personal-hopspot/embedded/esp32/src/storage.rs
+++ b/personal-hopspot/embedded/esp32/src/storage.rs
@@ -97,7 +97,7 @@ pub unsafe fn init_private_psram_heap(start: *mut u8, size: usize) {
 
 /// Reset the private PSRAM bump cursor over the window from [`init_private_psram_heap`].
 /// No-op when this board uses the global `esp_alloc` external region instead.
-#[cfg(target_arch = "xtensa")]
+#[cfg(all(target_arch = "xtensa", feature = "lora"))]
 pub fn reinit_private_psram_heap() {
     critical_section::with(|cs| {
         if let Some(bump) = PRIVATE_PSRAM.borrow_ref_mut(cs).as_mut() {
@@ -106,7 +106,7 @@ pub fn reinit_private_psram_heap() {
     });
 }
 
-#[cfg(target_arch = "xtensa")]
+#[cfg(all(target_arch = "xtensa", feature = "lora"))]
 pub fn allocate_lora_tx_queue() -> &'static mut [u8; personal_rns::lora::LORA_TX_QUEUE_BYTES] {
     let mut storage = Vec::with_capacity_in(personal_rns::lora::LORA_TX_QUEUE_BYTES, PsramAlloc);
     storage.resize(personal_rns::lora::LORA_TX_QUEUE_BYTES, 0);


### PR DESCRIPTION
Every S3 board in the tree so far has carried an SX1262, so the shared S3 firmware requires the `lora` feature outright: `lib.rs` hard-errors without it, and the LoRa interface id, status, and spectrum plumbing run unconditionally through the render loop, the sleep and wake paths, and the card toggles. A board without that radio can't compile the tree today, and boards like that are now real: I've got a LilyGO T-Halow on the bench (S3 plus a Wi-Fi HaLow module, no SX1262), and the direction of #95 is the same tree stripped down for boards that can't afford the full feature set.

This makes `lora` a real per-board choice, the same way `esp-now` already is, and by the same mechanism: Option shims. The card, toggle, sleep, and menu paths see `None` instead of forking the render loop, the lane count follows the feature set (`3 + lora + bluetooth-auto + esp-now`), and the SX1262 board modules plus the Heltec RX-gain constants gate on the feature so a radio-less board never has to invent hardware it doesn't carry. Boards with the radio select `lora` exactly as they did before and compile unchanged.

What I ran, and where:

- `bash validation/hygiene/fmt-docs.sh` green (all three markers), both on my Windows bench and on an ubuntu-24.04 box at CI's pinned toolchain.
- `cargo heltec-v4-r8` (release, Xtensa, Windows esp toolchain): exit 0, zero warnings. The existing lora shape is the same feature set as before.
- The new no-lora shape type-checks on Xtensa (`cargo check --no-default-features --features bluetooth-auto,wifi-auto,esp-now,usb,tcp`). No board in this PR selects it, so that check is synthetic and its dead-code warnings are expected; on my HaLow branch a real board package built on this exact mechanism compiles release with zero warnings and boots on hardware.
- Host side: `personal-hopspot-core` tests (128 passed) and clippy clean on Linux.

No dependency, manifest, or release-graph changes: this is `src/` only. The point of landing it on its own is single-source-of-truth for the S3 tree. My T-Halow board package wants it, and the compact V3 profile in #95 is pushing the same files the same direction, so the shared mechanism seems worth having in first rather than each board growing its own forks.
