### PR TITLE
host: keep -D warnings green where every control variant compiles out

### DIFF
--- a/prns-host/abi/c/src/supplied_pipe.rs
+++ b/prns-host/abi/c/src/supplied_pipe.rs
@@ -1,14 +1,19 @@
 use std::ffi::c_void;
 use std::ptr;
 use std::sync::{Arc, Mutex};
+// `Duration` and `issued_command` are only reached from the unix arms below; the non-unix arms
+// return `Unsupported` before either would be used.
+#[cfg_attr(not(unix), allow(unused_imports))]
 use std::time::Duration;
 
 #[cfg(unix)]
 use std::os::fd::{FromRawFd, OwnedFd, RawFd};
 
+#[cfg_attr(not(unix), allow(unused_imports))]
+use crate::issued_command;
 use crate::readiness::{Readiness, ReadinessCallback, RegisteredReadiness};
 use crate::{
-    catch_status, issued_command, lock, required_mut, required_ref, status, PrnsIssuedCommand,
+    catch_status, lock, required_mut, required_ref, status, PrnsIssuedCommand,
     PrnsReadinessRegistration, PrnsStringView,
 };
 use prns_host_core::{Status as AbiStatus, SAFE_UINT_MAX};
@@ -16,6 +21,9 @@ use prns_host_core::{Status as AbiStatus, SAFE_UINT_MAX};
 pub struct PrnsSuppliedPipe {
     #[cfg(unix)]
     native: prns_host_native::NativeSuppliedPipe,
+    // Only the unix attach path constructs this struct and only unix code reads the field; it
+    // stays unconditional so the struct's shape does not vary by platform.
+    #[cfg_attr(not(unix), allow(dead_code))]
     attachment_readiness: Arc<Readiness>,
     request_readiness: Arc<Readiness>,
     readiness_registration: Mutex<Option<Arc<RegisteredReadiness>>>,
@@ -111,6 +119,8 @@ pub unsafe extern "C" fn prns_host_attach_supplied_pipe(
     })
 }
 
+// Called only from the unix attach path; on other targets that path compiles out.
+#[cfg_attr(not(unix), allow(dead_code))]
 fn weak_signal(readiness: &Arc<Readiness>) -> prns_host_native::ReadinessSignal {
     let readiness = Arc::downgrade(readiness);
     Arc::new(move || {
@@ -231,6 +241,9 @@ pub unsafe extern "C" fn prns_supplied_pipe_register_readiness(
     })
 }
 
+// On non-unix targets the body compiles out and the rebound `supplied_pipe` only looks unused
+// because no code is left to read it.
+#[cfg_attr(not(unix), allow(unused_variables))]
 #[no_mangle]
 pub unsafe extern "C" fn prns_supplied_pipe_interrupt_wait(supplied_pipe: *mut PrnsSuppliedPipe) {
     if let Ok(Some(supplied_pipe)) =

--- a/prns-host/impls/native/src/lib.rs
+++ b/prns-host/impls/native/src/lib.rs
@@ -269,6 +269,10 @@ impl Drop for CommandJob {
 
 pub struct NativeHost {
     commands: mpsc::Sender<CommandJob>,
+    // Every current `NativeControl` variant is unix-only, so on other targets the enum is
+    // uninhabited and this sender can never be used. The channel stays platform-neutral so a
+    // future non-unix control needs no re-plumbing.
+    #[cfg_attr(not(unix), allow(dead_code))]
     controls: mpsc::UnboundedSender<NativeControl>,
     uploads: mpsc::Sender<UploadJob>,
     snapshots: mpsc::Sender<SnapshotJob>,
@@ -2110,6 +2114,10 @@ async fn attach_typed_interface(
     })
 }
 
+// On targets where every `NativeControl` variant is compiled out the enum is uninhabited: the
+// match below is legal with no arms, and the parameters only look unused because no arm is left
+// to read them.
+#[cfg_attr(not(unix), allow(unused_variables))]
 async fn execute_control(
     handle: &PrnsNodeHandle,
     attachments: &mut BTreeMap<InterfaceId, Attachment>,


### PR DESCRIPTION
Both Windows native lanes are red on trunk right now, and the break is one the Ubuntu lanes can't see. `NativeControl`'s only variant is `#[cfg(unix)]`, so on Windows the enum is uninhabited: `execute_control`'s parameters go unused and the host's `controls` sender is never read, and `-D warnings` promotes all three to errors.

Neither is a defect. The empty match is the totality proof over an uninhabited enum, and the control channel's plumbing is platform-neutral on purpose, so a future non-unix control slots in without re-plumbing. The fix scopes two allows to `not(unix)` with comments saying exactly that, rather than underscoring parameters the unix arm really does read.

Ran on Windows 11, `x86_64-pc-windows-msvc`, in `prns-host/impls/native`:

- reproduced the three CI errors on unmodified trunk first (`RUSTFLAGS=-D warnings cargo check`)
- after the fix: check and `clippy -- -D warnings` both green
- `RUSTFLAGS='-D warnings' cargo check` stays green on Linux (WSL), where the annotations are inert
- `bash validation/hygiene/fmt-docs.sh` - `FMT_DOC_CHECK_GATE_OK`
