### PR TITLE
metrics: count the twenty-seventh ignore reason instead of panicking on it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,15 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libsdl2-dev
       - name: clippy and test — prns-core external-alloc
         run: bash validation/native/external-alloc.sh
+      # prns-core's own suite under runtime-metrics. Nothing else on this lane executes it with the
+      # counters compiled: the root test job builds prns-core without the feature, and the prnsd
+      # step below runs inside prnsd's own workspace, which does not have prns-core as a member, so
+      # feature unification compiles the counters there without ever running prns-core's tests
+      # against them. The scheduled mutation audit does use this feature set, but monthly and on a
+      # branch that trails this one. Without this step a counter array missing a variant stays green
+      # here and fails somewhere slower.
+      - name: test — prns-core runtime-metrics
+        run: cargo test -p prns-core --features std,runtime-metrics --locked
       # The tokio interface crate: every host interface family above the engine's tokio-host bind,
       # linted/tested/doc'd as the standalone workspace consumers actually build. --all-features is
       # honest here — the per-OS BLE backends live in target tables, so Linux gets BlueR and never

--- a/prns-core/src/engine/metrics.rs
+++ b/prns-core/src/engine/metrics.rs
@@ -249,7 +249,7 @@ pub enum IgnoreReasonKind {
 }
 
 impl IgnoreReasonKind {
-    pub const ALL: [Self; 26] = [
+    pub const ALL: [Self; 27] = [
         Self::Consumed,
         Self::Malformed,
         Self::UnhandledContext,
@@ -276,6 +276,7 @@ impl IgnoreReasonKind {
         Self::StrategyDeclined,
         Self::UnmatchedResponse,
         Self::IfacRefused,
+        Self::RequestTooLarge,
     ];
 
     const fn index(self) -> usize {


### PR DESCRIPTION
`IgnoreReasonKind` has 27 variants and `ALL` listed 26, leaving out
`RequestTooLarge`. `IgnoreReasonCounts` sizes its array from `ALL.len()` and
indexes it by the variant's discriminant, so recording that one reason indexes
one past the end:

    index out of bounds: the len is 26 but the index is 26
    prns-core/src/engine/metrics.rs:351

The variant, the `From<IgnoreReason>` arm and the test's reason list all arrived
together in df921237; only the `ALL` entry was missed, which is why the coverage
test already names the reason it cannot count.

It is reachable. `links.rs:717` returns it whenever a decryptable request over an
established link exceeds a destination's registered `maximum_request_bytes`, so a
peer triggers it remotely.

Who that reaches, as far as I can tell:

- `prns-napi` enables `runtime-metrics` unconditionally and publishes to npm, and
  `maximumRequestBytes` is part of its public destination spec. A Node app that
  sets a ceiling and then receives an oversized request panics inside the engine.
- prnsd compiles the counters in the cloud image, but every destination it
  registers takes the default `ByteLimit::Unlimited`, so it never reaches the
  reason at all.

There is a quieter half too: before the fix, `iter()` skipped `RequestTooLarge`
entirely, so it was missing from every snapshot and every OTLP export even when
nothing panicked.

Reproducing it needs no new test. `every_ignore_reason_has_one_stable_counter`
already records every reason, so it panics rather than fails as soon as the
feature is on, and it takes a real engine test with it:

    cargo test -p prns-core --features std,runtime-metrics

    engine::metrics::tests::every_ignore_reason_has_one_stable_counter
    routing::links::request::tests::packet_requests_are_admitted_at_the_destination_limit_and_refused_past_it

Red on 0.3.6, green after, 1440 passing.

The second commit adds a CI step, because the reason this sat is that nothing on
the lane runs prns-core's own tests with the feature compiled. The root test job
builds it without, and the prnsd step runs inside prnsd's workspace, which does
not have prns-core as a member. The scheduled mutation audit does use this exact
feature set, but monthly and against a branch that trails trunk.

Run on x86_64 Linux (rustc 1.96.0) and on aarch64 Linux, a Raspberry Pi running
Debian with rustc 1.97.1. Red then green on both. I have not run macOS or Windows.
