### PR TITLE
interfaces: frame-level RX accounting, carried to the USB peer behind a capability bit

### DIFF
--- a/personal-hopspot/mobile/ios/rust/Cargo.lock
+++ b/personal-hopspot/mobile/ios/rust/Cargo.lock
@@ -1327,6 +1327,7 @@ dependencies = [
  "embedded-storage-async",
  "heapless 0.8.0",
  "personal-rns",
+ "prns-macros",
  "sha2 0.11.0",
 ]
 
@@ -1430,6 +1431,7 @@ dependencies = [
  "heapless 0.8.0",
  "hkdf",
  "hmac",
+ "prns-macros",
  "rayon",
  "roaring",
  "sha2 0.11.0",
@@ -1486,6 +1488,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "prns-macros"
+version = "0.3.6"
+
+[[package]]
 name = "prns-runtime"
 version = "0.3.6"
 dependencies = [
@@ -1493,6 +1499,7 @@ dependencies = [
  "cfg-if",
  "heapless 0.8.0",
  "prns-core",
+ "prns-macros",
 ]
 
 [[package]]

--- a/personal-hopspot/mobile/ios/rust/src/usbmux.rs
+++ b/personal-hopspot/mobile/ios/rust/src/usbmux.rs
@@ -162,7 +162,10 @@ async fn serve_stream<Seam: InterfaceSeam>(
                         Ok(Message::Data(packet)) if !packet.is_empty() => {
                             seam.next_inbound(packet).await;
                         }
-                        Ok(Message::Data(_)) | Ok(Message::HelloAck { .. }) | Err(_) => {}
+                        Ok(Message::Data(_))
+                        | Ok(Message::HelloAck { .. })
+                        | Ok(Message::Vitals(_))
+                        | Err(_) => {}
                     }
                 }
             }

--- a/prns-core/src/interfaces/mod.rs
+++ b/prns-core/src/interfaces/mod.rs
@@ -50,8 +50,8 @@ pub use policy::{
     TransportCapability, LOCAL_INTERFACE_BITRATE_ESTIMATE, TRAVERSED_NETWORK_BITRATE_ESTIMATE,
 };
 pub use status::{
-    AirtimeUtilization, ConnectionState, InterfaceSnapshot, InterfaceStatus, InterfaceVitals,
-    Membership, TransferRates,
+    AirtimeUtilization, ConnectionState, FrameAccounting, InterfaceSnapshot, InterfaceStatus,
+    InterfaceVitals, Membership, TransferRates,
 };
 #[cfg(feature = "tokio-host")]
 pub use status::{ConnectionView, ReportsStatus, StatusView};

--- a/prns-core/src/interfaces/status/connection.rs
+++ b/prns-core/src/interfaces/status/connection.rs
@@ -11,7 +11,6 @@ pub enum ConnectionState {
     Unknown,
 }
 
-#[cfg(any(feature = "tokio-host", feature = "embassy-host"))]
 impl ConnectionState {
     pub const fn is_online(self) -> bool {
         matches!(self, Self::Connected | Self::Degraded)

--- a/prns-core/src/interfaces/status/mod.rs
+++ b/prns-core/src/interfaces/status/mod.rs
@@ -16,6 +16,22 @@ pub struct TransferRates {
     pub tx_bps: u32,
 }
 
+/// Frame-level receive accounting, for telling "nothing arrived" apart from "something arrived
+/// and was thrown away". Byte counters cannot make that distinction: a frame discarded before
+/// reassembly still moves `rx_bytes`, so a silent decode failure and a healthy link look alike
+/// from outside.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct FrameAccounting {
+    /// Frames taken off the medium, after any self-addressed echo is filtered out.
+    pub frames_in: u64,
+    /// Frames whose delivery header did not parse, so no sender could be attributed.
+    pub malformed: u64,
+    /// Frames that parsed but whose stream segment failed to decode. Discarded at resync.
+    pub undecodable: u64,
+    /// Wire frames fully reassembled and handed upward to the engine.
+    pub delivered: u64,
+}
+
 pub trait InterfaceStatus {
     fn id(&self) -> InterfaceId;
     fn connection(&self) -> ConnectionState;
@@ -30,6 +46,13 @@ pub trait InterfaceStatus {
     }
 
     fn transfer_rates(&self) -> Option<TransferRates> {
+        None
+    }
+
+    /// Frame-level receive accounting, when the family keeps it. `None` means the family does
+    /// not account for frames, which a caller must not read as all-zero: unaccounted and
+    /// "nothing arrived" are different answers.
+    fn frame_accounting(&self) -> Option<FrameAccounting> {
         None
     }
 }
@@ -142,5 +165,9 @@ impl<T: InterfaceStatus + ?Sized> InterfaceStatus for &T {
 
     fn transfer_rates(&self) -> Option<TransferRates> {
         (**self).transfer_rates()
+    }
+
+    fn frame_accounting(&self) -> Option<FrameAccounting> {
+        (**self).frame_accounting()
     }
 }

--- a/prns-core/src/interfaces/status/mod.rs
+++ b/prns-core/src/interfaces/status/mod.rs
@@ -24,6 +24,9 @@ pub struct TransferRates {
 pub struct FrameAccounting {
     /// Frames taken off the medium, after any self-addressed echo is filtered out.
     pub frames_in: u64,
+    /// Air frames the medium accepted for transmission. Says the driver asked and the hardware
+    /// took it — not that anything left the antenna, which only an outside observer can attest.
+    pub frames_out: u64,
     /// Frames whose delivery header did not parse, so no sender could be attributed.
     pub malformed: u64,
     /// Frames that parsed but whose stream segment failed to decode. Discarded at resync.

--- a/prns-core/src/interfaces/status/mod.rs
+++ b/prns-core/src/interfaces/status/mod.rs
@@ -58,6 +58,14 @@ pub trait InterfaceStatus {
     fn frame_accounting(&self) -> Option<FrameAccounting> {
         None
     }
+
+    /// The family's own monotonic clock when an inbound frame was last accepted, `None` before
+    /// the first one. Read beside `frame_accounting`: the totals say how much, this says how
+    /// recently, and only the pair can tell a frozen interface from a quiet one in one look —
+    /// the totals are monotonic, and `connection` only dissents once the link layer notices.
+    fn last_frame_in_at_ms(&self) -> Option<u64> {
+        None
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -172,5 +180,9 @@ impl<T: InterfaceStatus + ?Sized> InterfaceStatus for &T {
 
     fn frame_accounting(&self) -> Option<FrameAccounting> {
         (**self).frame_accounting()
+    }
+
+    fn last_frame_in_at_ms(&self) -> Option<u64> {
+        (**self).last_frame_in_at_ms()
     }
 }

--- a/prns-core/src/interfaces/usb_auto/mod.rs
+++ b/prns-core/src/interfaces/usb_auto/mod.rs
@@ -7,7 +7,7 @@ pub use policy::{
 };
 pub use protocol::{
     decode_message, host_react, node_tag_for, Capabilities, Decoder, HostInbound, MalformedMessage,
-    Message, NodeTag, PeerProfile, WriteError, ANDROID_ACCESSORY_DESCRIPTION,
+    Message, NodeTag, PeerProfile, VitalsReport, WriteError, ANDROID_ACCESSORY_DESCRIPTION,
     ANDROID_ACCESSORY_MANUFACTURER, ANDROID_ACCESSORY_MODEL, ANDROID_ACCESSORY_SERIAL,
     ANDROID_ACCESSORY_URI, ANDROID_ACCESSORY_VERSION, MAGIC, MAX_DATA_BYTES, MAX_FRAMED_BYTES,
     MAX_MESSAGE_BYTES, NODE_TAG_LEN, PROTOCOL_VERSION, READ_CHUNK_BYTES, WEBUSB_PRODUCT_ID,

--- a/prns-core/src/interfaces/usb_auto/protocol.rs
+++ b/prns-core/src/interfaces/usb_auto/protocol.rs
@@ -1,6 +1,6 @@
 use crate::interfaces::framing::rns_serial_framing;
 use crate::interfaces::framing::rns_serial_framing::RnsSerialDecoder;
-use crate::interfaces::InterfaceId;
+use crate::interfaces::{ConnectionState, FrameAccounting, InterfaceId};
 use crate::wire::BROADCAST_MTU;
 
 const PROTOCOL_VERSION_LEN: usize = 1;
@@ -30,6 +30,7 @@ enum MessageKind {
     Hello = 0x01,
     HelloAck = 0x02,
     Data = 0x03,
+    Vitals = 0x04,
 }
 
 impl MessageKind {
@@ -38,6 +39,7 @@ impl MessageKind {
             b if b == Self::Hello as u8 => Self::Hello,
             b if b == Self::HelloAck as u8 => Self::HelloAck,
             b if b == Self::Data as u8 => Self::Data,
+            b if b == Self::Vitals as u8 => Self::Vitals,
             unknown => return Err(MalformedMessage::UnknownMessageKind { kind_byte: unknown }),
         })
     }
@@ -57,6 +59,7 @@ pub struct Capabilities(u8);
 
 impl Capabilities {
     const HOST_LANE: u8 = 0b0000_0001;
+    const VITALS: u8 = 0b0000_0010;
 
     pub const fn none() -> Self {
         Self(0)
@@ -68,6 +71,16 @@ impl Capabilities {
 
     pub const fn supports_host_lane(self) -> bool {
         self.0 & Self::HOST_LANE != 0
+    }
+
+    /// This peer wants [`Message::Vitals`] reports. A sender only emits them toward a peer that
+    /// advertised the bit, so a pre-vitals peer never sees the message kind at all.
+    pub const fn with_vitals(self) -> Self {
+        Self(self.0 | Self::VITALS)
+    }
+
+    pub const fn supports_vitals(self) -> bool {
+        self.0 & Self::VITALS != 0
     }
 }
 
@@ -87,6 +100,30 @@ impl PeerProfile {
     }
 }
 
+/// One interface's health as seen from inside the node that owns it, shipped across the USB link
+/// so the peer can watch a radio it has no console to. `frames` is `None` when the interface
+/// family does not count frames — which a reader must not collapse into all-zero, because
+/// "unaccounted" and "nothing arrived" are different answers.
+///
+/// `uptime_ms` is the reporting node's own monotonic clock at the moment the report was built,
+/// so every sample dates itself. A host stamping arrival time instead would fold its polling
+/// gaps into the timeline — and when the question is "when did arrivals stop", that resolution
+/// is the point.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct VitalsReport {
+    pub interface_id: InterfaceId,
+    pub connection: ConnectionState,
+    pub uptime_ms: u64,
+    pub rx_bytes: u64,
+    pub tx_bytes: u64,
+    pub frames: Option<FrameAccounting>,
+}
+
+const VITALS_FIXED_LEN: usize = 8 + 1 + 8 + 8 + 8 + 1;
+const VITALS_FRAMES_LEN: usize = 5 * 8;
+const VITALS_FRAMES_ABSENT: u8 = 0;
+const VITALS_FRAMES_PRESENT: u8 = 1;
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Message<'a> {
     Hello(Capabilities),
@@ -95,6 +132,7 @@ pub enum Message<'a> {
         capabilities: Capabilities,
     },
     Data(&'a [u8]),
+    Vitals(VitalsReport),
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -111,6 +149,7 @@ pub enum MalformedMessage {
     WrongMagic,
     UnsupportedVersion { peer_version: u8 },
     DataTooLarge,
+    MalformedVitals,
 }
 
 impl Message<'_> {
@@ -141,6 +180,33 @@ impl Message<'_> {
                 let slot = out.get_mut(..total).ok_or(WriteError::BufferTooSmall)?;
                 slot[0] = MessageKind::Data as u8;
                 slot[MESSAGE_KIND_LEN..].copy_from_slice(packet);
+                Ok(total)
+            }
+            Message::Vitals(report) => {
+                let frames_len = match report.frames {
+                    Some(_) => VITALS_FRAMES_LEN,
+                    None => 0,
+                };
+                let total = MESSAGE_KIND_LEN + VITALS_FIXED_LEN + frames_len;
+                let slot = out.get_mut(..total).ok_or(WriteError::BufferTooSmall)?;
+                slot[0] = MessageKind::Vitals as u8;
+                let body = &mut slot[MESSAGE_KIND_LEN..];
+                body[..8].copy_from_slice(report.interface_id.as_bytes());
+                body[8] = report.connection.as_u8();
+                body[9..17].copy_from_slice(&report.uptime_ms.to_be_bytes());
+                body[17..25].copy_from_slice(&report.rx_bytes.to_be_bytes());
+                body[25..33].copy_from_slice(&report.tx_bytes.to_be_bytes());
+                match report.frames {
+                    None => body[33] = VITALS_FRAMES_ABSENT,
+                    Some(frames) => {
+                        body[33] = VITALS_FRAMES_PRESENT;
+                        body[34..42].copy_from_slice(&frames.frames_in.to_be_bytes());
+                        body[42..50].copy_from_slice(&frames.frames_out.to_be_bytes());
+                        body[50..58].copy_from_slice(&frames.malformed.to_be_bytes());
+                        body[58..66].copy_from_slice(&frames.undecodable.to_be_bytes());
+                        body[66..74].copy_from_slice(&frames.delivered.to_be_bytes());
+                    }
+                }
                 Ok(total)
             }
         }
@@ -191,7 +257,41 @@ pub fn decode_message(payload: &[u8]) -> Result<Message<'_>, MalformedMessage> {
             }
             Ok(Message::Data(body))
         }
+        MessageKind::Vitals => decode_vitals(body).map(Message::Vitals),
     }
+}
+
+fn decode_vitals(body: &[u8]) -> Result<VitalsReport, MalformedMessage> {
+    let (fixed, frames_body) = body
+        .split_at_checked(VITALS_FIXED_LEN)
+        .ok_or(MalformedMessage::MalformedVitals)?;
+    let mut id = [0u8; 8];
+    id.copy_from_slice(&fixed[..8]);
+    let frames = match (fixed[33], frames_body.len()) {
+        (VITALS_FRAMES_ABSENT, 0) => None,
+        (VITALS_FRAMES_PRESENT, VITALS_FRAMES_LEN) => Some(FrameAccounting {
+            frames_in: be_u64(&frames_body[..8]),
+            frames_out: be_u64(&frames_body[8..16]),
+            malformed: be_u64(&frames_body[16..24]),
+            undecodable: be_u64(&frames_body[24..32]),
+            delivered: be_u64(&frames_body[32..40]),
+        }),
+        _ => return Err(MalformedMessage::MalformedVitals),
+    };
+    Ok(VitalsReport {
+        interface_id: InterfaceId::new(id),
+        connection: ConnectionState::from_u8(fixed[8]),
+        uptime_ms: be_u64(&fixed[9..17]),
+        rx_bytes: be_u64(&fixed[17..25]),
+        tx_bytes: be_u64(&fixed[25..33]),
+        frames,
+    })
+}
+
+fn be_u64(bytes: &[u8]) -> u64 {
+    let mut word = [0u8; 8];
+    word.copy_from_slice(bytes);
+    u64::from_be_bytes(word)
 }
 
 fn vet_handshake(body: &[u8], expected_len: usize) -> Result<(), MalformedMessage> {
@@ -220,7 +320,7 @@ pub fn react_to(message: Result<Message<'_>, MalformedMessage>) -> InboundReacti
     match message {
         Ok(Message::Hello(_)) => InboundReaction::AnswerHandshake,
         Ok(Message::Data(packet)) => InboundReaction::Deliver(packet),
-        Ok(Message::HelloAck { .. }) | Err(_) => InboundReaction::Ignore,
+        Ok(Message::HelloAck { .. } | Message::Vitals(_)) | Err(_) => InboundReaction::Ignore,
     }
 }
 
@@ -230,6 +330,7 @@ pub enum HostInbound<'a> {
     AnswerHandshake,
     Confirmed(NodeTag),
     Data(&'a [u8]),
+    Vitals(VitalsReport),
     Ignore,
 }
 
@@ -238,6 +339,7 @@ pub fn host_react(message: Result<Message<'_>, MalformedMessage>) -> HostInbound
         Ok(Message::Hello(_)) => HostInbound::AnswerHandshake,
         Ok(Message::HelloAck { tag, .. }) => HostInbound::Confirmed(tag),
         Ok(Message::Data(packet)) => HostInbound::Data(packet),
+        Ok(Message::Vitals(report)) => HostInbound::Vitals(report),
         Err(_) => HostInbound::Ignore,
     }
 }
@@ -256,6 +358,7 @@ mod tests {
             capabilities: Capabilities,
         },
         Data(std::vec::Vec<u8>),
+        Vitals(VitalsReport),
     }
 
     impl OwnedMessage {
@@ -267,6 +370,7 @@ mod tests {
                     capabilities: *capabilities,
                 },
                 OwnedMessage::Data(packet) => Message::Data(packet),
+                OwnedMessage::Vitals(report) => Message::Vitals(*report),
             }
         }
 
@@ -275,6 +379,11 @@ mod tests {
                 OwnedMessage::Hello(_) => MESSAGE_KIND_LEN + HELLO_BODY_LEN,
                 OwnedMessage::HelloAck { .. } => MESSAGE_KIND_LEN + HELLO_ACK_BODY_LEN,
                 OwnedMessage::Data(packet) => MESSAGE_KIND_LEN + packet.len(),
+                OwnedMessage::Vitals(report) => {
+                    MESSAGE_KIND_LEN
+                        + VITALS_FIXED_LEN
+                        + report.frames.map_or(0, |_| VITALS_FRAMES_LEN)
+                }
             }
         }
     }
@@ -284,6 +393,7 @@ mod tests {
             Message::Hello(capabilities) => OwnedMessage::Hello(capabilities),
             Message::HelloAck { tag, capabilities } => OwnedMessage::HelloAck { tag, capabilities },
             Message::Data(packet) => OwnedMessage::Data(packet.to_vec()),
+            Message::Vitals(report) => OwnedMessage::Vitals(report),
         }
     }
 
@@ -295,12 +405,48 @@ mod tests {
         any::<[u8; NODE_TAG_LEN]>().prop_map(NodeTag)
     }
 
+    fn vitals_reports() -> impl Strategy<Value = VitalsReport> {
+        (
+            any::<[u8; 8]>(),
+            any::<u8>(),
+            any::<(u64, u64, u64)>(),
+            prop::option::of((
+                any::<u64>(),
+                any::<u64>(),
+                any::<u64>(),
+                any::<u64>(),
+                any::<u64>(),
+            )),
+        )
+            .prop_map(
+                |(id, connection, (uptime_ms, rx_bytes, tx_bytes), frames)| VitalsReport {
+                    interface_id: InterfaceId::new(id),
+                    connection: ConnectionState::from_u8(connection),
+                    uptime_ms,
+                    rx_bytes,
+                    tx_bytes,
+                    frames: frames.map(
+                        |(frames_in, frames_out, malformed, undecodable, delivered)| {
+                            FrameAccounting {
+                                frames_in,
+                                frames_out,
+                                malformed,
+                                undecodable,
+                                delivered,
+                            }
+                        },
+                    ),
+                },
+            )
+    }
+
     fn owned_messages() -> impl Strategy<Value = OwnedMessage> {
         prop_oneof![
             capabilities().prop_map(OwnedMessage::Hello),
             (node_tags(), capabilities())
                 .prop_map(|(tag, capabilities)| OwnedMessage::HelloAck { tag, capabilities }),
             prop::collection::vec(any::<u8>(), 0..=MAX_DATA_BYTES).prop_map(OwnedMessage::Data),
+            vitals_reports().prop_map(OwnedMessage::Vitals),
         ]
     }
 
@@ -311,7 +457,9 @@ mod tests {
         match decode_message(&owned).expect("decode") {
             Message::Hello(capabilities) => Message::Hello(capabilities),
             Message::HelloAck { tag, capabilities } => Message::HelloAck { tag, capabilities },
-            Message::Data(_) => unreachable!("test helper not used for data"),
+            Message::Data(_) | Message::Vitals(_) => {
+                unreachable!("test helper only used for handshakes")
+            }
         }
     }
 
@@ -447,6 +595,101 @@ mod tests {
         match decode_message(&frame).expect("decode") {
             Message::Data(body) => assert_eq!(body.len(), MAX_DATA_BYTES),
             other => panic!("expected data, got {other:?}"),
+        }
+    }
+
+    fn sample_vitals(frames: Option<FrameAccounting>) -> VitalsReport {
+        VitalsReport {
+            interface_id: InterfaceId::new(*b"halowat0"),
+            connection: ConnectionState::Connected,
+            uptime_ms: 1_923_004,
+            rx_bytes: 0x0102_0304_0506_0708,
+            tx_bytes: 42,
+            frames,
+        }
+    }
+
+    #[test]
+    fn vitals_round_trip_with_frame_accounting() {
+        let report = sample_vitals(Some(FrameAccounting {
+            frames_in: 61,
+            frames_out: 33,
+            malformed: 2,
+            undecodable: 17,
+            delivered: 40,
+        }));
+        let mut buf = [0u8; MAX_MESSAGE_BYTES];
+        let n = Message::Vitals(report).write_payload(&mut buf).unwrap();
+        assert_eq!(decode_message(&buf[..n]), Ok(Message::Vitals(report)));
+    }
+
+    #[test]
+    fn vitals_round_trip_without_frame_accounting_stays_unaccounted() {
+        // None must survive the wire as None: an interface that does not count frames must not
+        // arrive at the host reading all-zero.
+        let report = sample_vitals(None);
+        let mut buf = [0u8; MAX_MESSAGE_BYTES];
+        let n = Message::Vitals(report).write_payload(&mut buf).unwrap();
+        match decode_message(&buf[..n]) {
+            Ok(Message::Vitals(decoded)) => assert_eq!(decoded.frames, None),
+            other => panic!("expected vitals, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn truncated_vitals_are_rejected() {
+        let report = sample_vitals(Some(FrameAccounting::default()));
+        let mut buf = [0u8; MAX_MESSAGE_BYTES];
+        let n = Message::Vitals(report).write_payload(&mut buf).unwrap();
+        for cut in 1..n {
+            assert!(
+                decode_message(&buf[..cut]).is_err(),
+                "a vitals frame cut to {cut} of {n} bytes decoded anyway"
+            );
+        }
+    }
+
+    #[test]
+    fn vitals_with_a_presence_flag_that_contradicts_the_length_are_rejected() {
+        let report = sample_vitals(None);
+        let mut buf = [0u8; MAX_MESSAGE_BYTES];
+        let n = Message::Vitals(report).write_payload(&mut buf).unwrap();
+        // Claim the accounting block is present while sending none of it.
+        buf[n - 1] = 1;
+        assert_eq!(
+            decode_message(&buf[..n]),
+            Err(MalformedMessage::MalformedVitals)
+        );
+    }
+
+    #[test]
+    fn the_vitals_capability_composes_with_the_host_lane() {
+        let both = Capabilities::host().with_vitals();
+        assert!(both.supports_host_lane());
+        assert!(both.supports_vitals());
+        assert!(!Capabilities::host().supports_vitals());
+        assert!(!Capabilities::none().supports_vitals());
+        // The bit must not disturb lane negotiation with a pre-vitals peer.
+        assert_eq!(
+            PeerProfile::negotiate(both, Capabilities::host()),
+            PeerProfile::Host
+        );
+    }
+
+    #[test]
+    fn the_device_ignores_an_inbound_vitals_report() {
+        assert!(matches!(
+            react_to(Ok(Message::Vitals(sample_vitals(None)))),
+            InboundReaction::Ignore
+        ));
+    }
+
+    #[test]
+    fn the_host_surfaces_a_vitals_report() {
+        let report = sample_vitals(Some(FrameAccounting::default()));
+        match host_react(Ok(Message::Vitals(report))) {
+            HostInbound::Vitals(surfaced) => assert_eq!(surfaced, report),
+            _ => panic!("expected the host to surface the report"),
         }
     }
 

--- a/prns-core/src/interfaces/usb_auto/protocol.rs
+++ b/prns-core/src/interfaces/usb_auto/protocol.rs
@@ -109,17 +109,27 @@ impl PeerProfile {
 /// so every sample dates itself. A host stamping arrival time instead would fold its polling
 /// gaps into the timeline — and when the question is "when did arrivals stop", that resolution
 /// is the point.
+///
+/// `last_frame_in_at_ms` is that same clock's value when the interface last accepted an inbound
+/// frame, `None` before the first one. The pair answers "how long ago did arrivals stop" from a
+/// single report: the accounting counters are monotonic totals, so one read of them cannot tell
+/// a frozen interface from a quiet one, and `connection` only dissents once the link layer has
+/// noticed. `uptime_ms - last_frame_in_at_ms` needs no second sample and no host clock.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct VitalsReport {
     pub interface_id: InterfaceId,
     pub connection: ConnectionState,
     pub uptime_ms: u64,
+    pub last_frame_in_at_ms: Option<u64>,
     pub rx_bytes: u64,
     pub tx_bytes: u64,
     pub frames: Option<FrameAccounting>,
 }
 
-const VITALS_FIXED_LEN: usize = 8 + 1 + 8 + 8 + 8 + 1;
+const VITALS_FIXED_LEN: usize = 8 + 1 + 8 + 8 + 8 + 8 + 1;
+/// "No inbound frame since boot" on the wire. A real stamp cannot reach it: 2^64 - 1 ms of
+/// uptime is over half a billion years, so the sentinel costs no representable value.
+const VITALS_NO_FRAME_YET: u64 = u64::MAX;
 const VITALS_FRAMES_LEN: usize = 5 * 8;
 const VITALS_FRAMES_ABSENT: u8 = 0;
 const VITALS_FRAMES_PRESENT: u8 = 1;
@@ -194,17 +204,19 @@ impl Message<'_> {
                 body[..8].copy_from_slice(report.interface_id.as_bytes());
                 body[8] = report.connection.as_u8();
                 body[9..17].copy_from_slice(&report.uptime_ms.to_be_bytes());
-                body[17..25].copy_from_slice(&report.rx_bytes.to_be_bytes());
-                body[25..33].copy_from_slice(&report.tx_bytes.to_be_bytes());
+                let last_frame_in = report.last_frame_in_at_ms.unwrap_or(VITALS_NO_FRAME_YET);
+                body[17..25].copy_from_slice(&last_frame_in.to_be_bytes());
+                body[25..33].copy_from_slice(&report.rx_bytes.to_be_bytes());
+                body[33..41].copy_from_slice(&report.tx_bytes.to_be_bytes());
                 match report.frames {
-                    None => body[33] = VITALS_FRAMES_ABSENT,
+                    None => body[41] = VITALS_FRAMES_ABSENT,
                     Some(frames) => {
-                        body[33] = VITALS_FRAMES_PRESENT;
-                        body[34..42].copy_from_slice(&frames.frames_in.to_be_bytes());
-                        body[42..50].copy_from_slice(&frames.frames_out.to_be_bytes());
-                        body[50..58].copy_from_slice(&frames.malformed.to_be_bytes());
-                        body[58..66].copy_from_slice(&frames.undecodable.to_be_bytes());
-                        body[66..74].copy_from_slice(&frames.delivered.to_be_bytes());
+                        body[41] = VITALS_FRAMES_PRESENT;
+                        body[42..50].copy_from_slice(&frames.frames_in.to_be_bytes());
+                        body[50..58].copy_from_slice(&frames.frames_out.to_be_bytes());
+                        body[58..66].copy_from_slice(&frames.malformed.to_be_bytes());
+                        body[66..74].copy_from_slice(&frames.undecodable.to_be_bytes());
+                        body[74..82].copy_from_slice(&frames.delivered.to_be_bytes());
                     }
                 }
                 Ok(total)
@@ -267,7 +279,7 @@ fn decode_vitals(body: &[u8]) -> Result<VitalsReport, MalformedMessage> {
         .ok_or(MalformedMessage::MalformedVitals)?;
     let mut id = [0u8; 8];
     id.copy_from_slice(&fixed[..8]);
-    let frames = match (fixed[33], frames_body.len()) {
+    let frames = match (fixed[41], frames_body.len()) {
         (VITALS_FRAMES_ABSENT, 0) => None,
         (VITALS_FRAMES_PRESENT, VITALS_FRAMES_LEN) => Some(FrameAccounting {
             frames_in: be_u64(&frames_body[..8]),
@@ -282,8 +294,12 @@ fn decode_vitals(body: &[u8]) -> Result<VitalsReport, MalformedMessage> {
         interface_id: InterfaceId::new(id),
         connection: ConnectionState::from_u8(fixed[8]),
         uptime_ms: be_u64(&fixed[9..17]),
-        rx_bytes: be_u64(&fixed[17..25]),
-        tx_bytes: be_u64(&fixed[25..33]),
+        last_frame_in_at_ms: match be_u64(&fixed[17..25]) {
+            VITALS_NO_FRAME_YET => None,
+            at_ms => Some(at_ms),
+        },
+        rx_bytes: be_u64(&fixed[25..33]),
+        tx_bytes: be_u64(&fixed[33..41]),
         frames,
     })
 }
@@ -410,6 +426,8 @@ mod tests {
             any::<[u8; 8]>(),
             any::<u8>(),
             any::<(u64, u64, u64)>(),
+            // The wire spends u64::MAX on "no frame yet", so it is not a representable stamp.
+            prop::option::of(0..u64::MAX),
             prop::option::of((
                 any::<u64>(),
                 any::<u64>(),
@@ -419,23 +437,26 @@ mod tests {
             )),
         )
             .prop_map(
-                |(id, connection, (uptime_ms, rx_bytes, tx_bytes), frames)| VitalsReport {
-                    interface_id: InterfaceId::new(id),
-                    connection: ConnectionState::from_u8(connection),
-                    uptime_ms,
-                    rx_bytes,
-                    tx_bytes,
-                    frames: frames.map(
-                        |(frames_in, frames_out, malformed, undecodable, delivered)| {
-                            FrameAccounting {
-                                frames_in,
-                                frames_out,
-                                malformed,
-                                undecodable,
-                                delivered,
-                            }
-                        },
-                    ),
+                |(id, connection, (uptime_ms, rx_bytes, tx_bytes), last_frame_in_at_ms, frames)| {
+                    VitalsReport {
+                        interface_id: InterfaceId::new(id),
+                        connection: ConnectionState::from_u8(connection),
+                        uptime_ms,
+                        last_frame_in_at_ms,
+                        rx_bytes,
+                        tx_bytes,
+                        frames: frames.map(
+                            |(frames_in, frames_out, malformed, undecodable, delivered)| {
+                                FrameAccounting {
+                                    frames_in,
+                                    frames_out,
+                                    malformed,
+                                    undecodable,
+                                    delivered,
+                                }
+                            },
+                        ),
+                    }
                 },
             )
     }
@@ -603,6 +624,7 @@ mod tests {
             interface_id: InterfaceId::new(*b"halowat0"),
             connection: ConnectionState::Connected,
             uptime_ms: 1_923_004,
+            last_frame_in_at_ms: Some(1_919_557),
             rx_bytes: 0x0102_0304_0506_0708,
             tx_bytes: 42,
             frames,
@@ -634,6 +656,50 @@ mod tests {
             Ok(Message::Vitals(decoded)) => assert_eq!(decoded.frames, None),
             other => panic!("expected vitals, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn a_never_stamped_interface_survives_the_wire_as_never() {
+        // None must not collapse into a number: "no frame since boot" and "a frame at some
+        // stamp" are different answers, exactly like the accounting block's None.
+        let report = VitalsReport {
+            last_frame_in_at_ms: None,
+            ..sample_vitals(None)
+        };
+        let mut buf = [0u8; MAX_MESSAGE_BYTES];
+        let n = Message::Vitals(report).write_payload(&mut buf).unwrap();
+        match decode_message(&buf[..n]) {
+            Ok(Message::Vitals(decoded)) => assert_eq!(decoded.last_frame_in_at_ms, None),
+            other => panic!("expected vitals, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn one_sample_tells_a_frozen_interface_from_a_quiet_one() {
+        // The counters below are identical, so nothing else in the report can make this call.
+        // Both stamps ride the reporter's own clock, so the ages are commensurable by
+        // construction and no second sample or host clock enters the arithmetic.
+        let frames = Some(FrameAccounting {
+            frames_in: 5058,
+            frames_out: 5258,
+            malformed: 0,
+            undecodable: 0,
+            delivered: 5058,
+        });
+        let quiet = VitalsReport {
+            uptime_ms: 3_600_000,
+            last_frame_in_at_ms: Some(3_594_000),
+            ..sample_vitals(frames)
+        };
+        let frozen = VitalsReport {
+            uptime_ms: 3_600_000,
+            last_frame_in_at_ms: Some(600_000),
+            ..sample_vitals(frames)
+        };
+        let age = |report: VitalsReport| report.uptime_ms - report.last_frame_in_at_ms.unwrap();
+        assert_eq!(age(quiet), 6_000);
+        assert_eq!(age(frozen), 3_000_000);
+        assert_eq!(quiet.frames, frozen.frames);
     }
 
     #[test]

--- a/prns-interfaces/impls/tokio/src/usb_auto/mod.rs
+++ b/prns-interfaces/impls/tokio/src/usb_auto/mod.rs
@@ -483,6 +483,10 @@ async fn serve_port<S>(
                                 let _ = notify.send(key);
                             }
                         }
+                        // Not stored yet: the vitals store and the surface that reads it are the
+                        // other half of this seam. Until they exist, a report proves the link
+                        // works and nothing else.
+                        HostInbound::Vitals(_) => {}
                         HostInbound::Ignore => {}
                     }
                 }

--- a/prns-runtime/impls/embassy/Cargo.lock
+++ b/prns-runtime/impls/embassy/Cargo.lock
@@ -506,6 +506,7 @@ dependencies = [
  "heapless 0.8.0",
  "hkdf",
  "hmac",
+ "prns-macros",
  "rmp",
  "roaring",
  "sha2 0.11.0",
@@ -514,12 +515,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prns-macros"
+version = "0.3.6"
+
+[[package]]
 name = "prns-runtime"
 version = "0.3.6"
 dependencies = [
  "cfg-if",
  "heapless 0.8.0",
  "prns-core",
+ "prns-macros",
 ]
 
 [[package]]

--- a/prns-runtime/impls/embassy/src/manifold/driver/interface_status.rs
+++ b/prns-runtime/impls/embassy/src/manifold/driver/interface_status.rs
@@ -17,6 +17,7 @@ pub struct EmbassyInterfaceStatus {
     enabled: AtomicBool,
     enabled_changed: Signal<CriticalSectionRawMutex, bool>,
     accounts_frames: AtomicBool,
+    last_frame_in_at: AtomicU64,
     frames_in: AtomicU64,
     frames_out: AtomicU64,
     frames_malformed: AtomicU64,
@@ -26,6 +27,7 @@ pub struct EmbassyInterfaceStatus {
 
 const AIRTIME_UNPUBLISHED: u32 = u32::MAX;
 const RATES_UNPUBLISHED: u64 = u64::MAX;
+const NO_FRAME_YET: u64 = u64::MAX;
 
 impl EmbassyInterfaceStatus {
     #[must_use]
@@ -40,6 +42,7 @@ impl EmbassyInterfaceStatus {
             enabled: AtomicBool::new(true),
             enabled_changed: Signal::new(),
             accounts_frames: AtomicBool::new(false),
+            last_frame_in_at: AtomicU64::new(NO_FRAME_YET),
             frames_in: AtomicU64::new(0),
             frames_out: AtomicU64::new(0),
             frames_malformed: AtomicU64::new(0),
@@ -126,7 +129,11 @@ impl EmbassyInterfaceStatus {
         self.accounts_frames.store(true, Ordering::Relaxed);
     }
 
-    pub fn count_frame_in(&self) {
+    /// Count an accepted inbound frame and stamp when, on the driver's own monotonic clock.
+    /// One call does both so a counted frame can never be an unstamped one — a counter that
+    /// moves while the stamp stands still would recreate the ambiguity the stamp exists to end.
+    pub fn count_frame_in(&self, at_ms: u64) {
+        self.last_frame_in_at.store(at_ms, Ordering::Relaxed);
         self.frames_in.fetch_add(1, Ordering::Relaxed);
     }
 
@@ -201,6 +208,13 @@ impl InterfaceStatus for EmbassyInterfaceStatus {
             delivered: self.frames_delivered.load(Ordering::Relaxed),
         })
     }
+
+    fn last_frame_in_at_ms(&self) -> Option<u64> {
+        match self.last_frame_in_at.load(Ordering::Relaxed) {
+            NO_FRAME_YET => None,
+            at_ms => Some(at_ms),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -237,14 +251,14 @@ mod tests {
 
         // Counting before declaring must not publish: a family that never declares stays None,
         // and None must remain distinguishable from an idle link's all-zero.
-        status.count_frame_in();
+        status.count_frame_in(7);
         assert_eq!(status.frame_accounting(), None);
 
         status.account_frames();
         let counts = status.frame_accounting().unwrap();
         assert_eq!(counts.frames_in, 1);
 
-        status.count_frame_in();
+        status.count_frame_in(19);
         status.count_frame_out();
         status.count_frame_malformed();
         status.count_frame_undecodable();
@@ -260,5 +274,27 @@ mod tests {
             ),
             (2, 1, 1, 1, 1)
         );
+    }
+
+    #[test]
+    fn the_inbound_stamp_tracks_the_latest_accepted_frame() {
+        let status =
+            EmbassyInterfaceStatus::new(InterfaceId::new([0x5A; 8]), ConnectionState::Connected);
+
+        // No frame yet reads None, not zero: "never" and "at boot" are different answers.
+        assert_eq!(status.last_frame_in_at_ms(), None);
+
+        status.count_frame_in(1_000);
+        assert_eq!(status.last_frame_in_at_ms(), Some(1_000));
+
+        // Only accepted inbound frames move the stamp; discards and TX must not refresh it,
+        // or a link delivering nothing but garbage would keep reading fresh.
+        status.count_frame_out();
+        status.count_frame_malformed();
+        status.count_frame_undecodable();
+        assert_eq!(status.last_frame_in_at_ms(), Some(1_000));
+
+        status.count_frame_in(2_500);
+        assert_eq!(status.last_frame_in_at_ms(), Some(2_500));
     }
 }

--- a/prns-runtime/impls/embassy/src/manifold/driver/interface_status.rs
+++ b/prns-runtime/impls/embassy/src/manifold/driver/interface_status.rs
@@ -3,7 +3,8 @@ use embassy_sync::signal::Signal;
 use portable_atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicU8, Ordering};
 
 use crate::interfaces::{
-    AirtimeUtilization, ConnectionState, InterfaceId, InterfaceStatus, TransferRates,
+    AirtimeUtilization, ConnectionState, FrameAccounting, InterfaceId, InterfaceStatus,
+    TransferRates,
 };
 
 pub struct EmbassyInterfaceStatus {
@@ -15,6 +16,11 @@ pub struct EmbassyInterfaceStatus {
     transfer_rates: AtomicU64,
     enabled: AtomicBool,
     enabled_changed: Signal<CriticalSectionRawMutex, bool>,
+    accounts_frames: AtomicBool,
+    frames_in: AtomicU64,
+    frames_malformed: AtomicU64,
+    frames_undecodable: AtomicU64,
+    frames_delivered: AtomicU64,
 }
 
 const AIRTIME_UNPUBLISHED: u32 = u32::MAX;
@@ -32,6 +38,11 @@ impl EmbassyInterfaceStatus {
             transfer_rates: AtomicU64::new(RATES_UNPUBLISHED),
             enabled: AtomicBool::new(true),
             enabled_changed: Signal::new(),
+            accounts_frames: AtomicBool::new(false),
+            frames_in: AtomicU64::new(0),
+            frames_malformed: AtomicU64::new(0),
+            frames_undecodable: AtomicU64::new(0),
+            frames_delivered: AtomicU64::new(0),
         }
     }
 
@@ -105,6 +116,29 @@ impl EmbassyInterfaceStatus {
         let packed = (u64::from(rates.rx_bps) << 32) | u64::from(rates.tx_bps);
         self.transfer_rates.store(packed, Ordering::Relaxed);
     }
+
+    /// Declare that this interface counts frames, so a reader can tell an idle accounted link
+    /// (all-zero) from a family that never counted (`None`). A driver calls this once at bring-up,
+    /// before the first frame, and the counters publish from then on.
+    pub fn account_frames(&self) {
+        self.accounts_frames.store(true, Ordering::Relaxed);
+    }
+
+    pub fn count_frame_in(&self) {
+        self.frames_in.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn count_frame_malformed(&self) {
+        self.frames_malformed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn count_frame_undecodable(&self) {
+        self.frames_undecodable.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn count_frame_delivered(&self) {
+        self.frames_delivered.fetch_add(1, Ordering::Relaxed);
+    }
 }
 
 impl InterfaceStatus for EmbassyInterfaceStatus {
@@ -148,6 +182,18 @@ impl InterfaceStatus for EmbassyInterfaceStatus {
             tx_bps: packed as u32,
         })
     }
+
+    fn frame_accounting(&self) -> Option<FrameAccounting> {
+        if !self.accounts_frames.load(Ordering::Relaxed) {
+            return None;
+        }
+        Some(FrameAccounting {
+            frames_in: self.frames_in.load(Ordering::Relaxed),
+            malformed: self.frames_malformed.load(Ordering::Relaxed),
+            undecodable: self.frames_undecodable.load(Ordering::Relaxed),
+            delivered: self.frames_delivered.load(Ordering::Relaxed),
+        })
+    }
 }
 
 #[cfg(test)]
@@ -175,5 +221,35 @@ mod tests {
         assert!(!status.is_enabled());
         status.enable();
         assert!(status.is_enabled());
+    }
+
+    #[test]
+    fn frame_accounting_stays_unpublished_until_declared() {
+        let status =
+            EmbassyInterfaceStatus::new(InterfaceId::new([0x5A; 8]), ConnectionState::Connected);
+
+        // Counting before declaring must not publish: a family that never declares stays None,
+        // and None must remain distinguishable from an idle link's all-zero.
+        status.count_frame_in();
+        assert_eq!(status.frame_accounting(), None);
+
+        status.account_frames();
+        let counts = status.frame_accounting().unwrap();
+        assert_eq!(counts.frames_in, 1);
+
+        status.count_frame_in();
+        status.count_frame_malformed();
+        status.count_frame_undecodable();
+        status.count_frame_delivered();
+        let counts = status.frame_accounting().unwrap();
+        assert_eq!(
+            (
+                counts.frames_in,
+                counts.malformed,
+                counts.undecodable,
+                counts.delivered
+            ),
+            (2, 1, 1, 1)
+        );
     }
 }

--- a/prns-runtime/impls/embassy/src/manifold/driver/interface_status.rs
+++ b/prns-runtime/impls/embassy/src/manifold/driver/interface_status.rs
@@ -18,6 +18,7 @@ pub struct EmbassyInterfaceStatus {
     enabled_changed: Signal<CriticalSectionRawMutex, bool>,
     accounts_frames: AtomicBool,
     frames_in: AtomicU64,
+    frames_out: AtomicU64,
     frames_malformed: AtomicU64,
     frames_undecodable: AtomicU64,
     frames_delivered: AtomicU64,
@@ -40,6 +41,7 @@ impl EmbassyInterfaceStatus {
             enabled_changed: Signal::new(),
             accounts_frames: AtomicBool::new(false),
             frames_in: AtomicU64::new(0),
+            frames_out: AtomicU64::new(0),
             frames_malformed: AtomicU64::new(0),
             frames_undecodable: AtomicU64::new(0),
             frames_delivered: AtomicU64::new(0),
@@ -128,6 +130,10 @@ impl EmbassyInterfaceStatus {
         self.frames_in.fetch_add(1, Ordering::Relaxed);
     }
 
+    pub fn count_frame_out(&self) {
+        self.frames_out.fetch_add(1, Ordering::Relaxed);
+    }
+
     pub fn count_frame_malformed(&self) {
         self.frames_malformed.fetch_add(1, Ordering::Relaxed);
     }
@@ -189,6 +195,7 @@ impl InterfaceStatus for EmbassyInterfaceStatus {
         }
         Some(FrameAccounting {
             frames_in: self.frames_in.load(Ordering::Relaxed),
+            frames_out: self.frames_out.load(Ordering::Relaxed),
             malformed: self.frames_malformed.load(Ordering::Relaxed),
             undecodable: self.frames_undecodable.load(Ordering::Relaxed),
             delivered: self.frames_delivered.load(Ordering::Relaxed),
@@ -238,6 +245,7 @@ mod tests {
         assert_eq!(counts.frames_in, 1);
 
         status.count_frame_in();
+        status.count_frame_out();
         status.count_frame_malformed();
         status.count_frame_undecodable();
         status.count_frame_delivered();
@@ -245,11 +253,12 @@ mod tests {
         assert_eq!(
             (
                 counts.frames_in,
+                counts.frames_out,
                 counts.malformed,
                 counts.undecodable,
                 counts.delivered
             ),
-            (2, 1, 1, 1)
+            (2, 1, 1, 1, 1)
         );
     }
 }

--- a/prns-wasm/Cargo.lock
+++ b/prns-wasm/Cargo.lock
@@ -425,6 +425,7 @@ dependencies = [
  "embedded-storage-async",
  "heapless",
  "personal-rns",
+ "prns-macros",
  "sha2 0.11.0",
 ]
 
@@ -457,6 +458,7 @@ dependencies = [
  "heapless",
  "hkdf",
  "hmac",
+ "prns-macros",
  "roaring",
  "sha2 0.11.0",
  "x25519-dalek",
@@ -478,6 +480,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "prns-macros"
+version = "0.3.6"
+
+[[package]]
 name = "prns-runtime"
 version = "0.3.6"
 dependencies = [
@@ -485,6 +491,7 @@ dependencies = [
  "cfg-if",
  "heapless",
  "prns-core",
+ "prns-macros",
 ]
 
 [[package]]

--- a/prns-wasm/src/js_translation.rs
+++ b/prns-wasm/src/js_translation.rs
@@ -619,6 +619,10 @@ pub(crate) fn usb_auto_message_to_js(message: usb_auto::Message<'_>) -> JsValue 
             set_str(&object, "type", "data");
             set_bytes(&object, "bytes", packet);
         }
+        // Typed but not unpacked: the surface that reads a report is the other half of this
+        // seam, the same boundary the tokio host draws. A JS caller can see that a report
+        // arrived without this crate inventing a shape for it first.
+        usb_auto::Message::Vitals(_) => set_str(&object, "type", "vitals"),
     }
     object.into()
 }


### PR DESCRIPTION
This one comes out of a long bench night. Two boards on a radio link, a daemon on each side holding the board's only USB port, and forty addressed messages that never arrived while every announce crossed fine. The question that mattered was simple: are the frames dying on the air, or arriving and being thrown away? And there was no way to answer it, because `rx_bytes` moves either way. A frame that arrives and fails reassembly has already been counted by the time it's discarded, so from outside the node a link dropping everything is byte-for-byte indistinguishable from a healthy idle one. Taking the console to look kills the daemon that keeps the link alive, and with it the traffic you're trying to observe.

Two changes, one per commit.

**Frame accounting.** `FrameAccounting { frames_in, frames_out, malformed, undecodable, delivered }` joins `InterfaceStatus` as a defaulted method returning `Option`. `frames_out` counts what the medium accepted for transmission, which is deliberately not the claim that RF left the antenna - a link can also die by transmitting into a void, and the TX/RX split is what gives that state a signature. `None` means the family doesn't count, and a caller must not read that as all-zero: "unaccounted" and "nothing arrived" are different answers, which is the whole point. It's defaulted, so no existing family, binding, or FFI surface changes. `EmbassyInterfaceStatus` backs it with atomics behind an opt-in `account_frames()` declaration, so a family that never declares stays `None` even if a stray increment lands, and a test pins that.

**Carrying it to the peer.** `Message::Vitals` (kind 0x04) in the usb_auto protocol carries one interface's id, connection state, the node's own monotonic uptime (so every sample dates itself even across host polling gaps - when the question is "when did arrivals stop", host-side timestamps fold polling gaps into the timeline), byte counters, and the optional accounting block, with a presence flag so `None` survives the wire as `None`. It sits behind a new `Capabilities` bit: a sender only emits it toward a peer that advertised the bit, so a pre-vitals peer never sees the kind byte at all, and lane negotiation ignores the bit entirely (the composition test covers both directions, and your existing "unknown capability bit is preserved, not rejected" test already had the forward path covered, which is a nice piece of design). The device reaction ignores an inbound report; the host reaction surfaces it as `HostInbound::Vitals`.

Deliberately not in this PR: nothing sends the message yet and the host does nothing with it past parsing. The sender needs a per-board list of statuses and a cadence decision, and the host needs a store and somewhere to expose it. Both are worth their own conversation once this seam exists. What's here is complete at its own layer: codec, negotiation, both reaction surfaces, and the accounting source it carries.

Testing, all host-side on Linux: the usb_auto suite (30 tests) including round-trips with and without the accounting block, truncation rejected at every cut point, a presence flag that contradicts the length rejected, and the three existing property tests now generating arbitrary `VitalsReport`s through the payload and framed-stream codecs. The accounting tests were proven red first: with the increments stripped, the counter tests fail and only the overcount guards pass. `cargo test` and `clippy -D warnings` green on prns-core, prns-runtime-embassy, prns-interfaces-tokio, and prns-interfaces-embassy, plus the workspace check, the fmt/docs gate, and the validation registry; the test-and-clippy pass repeated at 1.96.0 to match the pinned CI toolchain. One small enabling change: `ConnectionState::as_u8`/`from_u8` lose their host-feature gate because the ungated codec now needs them.
