### PR TITLE
Recover macOS Bluetooth Auto after hopspot reboot

### DIFF
--- a/prns-ffi/src/bluetooth_auto/macos/backend.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/backend.rs
@@ -34,6 +34,7 @@ use super::{
 
 const POWER_ON_TIMEOUT: Duration = Duration::from_secs(10);
 const DIAL_TIMEOUT: Duration = Duration::from_secs(15);
+const RADIO_REFRESH_INTERVAL: Duration = Duration::from_secs(20);
 
 #[derive(Default)]
 pub(super) struct StartupReadiness {
@@ -81,6 +82,29 @@ fn cancel_connection(central: &SendCentralManager, peripheral: &SendPeripheral) 
     // SAFETY: both retained objects remain alive through this call and are messaged only on the
     // CoreBluetooth serial dispatch queue.
     unsafe { central.0.cancelPeripheralConnection(&peripheral.0) };
+}
+
+fn apply_scanning(central: SendCentralManager, enabled: bool, restart: bool) {
+    // SAFETY: this authoritative CoreBluetooth state query runs on the retained manager's
+    // serial dispatch queue.
+    let is_scanning = unsafe { central.0.isScanning() };
+    if enabled {
+        if is_scanning && restart {
+            // SAFETY: the retained central manager is only messaged on its serial dispatch queue.
+            unsafe { central.0.stopScan() };
+            start_scan(&central.0);
+            crate::diagnostic_log::debug!(
+                "bluetooth: restarted Prns scan so late-arriving peers can be sighted"
+            );
+        } else if !is_scanning {
+            start_scan(&central.0);
+            crate::diagnostic_log::debug!("bluetooth: scanning for Prns peers");
+        }
+    } else if is_scanning {
+        // SAFETY: the retained central manager is only messaged on its serial dispatch queue.
+        unsafe { central.0.stopScan() };
+        crate::diagnostic_log::debug!("bluetooth: scanning stopped — at connection capacity");
+    }
 }
 
 fn begin_dial(command: DialCommand) {
@@ -143,6 +167,9 @@ pub struct MacosBleBackend {
     restored: RestoredPeripherals,
     dials: JoinSet<DialTaskOutcome>,
     queue: DispatchRetained<DispatchQueue>,
+    scan_enabled: bool,
+    advertise_enabled: bool,
+    radio_refresh_at: tokio::time::Instant,
 }
 
 struct NativeThread {
@@ -349,6 +376,9 @@ impl PreparedMacosBleBackend {
             restored: self.restored,
             dials: JoinSet::new(),
             queue,
+            scan_enabled: false,
+            advertise_enabled: false,
+            radio_refresh_at: tokio::time::Instant::now() + RADIO_REFRESH_INTERVAL,
         })
     }
 }
@@ -358,29 +388,17 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
     type Link = GattLink;
 
     async fn set_advertising(&mut self, mode: AdvertisingMode) -> Result<(), MacosBleError> {
+        self.advertise_enabled = mode.is_on();
         self.peripheral_delegate.0.set_advertising(mode);
         Ok(())
     }
 
     async fn set_scanning(&mut self, mode: ScanningMode) -> Result<(), MacosBleError> {
-        let enabled = mode.is_on();
+        self.scan_enabled = mode.is_on();
+        let restart = cfg!(target_os = "macos") && self.scan_enabled;
         let central = SendCentralManager(self.central.0.clone());
         self.queue.exec_async(move || {
-            let central = central;
-            // SAFETY: this authoritative CoreBluetooth state query runs on the retained manager's
-            // serial dispatch queue.
-            let is_scanning = unsafe { central.0.isScanning() };
-            if enabled && !is_scanning {
-                start_scan(&central.0);
-                crate::diagnostic_log::debug!("bluetooth: scanning for Prns peers");
-            } else if !enabled && is_scanning {
-                // SAFETY: the retained central manager is only messaged on its serial dispatch
-                // queue.
-                unsafe { central.0.stopScan() };
-                crate::diagnostic_log::debug!(
-                    "bluetooth: scanning stopped — at connection capacity"
-                );
-            }
+            apply_scanning(central, mode.is_on(), restart);
         });
         Ok(())
     }
@@ -399,6 +417,8 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
                 };
             }
             let pending_dials = !self.dials.is_empty();
+            let refresh_radio =
+                cfg!(target_os = "macos") && (self.scan_enabled || self.advertise_enabled);
             tokio::select! {
                 event = self.events.recv() => match event {
                     Some(Event::Sighting { address, rssi }) => {
@@ -426,6 +446,22 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
                         }
                         Err(_) => continue,
                     }
+                }
+                _ = tokio::time::sleep_until(self.radio_refresh_at), if refresh_radio => {
+                    if self.scan_enabled {
+                        let central = SendCentralManager(self.central.0.clone());
+                        self.queue.exec_async(move || {
+                            apply_scanning(central, true, true);
+                        });
+                    }
+                    if self.advertise_enabled {
+                        self.peripheral_delegate
+                            .0
+                            .set_advertising(AdvertisingMode::On);
+                    }
+                    self.radio_refresh_at =
+                        tokio::time::Instant::now() + RADIO_REFRESH_INTERVAL;
+                    continue;
                 }
             }
         }

--- a/prns-ffi/src/bluetooth_auto/macos/central.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/central.rs
@@ -27,6 +27,36 @@ use super::{
     PeripheralTable, RestoredPeripherals, SendCharacteristicRef, SendPeripheral,
 };
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum DiscoverDisposition {
+    Adopt,
+    Ignore,
+    CancelStale,
+}
+
+/// Decide what a CoreBluetooth advertisement means when the OS still has a link.
+///
+/// MeshTower (and other hopspots) stop advertising while connected, so an advertisement from a
+/// peripheral that CoreBluetooth still reports as connected *and that we no longer have a session
+/// for* is a reboot: the radio came back up before the Mac dropped the zombie GATT link. Cancelling
+/// that link lets the next advertisement be adopted instead of waiting for the supervision timeout
+/// or a daemon restart.
+///
+/// Duplicate ads while we still own the session are normal (`allowDuplicates`) and must be ignored,
+/// or a healthy connection is torn down a second after handshake.
+pub(super) const fn discover_disposition(
+    disconnected: bool,
+    has_session: bool,
+) -> DiscoverDisposition {
+    if disconnected {
+        DiscoverDisposition::Adopt
+    } else if has_session {
+        DiscoverDisposition::Ignore
+    } else {
+        DiscoverDisposition::CancelStale
+    }
+}
+
 pub(super) fn is_system_connected(
     central: &CBCentralManager,
     peer_id: CoreBluetoothPeerId,
@@ -326,15 +356,31 @@ define_class!(
         #[unsafe(method(centralManager:didDiscoverPeripheral:advertisementData:RSSI:))]
         fn did_discover(
             &self,
-            _central: &CBCentralManager,
+            central: &CBCentralManager,
             peripheral: &CBPeripheral,
             _advertisement_data: &NSDictionary<NSString, AnyObject>,
             rssi: &NSNumber,
         ) {
+            let peer_id = core_bluetooth_peer_id(peripheral);
             // SAFETY: CoreBluetooth supplied this live peripheral to its delegate on the manager
             // queue, so querying immutable framework state is valid.
-            if unsafe { peripheral.state() } != CBPeripheralState::Disconnected {
-                return;
+            let state = unsafe { peripheral.state() };
+            match discover_disposition(
+                state == CBPeripheralState::Disconnected,
+                self.ivars().sessions.borrow().contains_key(&peer_id),
+            ) {
+                DiscoverDisposition::Ignore => return,
+                DiscoverDisposition::CancelStale => {
+                    crate::diagnostic_log::debug!(
+                        "bluetooth: {:02x?} is advertising while CoreBluetooth still holds a link — cancelling the stale connection",
+                        peer_id.address().octets()
+                    );
+                    // SAFETY: `central` and `peripheral` are the live objects for this callback,
+                    // delivered on the manager's serial queue.
+                    unsafe { central.cancelPeripheralConnection(peripheral) };
+                    return;
+                }
+                DiscoverDisposition::Adopt => {}
             }
             let dbm = rssi.integerValue();
             let rssi = if dbm == 127 {
@@ -342,7 +388,6 @@ define_class!(
             } else {
                 i8::try_from(dbm).ok()
             };
-            let peer_id = core_bluetooth_peer_id(peripheral);
             let address = peer_id.address();
             if let Ok(mut map) = self.ivars().peripherals.lock() {
                 map.insert(peer_id, (SendPeripheral(peripheral.retain()), rssi));

--- a/prns-ffi/src/bluetooth_auto/macos/peripheral.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/peripheral.rs
@@ -675,14 +675,21 @@ impl PeripheralDelegate {
             // SAFETY: this authoritative CoreBluetooth state query runs on the retained manager's
             // serial dispatch queue.
             let is_advertising = unsafe { manager.isAdvertising() };
-            if mode.is_on() && !is_advertising {
-                let uuid = service_uuid();
-                let services = NSArray::from_slice(&[&*uuid]);
-                let data = advertisement_data(&services);
-                // SAFETY: the retained manager is messaged on its serial dispatch queue and the
-                // advertisement dictionary remains live for the synchronous call.
-                unsafe { manager.startAdvertising(Some(&data)) };
-            } else if !mode.is_on() && is_advertising {
+            if mode.is_on() {
+                let restart = cfg!(target_os = "macos") && is_advertising;
+                if restart {
+                    // SAFETY: the retained manager is messaged only on its serial dispatch queue.
+                    unsafe { manager.stopAdvertising() };
+                }
+                if restart || !is_advertising {
+                    let uuid = service_uuid();
+                    let services = NSArray::from_slice(&[&*uuid]);
+                    let data = advertisement_data(&services);
+                    // SAFETY: the retained manager is messaged on its serial dispatch queue and the
+                    // advertisement dictionary remains live for the synchronous call.
+                    unsafe { manager.startAdvertising(Some(&data)) };
+                }
+            } else if is_advertising {
                 // SAFETY: the retained manager is messaged only on its serial dispatch queue.
                 unsafe { manager.stopAdvertising() };
                 crate::diagnostic_log::debug!(

--- a/prns-ffi/src/bluetooth_auto/macos/tests.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/tests.rs
@@ -5,7 +5,7 @@ use prns_core::interfaces::bluetooth_auto::{
 use tokio::sync::{mpsc, oneshot};
 
 use super::backend::{dial_admission, DialAdmission, StartupReadiness};
-use super::central::CentralPeerSession;
+use super::central::{discover_disposition, CentralPeerSession, DiscoverDisposition};
 use super::gatt_link::{
     gatt_inbound_channel, gatt_inbound_channel_with_budget, GattInboundSendError,
 };
@@ -30,6 +30,31 @@ fn startup_requires_central_gatt_and_l2cap_readiness() {
 fn dial_yields_only_when_peer_is_already_system_connected() {
     assert_eq!(dial_admission(true), DialAdmission::YieldToSystemConnection);
     assert_eq!(dial_admission(false), DialAdmission::AttachCentralSession);
+}
+
+#[test]
+fn discovery_adopts_a_disconnected_peripheral() {
+    assert_eq!(
+        discover_disposition(true, false),
+        DiscoverDisposition::Adopt
+    );
+    assert_eq!(discover_disposition(true, true), DiscoverDisposition::Adopt);
+}
+
+#[test]
+fn discovery_ignores_duplicate_ads_once_we_own_the_link() {
+    assert_eq!(
+        discover_disposition(false, true),
+        DiscoverDisposition::Ignore
+    );
+}
+
+#[test]
+fn discovery_cancels_a_zombie_link_when_the_peer_advertises_again() {
+    assert_eq!(
+        discover_disposition(false, false),
+        DiscoverDisposition::CancelStale
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- After a hopspot reboot, CoreBluetooth can still report the old GATT link as connected and ignore new advertisements until the OS supervision timeout (or a daemon restart).
- Cancel that zombie link when the peer advertises again and we no longer own a session. Duplicate ads on a healthy session still leave the link alone.
- Periodically stop/start a long-lived macOS scan and advertising so CoreBluetooth keeps delivering new nRF advertisements.

## Test plan
- [ ] Connect Mac `prnsd` to a hopspot over Bluetooth Auto
- [ ] Reboot the hopspot without restarting `prnsd`; it should reappear and reconnect without waiting ~12 minutes
- [ ] Confirm a healthy connected session is not torn down by `allowDuplicates` advertisements
- [ ] Leave `prnsd` running for several minutes and confirm newly powered hopspots are still sighted


Made with [Cursor](https://cursor.com)