### PR TITLE
Restore the workspace lockfiles that --locked builds need

### DIFF
--- a/prns-config/Cargo.lock
+++ b/prns-config/Cargo.lock
@@ -508,6 +508,7 @@ dependencies = [
  "heapless",
  "hkdf",
  "hmac",
+ "prns-macros",
  "rmp",
  "roaring",
  "serde",
@@ -516,6 +517,10 @@ dependencies = [
  "x25519-dalek",
  "zeroize",
 ]
+
+[[package]]
+name = "prns-macros"
+version = "0.3.6"
 
 [[package]]
 name = "proc-macro2"

--- a/prns-ffi/Cargo.lock
+++ b/prns-ffi/Cargo.lock
@@ -395,6 +395,7 @@ dependencies = [
  "heapless",
  "hkdf",
  "hmac",
+ "prns-macros",
  "roaring",
  "sha2 0.11.0",
  "x25519-dalek",
@@ -417,6 +418,10 @@ dependencies = [
  "tokio",
  "windows",
 ]
+
+[[package]]
+name = "prns-macros"
+version = "0.3.6"
 
 [[package]]
 name = "proc-macro2"

--- a/prns-host/impls/cooperative/Cargo.lock
+++ b/prns-host/impls/cooperative/Cargo.lock
@@ -282,6 +282,7 @@ dependencies = [
  "heapless",
  "hkdf",
  "hmac",
+ "prns-macros",
  "sha2 0.11.0",
  "x25519-dalek",
  "zeroize",
@@ -302,12 +303,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prns-macros"
+version = "0.3.6"
+
+[[package]]
 name = "prns-runtime"
 version = "0.3.6"
 dependencies = [
  "cfg-if",
  "heapless",
  "prns-core",
+ "prns-macros",
 ]
 
 [[package]]

--- a/prns-host/impls/tokio/Cargo.lock
+++ b/prns-host/impls/tokio/Cargo.lock
@@ -288,6 +288,7 @@ dependencies = [
  "heapless",
  "hkdf",
  "hmac",
+ "prns-macros",
  "sha2 0.11.0",
  "x25519-dalek",
  "zeroize",
@@ -309,12 +310,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prns-macros"
+version = "0.3.6"
+
+[[package]]
 name = "prns-runtime"
 version = "0.3.6"
 dependencies = [
  "cfg-if",
  "heapless",
  "prns-core",
+ "prns-macros",
 ]
 
 [[package]]

--- a/prns-interfaces/impls/embassy/Cargo.lock
+++ b/prns-interfaces/impls/embassy/Cargo.lock
@@ -786,6 +786,7 @@ dependencies = [
  "heapless 0.8.0",
  "hkdf",
  "hmac",
+ "prns-macros",
  "roaring",
  "sha2 0.11.0",
  "x25519-dalek",
@@ -820,12 +821,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prns-macros"
+version = "0.3.6"
+
+[[package]]
 name = "prns-runtime"
 version = "0.3.6"
 dependencies = [
  "cfg-if",
  "heapless 0.8.0",
  "prns-core",
+ "prns-macros",
 ]
 
 [[package]]

--- a/prns-interfaces/impls/tokio/Cargo.lock
+++ b/prns-interfaces/impls/tokio/Cargo.lock
@@ -2036,6 +2036,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "md-5",
+ "prns-macros",
  "rmp",
  "roaring",
  "sha2 0.11.0",
@@ -2098,6 +2099,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "prns-macros"
+version = "0.3.6"
+
+[[package]]
 name = "prns-runtime"
 version = "0.3.6"
 dependencies = [
@@ -2105,6 +2110,7 @@ dependencies = [
  "cfg-if",
  "heapless",
  "prns-core",
+ "prns-macros",
 ]
 
 [[package]]

--- a/prns-napi/Cargo.lock
+++ b/prns-napi/Cargo.lock
@@ -1990,6 +1990,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "md-5",
+ "prns-macros",
  "rayon",
  "rmp",
  "roaring",
@@ -2078,6 +2079,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "prns-macros"
+version = "0.3.6"
+
+[[package]]
 name = "prns-napi"
 version = "0.3.6"
 dependencies = [
@@ -2099,6 +2104,7 @@ dependencies = [
  "cfg-if",
  "heapless 0.8.0",
  "prns-core",
+ "prns-macros",
 ]
 
 [[package]]

--- a/prns-runtime/impls/embassy/Cargo.lock
+++ b/prns-runtime/impls/embassy/Cargo.lock
@@ -506,6 +506,7 @@ dependencies = [
  "heapless 0.8.0",
  "hkdf",
  "hmac",
+ "prns-macros",
  "rmp",
  "roaring",
  "sha2 0.11.0",
@@ -514,12 +515,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prns-macros"
+version = "0.3.6"
+
+[[package]]
 name = "prns-runtime"
 version = "0.3.6"
 dependencies = [
  "cfg-if",
  "heapless 0.8.0",
  "prns-core",
+ "prns-macros",
 ]
 
 [[package]]

--- a/prns-runtime/impls/tokio/Cargo.lock
+++ b/prns-runtime/impls/tokio/Cargo.lock
@@ -487,6 +487,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "md-5",
+ "prns-macros",
  "rayon",
  "rmp",
  "roaring",
@@ -498,6 +499,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "prns-macros"
+version = "0.3.6"
+
+[[package]]
 name = "prns-runtime"
 version = "0.3.6"
 dependencies = [
@@ -505,6 +510,7 @@ dependencies = [
  "cfg-if",
  "heapless",
  "prns-core",
+ "prns-macros",
 ]
 
 [[package]]

--- a/validation/fuzz/Cargo.lock
+++ b/validation/fuzz/Cargo.lock
@@ -438,6 +438,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "md-5",
+ "prns-macros",
  "rmp",
  "roaring",
  "sha2 0.11.0",
@@ -446,12 +447,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prns-macros"
+version = "0.3.6"
+
+[[package]]
 name = "prns-runtime"
 version = "0.3.6"
 dependencies = [
  "cfg-if",
  "heapless",
  "prns-core",
+ "prns-macros",
 ]
 
 [[package]]

--- a/validation/integration/Cargo.lock
+++ b/validation/integration/Cargo.lock
@@ -1767,6 +1767,7 @@ dependencies = [
  "embedded-storage-async",
  "heapless 0.8.0",
  "personal-rns",
+ "prns-macros",
  "sha2 0.11.0",
 ]
 
@@ -1900,6 +1901,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "md-5",
+ "prns-macros",
  "rmp",
  "roaring",
  "sha2 0.11.0",
@@ -1976,6 +1978,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "prns-macros"
+version = "0.3.6"
+
+[[package]]
 name = "prns-runtime"
 version = "0.3.6"
 dependencies = [
@@ -1983,6 +1989,7 @@ dependencies = [
  "cfg-if",
  "heapless 0.8.0",
  "prns-core",
+ "prns-macros",
 ]
 
 [[package]]

--- a/validation/oracles/Cargo.lock
+++ b/validation/oracles/Cargo.lock
@@ -383,12 +383,17 @@ dependencies = [
  "heapless",
  "hkdf",
  "hmac",
+ "prns-macros",
  "rmp",
  "roaring",
  "sha2 0.11.0",
  "x25519-dalek",
  "zeroize",
 ]
+
+[[package]]
+name = "prns-macros"
+version = "0.3.6"
 
 [[package]]
 name = "prns-validation-oracles"


### PR DESCRIPTION
Twelve workspace lockfiles are out of date on trunk, and anything that builds them with `--locked` has been failing since 2026-08-12.

`02cbcba2` introduced the `prns-macros` crate and regenerated three lockfiles: the root, `benchmarks` and `docs/website`. Twelve other workspaces depend on it transitively and were not regenerated, so cargo wants to add it and `--locked` refuses:

```
error: cannot update the lock file .../Cargo.lock because --locked was passed to prevent this
##[error]Process completed with exit code 101
```

Two jobs are failing that way on trunk right now, same error on different files:

```
feature-configs   cargo clippy --all-features --all-targets --locked
                  prns-interfaces/impls/tokio/Cargo.lock
napi-clippy       cargo clippy --locked -- -D warnings
                  prns-napi/Cargo.lock
```

It shows up on pull requests too, which is what led me here: I noticed `napi-clippy` failing on one of mine and passing on another, went looking for what I had done differently, and found it was neither.

I swept every lockfile in the repo rather than fixing the two I had tripped over. Twelve of the twenty-seven fail, fifteen are clean:

`prns-config`, `prns-ffi`, `prns-host/impls/cooperative`, `prns-host/impls/tokio`, `prns-interfaces/impls/embassy`, `prns-interfaces/impls/tokio`, `prns-napi`, `prns-runtime/impls/embassy`, `prns-runtime/impls/tokio`, `validation/fuzz`, `validation/integration`, `validation/oracles`.

Each one is regenerated with a plain resolution, not an update, so nothing is repinned. The diff is **70 inserted lines and no deletions at all** across the twelve files, which is the part worth checking: a version move would show up as a deletion, and there are none. Every hunk is the `prns-macros` package entry and the reference to it.

Afterwards all twenty-seven lockfiles resolve under `--locked`, and `napi-clippy`'s exact command exits 0 where it exits 101 on trunk.

Also ran `validation/hygiene/fmt-docs.sh`, `validation/run.py verify` and `tools/prns verify`. All green.

One thing I could not check here: `--all-features` on `prns-interfaces/impls/tokio` needs `libdbus-1-dev`, which I don't have on this host, so I verified that workspace resolves under `--locked` rather than running the full `feature-configs` step. The `napi-clippy` step I ran end to end.


One thing worth flagging about CI here, because it looks worse than it is. `deny` fails on this branch, but it fails *differently* than it does without the change. On trunk and on my other open PR it exits 1 without ever getting past the lockfile. With the lockfiles fixed it gets through and reports something real:

```
error[unlicensed]: nrf-softdevice-s140-v7 = 0.1.2-prns.1 is unlicensed
```

That crate lives in `personal-hopspot/embedded/nrf52840/Cargo.lock`, which is one of the fifteen lockfiles this PR does not touch, and `deny` was already failing on trunk beforehand. So the licensing item is pre-existing and was hidden behind the lock failure, not caused by lifting it. I have left it alone rather than guess at how you would want it classified.

Measured against trunk's full check set: trunk fails 16 jobs, this branch fails 3, and all three of those also fail on trunk. `napi-clippy`, `android-service`, `msrv`, `no-std-embedded`, `windows-desktop` and `Release workflow contracts` go green here.
