### PR TITLE
Keep the limits rows inside the panel

### DIFF
--- a/personal-hopspot/core/src/screen/render/layout.rs
+++ b/personal-hopspot/core/src/screen/render/layout.rs
@@ -53,6 +53,8 @@ pub(super) const MENU_TEXT_X: i32 = 12;
 pub(in crate::screen) const MENU_REASON_X: i32 = 2;
 pub(super) const MENU_DETAIL_STEP: i32 = 7;
 pub(in crate::screen) const FONT_5X8_CHAR_W: i32 = 5;
+
+pub(in crate::screen) const LIMITS_TEXT_X: i32 = 2;
 pub(in crate::screen) const FONT_4X6_CHAR_W: i32 = 4;
 pub(super) const GLOBAL_MENU_ITEM_STEP: i32 = 11;
 pub(in crate::screen) const SPLASH_TEXT_X: i32 = 2;

--- a/personal-hopspot/core/src/screen/render/menus/mod.rs
+++ b/personal-hopspot/core/src/screen/render/menus/mod.rs
@@ -22,7 +22,7 @@ use crate::screen::state::{
 
 use super::glyphs::{draw_global_icon, draw_interface_icon, draw_menu_cursor};
 use super::layout::*;
-use super::metrics::{fmt_bytes, fmt_rate_bytes_per_sec};
+use super::metrics::{fmt_bytes, fmt_count, fmt_rate_bytes_per_sec};
 use super::primitives::{fill, line};
 
 fn menu_item_backing_width(label: &str) -> u32 {
@@ -247,7 +247,12 @@ fn fmt_limit_value(value: LimitValue) -> HString<12> {
     let mut s = HString::new();
     match value {
         LimitValue::Count(value) => {
-            let _ = write!(s, "{value}");
+            // Every other number on this face is compacted, and this one was
+            // not: 500,000 packet hashes came out as six raw digits, which is
+            // two characters more than a 64 pixel panel can draw. fmt_count
+            // leaves anything under a thousand alone, so no board-sized
+            // capacity changes.
+            let _ = write!(s, "{}", fmt_count(value));
         }
         LimitValue::Bytes(value) => {
             let _ = write!(s, "{}", fmt_bytes(value));
@@ -266,9 +271,18 @@ fn fmt_limit_value(value: LimitValue) -> HString<12> {
     s
 }
 
+/// The exact string a limits row draws. Shared with the test that asserts
+/// every row fits, so the check cannot drift from the drawing.
+pub(in crate::screen) fn limits_row_text(row: LimitRow) -> HString<16> {
+    let mut s = HString::new();
+    let _ = write!(s, "{} {}", row.label, fmt_limit_value(row.value));
+    s
+}
+
 fn draw_limits_text<D: DrawTarget<Color = BinaryColor>>(display: &mut D, y: i32, text: &str) {
     let style = MonoTextStyle::new(&FONT_5X8, BinaryColor::On);
-    let _ = Text::with_baseline(text, Point::new(2, y), style, Baseline::Top).draw(display);
+    let _ =
+        Text::with_baseline(text, Point::new(LIMITS_TEXT_X, y), style, Baseline::Top).draw(display);
 }
 
 pub(super) fn draw_limits_page<D: DrawTarget<Color = BinaryColor>>(
@@ -296,9 +310,7 @@ pub(super) fn draw_limits_page<D: DrawTarget<Color = BinaryColor>>(
 
     let start = page * LIMITS_PER_PAGE;
     for (offset, row) in rows.iter().skip(start).take(LIMITS_PER_PAGE).enumerate() {
-        let value = fmt_limit_value(row.value);
-        let mut line_buf: HString<16> = HString::new();
-        let _ = write!(line_buf, "{} {value}", row.label);
+        let line_buf = limits_row_text(*row);
         draw_limits_text(display, CARD_TOP + 29 + offset as i32 * 11, &line_buf);
     }
 }

--- a/personal-hopspot/core/src/screen/tests/limits.rs
+++ b/personal-hopspot/core/src/screen/tests/limits.rs
@@ -1,5 +1,98 @@
 use super::*;
 
+use crate::screen::render::layout::{FONT_5X8_CHAR_W, LIMITS_TEXT_X, WIDTH};
+use crate::screen::render::menus::limits_row_text;
+
+/// How many FONT_5X8 characters of a limits row the panel can actually draw.
+/// The row buffer is deliberately wider than this so a long row is truncated
+/// rather than lost, but nothing reconciled the two and a six digit capacity
+/// ran off the right edge. Derived from the same three layout constants the
+/// renderer draws with, so this cannot drift away from the screen.
+const LIMITS_ROW_MAX_CHARS: usize = ((WIDTH - LIMITS_TEXT_X) / FONT_5X8_CHAR_W) as usize;
+
+fn assert_every_row_fits(limits: DisplayedStorageLimits) {
+    for row in build_limit_rows(limits) {
+        let text = limits_row_text(row);
+        let drawn = text.chars().count();
+        assert!(
+            drawn <= LIMITS_ROW_MAX_CHARS,
+            "row {:?} renders {drawn} characters as {text:?}, panel draws {LIMITS_ROW_MAX_CHARS}",
+            row.label,
+        );
+    }
+}
+
+/// The bug this pins: on every heap platform `packet_hashes` is the single
+/// Fixed capacity and the largest number anywhere on the face, so the row came
+/// out as `PktHash 500000` - fourteen FONT_5X8 characters against a panel that
+/// draws twelve. The fourth zero was sliced down the middle on a real device,
+/// and nothing here or in the renderer noticed, because the row buffer is
+/// sized in bytes while the panel is sized in pixels.
+///
+/// Swept across every magnitude a `u32` capacity can hold rather than pinned to
+/// the 500,000 that broke, so this cannot quietly stop covering `GrowableHeap`
+/// if that constant moves.
+///
+/// One piece of headroom worth naming out loud: `Receipts` is the longest label
+/// at eight characters, which leaves room for a three character value and no
+/// more. Nothing declares a four figure receipt table today. If something does,
+/// this is the test that will say so.
+#[test]
+fn every_limits_row_fits_the_panel() {
+    assert_every_row_fits(DisplayedStorageLimits::DYNAMIC);
+
+    for hashes in [8usize, 999, 1_000, 500_000, u32::MAX as usize] {
+        assert_every_row_fits(DisplayedStorageLimits {
+            packet_hashes: StorageCapacity::Fixed(hashes),
+            ..DisplayedStorageLimits::DYNAMIC
+        });
+    }
+
+    // Board sized: the embedded layouts declare small fixed capacities, and
+    // those must keep rendering as exact numbers rather than being compacted.
+    assert_every_row_fits(DisplayedStorageLimits {
+        tracked_destinations: StorageCapacity::Fixed(36),
+        announce_records: StorageCapacity::Fixed(36),
+        upstream_app_destinations: StorageCapacity::Fixed(4),
+        held_identities: StorageCapacity::Fixed(2),
+        receipts: StorageCapacity::Fixed(8),
+        packet_hashes: StorageCapacity::Fixed(64),
+        blackholed_identities: StorageCapacity::Fixed(8),
+        ..DisplayedStorageLimits::DYNAMIC
+    });
+}
+
+/// A capacity a board can state exactly is still stated exactly. Compacting
+/// numbers to fit the panel must not cost precision where there is room for it.
+#[test]
+fn small_capacities_are_not_compacted() {
+    let rows = build_limit_rows(DisplayedStorageLimits {
+        packet_hashes: StorageCapacity::Fixed(64),
+        ..DisplayedStorageLimits::DYNAMIC
+    });
+    let row = rows
+        .iter()
+        .find(|row| row.label == "PktHash")
+        .copied()
+        .unwrap();
+    assert_eq!(limits_row_text(row).as_str(), "PktHash 64");
+}
+
+/// And the capacity that overflowed now reads as the face's own count format.
+#[test]
+fn the_heap_packet_hash_capacity_fits_as_a_compact_count() {
+    let rows = build_limit_rows(DisplayedStorageLimits {
+        packet_hashes: StorageCapacity::Fixed(500_000),
+        ..DisplayedStorageLimits::DYNAMIC
+    });
+    let row = rows
+        .iter()
+        .find(|row| row.label == "PktHash")
+        .copied()
+        .unwrap();
+    assert_eq!(limits_row_text(row).as_str(), "PktHash 500K");
+}
+
 #[test]
 fn limit_rows_use_the_supplied_storage_limits() {
     let rows = build_limit_rows(DisplayedStorageLimits {


### PR DESCRIPTION
The Limits screen writes counts as raw digits while every other number on the face goes through
`fmt_count`, and nothing checks that a row fits. On `GrowableHeap`, `packet_hashes` is the one
`Fixed` capacity and the largest number anywhere in the UI, so the row renders as `PktHash 500000`.

That is fourteen FONT_5X8 characters, drawn from `x = 2` on a 64 pixel panel, which draws twelve:

    P k t H a s h _ 5 0 0 0 | 0 0
    1 2 3 4 5 6 7 8 9 . . 12| 13 14

The thirteenth character is the fourth zero, and that is exactly where it is sliced. I set the
Android build up on a cheap video projector running Android 11 on 1 GB of RAM, pointed it at a
wall, and read the screen.

The root cause is that the row is assembled into an `HString<16>`, four characters wider than the
panel can draw, and nothing reconciles the two.

**The boards never showed it.** Their layouts declare capacities like 36, 64 and 1, and `fmt_count`
leaves anything under a thousand alone, so no embedded reading changes here at all. Seeing this needs
the Limits screen on a heap platform: desktop, Android or iOS.

Two things move:

- `LimitValue::Count` renders through `fmt_count`, so the row becomes `PktHash 500K` at twelve
  characters and fits exactly.
- The row string now comes from one shared `limits_row_text`, so the test asserts the same bytes the
  screen draws rather than its own idea of them.

The guard sweeps `packet_hashes` across every magnitude a `u32` can hold rather than pinning the
500,000 that broke, so it cannot quietly stop covering `GrowableHeap` if that constant moves. It
also covers an all-dynamic layout and a board-sized one, and a second test pins that a small
capacity is still rendered exactly, because compacting to fit must not cost precision where there
is room for it.

Proven red before it was trusted green. Reverting the one `fmt_count` call fails it with:

    row "PktHash" renders 14 characters as "PktHash 500000", panel draws 12

Remaining headroom, named rather than left to be rediscovered: `Receipts` is the longest label at
eight characters, so it fits a three character value and no more. Nothing declares a four figure
receipt table today. If something does, this is the test that will say so.

Run: 139 tests in `personal-hopspot-core` and `cargo clippy --all-targets -- -D warnings` clean, both
on Ubuntu under WSL, which is what CI runs; `VALIDATION_REGISTRY_OK`, `TOOLING_REGISTRY_OK` and
`FMT_DOC_CHECK_GATE_OK` from `validation/hygiene/fmt-docs.sh` on Windows; and the `heltec-v4-r8`
firmware builds, also on Windows, since this code compiles into it.
