### PR TITLE
fix Heltec V4-R8 first-render I2C panic from private PSRAM clobber

### DIFF
--- a/personal-hopspot/embedded/esp32/src/s3/firmware.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/firmware.rs
@@ -4,7 +4,11 @@ pub(crate) async fn run<B: Esp32S3Board>(spawner: Spawner) {
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     let p = esp_hal::init(config);
     let bringup = B::bringup(p).await;
-    allocator_api2::boxed::Box::pin_in(run_core::<B>(spawner, bringup), crate::storage::PsramAlloc)
+    // Pin into esp_alloc's global external heap, not `PsramAlloc`. On Heltec V4-R8, `PsramAlloc` is
+    // the private bump that `reinit_private_psram_heap` resets inside `run_core` before the LoRa
+    // queue lands — pinning here would place the live future (OLED/I2C state) in that window and
+    // get overwritten, which zeroed I2C Config.frequency after radio bring-up.
+    allocator_api2::boxed::Box::pin_in(run_core::<B>(spawner, bringup), esp_alloc::ExternalMemory)
         .await;
 }
 


### PR DESCRIPTION
## Summary
- Heltec V4-R8 panicked on the first post-radio UI flush with an I2C divide-by-zero in `esp-hal` (`Config.frequency` became 0).
- Root cause: `run_core` was pinned into the R8 private PSRAM bump (`PsramAlloc`), then `reinit_private_psram_heap()` reset that bump before allocating the LoRa TX queue — overwriting the live future (including OLED/I2C state). Heltec V4 (R2) was unaffected because `PsramAlloc` there is global `ExternalMemory` and reinit is a no-op.
- Fix: pin `run_core` into `esp_alloc::ExternalMemory` instead of `PsramAlloc`.

## Test plan
- [x] Smoke Heltec V4-R8 with this build: `first-render.complete`, no panic (MAC `ac:a7:04:e1:4b:3c`)
- [x] Confirm unfixed trunk still boots cleanly on Heltec V4 R2 (`first-render.complete`)
- [ ] Optional: re-smoke R2 with this branch for shared-path confidence