### PR TITLE
fix: the Web Serial message contradicted the guidance printed under it

### DIFF
--- a/docs/website/web-flasher/src/prns-flash.js
+++ b/docs/website/web-flasher/src/prns-flash.js
@@ -334,7 +334,7 @@ export async function flash(emit = () => {}, dependencies = {}) {
       events,
       new FlashBridgeError(
         "unsupported_browser",
-        "This browser does not provide Web Serial. Use current Chrome/Edge or the CLI.",
+        "This browser does not provide Web Serial. Use current desktop Chrome, Edge, or Firefox 151 or later, or the CLI.",
       ),
     );
   }

--- a/docs/website/web-flasher/test/bridge.test.mjs
+++ b/docs/website/web-flasher/test/bridge.test.mjs
@@ -1231,6 +1231,12 @@ test("unsupported and insecure browser failures emit terminal bridge events", as
     { phase: unsupportedEvents.at(-1).phase, code: unsupportedEvents.at(-1).code },
     { phase: "failed", code: "unsupported_browser" },
   );
+  // The emitted message is the thrown text plus the recovery guidance, so the
+  // reader sees both sentences at once and they have to agree. The guidance has
+  // named Firefox since it shipped Web Serial in 151; a leading sentence that
+  // still says "Chrome/Edge" contradicts the sentence right after it.
+  assert.match(unsupportedEvents.at(-1).message, /Firefox/);
+  assert.doesNotMatch(unsupportedEvents.at(-1).message, /Chrome\/Edge/);
   assert.equal(testing.prepared(), null);
   assert.equal(unsupportedConfiguration.every((byte) => byte === 0), true);
 });

--- a/docs/website/web-flasher/test/bridge.test.mjs
+++ b/docs/website/web-flasher/test/bridge.test.mjs
@@ -1231,10 +1231,6 @@ test("unsupported and insecure browser failures emit terminal bridge events", as
     { phase: unsupportedEvents.at(-1).phase, code: unsupportedEvents.at(-1).code },
     { phase: "failed", code: "unsupported_browser" },
   );
-  // The emitted message is the thrown text plus the recovery guidance, so the
-  // reader sees both sentences at once and they have to agree. The guidance has
-  // named Firefox since it shipped Web Serial in 151; a leading sentence that
-  // still says "Chrome/Edge" contradicts the sentence right after it.
   assert.match(unsupportedEvents.at(-1).message, /Firefox/);
   assert.doesNotMatch(unsupportedEvents.at(-1).message, /Chrome\/Edge/);
   assert.equal(testing.prepared(), null);


### PR DESCRIPTION
Running the 0.3.5 acceptance rows tonight I opened the flasher in Firefox to record the fallback check, and hit something small but user-facing.

The bridge builds what the reader sees by joining the thrown message to the recovery guidance for that code:

```js
return { code, message: `${message} ${guidance}` };
```

So for `unsupported_browser` both sentences land together, and they disagreed. The guidance says "Use current desktop Chrome, Edge, or Firefox 151 or later"; the sentence immediately before it said "Use current Chrome/Edge or the CLI." Someone reading top to bottom gets told to leave a browser that works, by the half of the message that comes first.

`c6a1673a` named Firefox in `docs/website/src/pages/flash/model.rs` and `65f441c2` carried it through the copies it found, but this string lives in the bridge itself and was missed. It is also the one the flasher actually throws, and I found it minified in the shipped 0.3.5 bundle.

The test for this case already existed. It asserted the phase and the code and nothing about the wording, which is how the two halves drifted apart underneath it. It now also checks the emitted message.

One thing worth flagging about that test, because it nearly went in wrong. My first version asserted the message matches `/Firefox/`, which **passes on the broken string**, since the guidance half already says Firefox. That would have been a test that could not fail. The assertion that actually catches it is `doesNotMatch(/Chrome\/Edge/)`, and I confirmed it red on the old string with `operator: 'doesNotMatch'` before taking the fix.

On the browser question itself: Firefox 153.0.3 on Windows raised its own Web Serial permission prompt against the served candidate and enumerated the real board, so `navigator.serial.requestPort` is present. I deliberately did not flash through it, so I am not claiming a Firefox flash works end to end, only that the API is there and this message points people away from it. That is the same evidence I owe discussion #67.

### What I ran

- `npm run test:flasher` (`node --test web-flasher/test/*.test.mjs`) - 61 pass, 0 fail
- `bash validation/hygiene/fmt-docs.sh` - `FMT_DOC_CHECK_GATE_OK`
- `python validation/run.py verify` - `VALIDATION_REGISTRY_OK`
- `./tools/prns verify` - `TOOLING_REGISTRY_OK`

Gates in Git Bash on Windows 11, x86_64. I have not exercised this path on macOS or Linux, and no Safari check is included here.