### PR TITLE
Let Android Hopspot export a live RNS join config

### DIFF
--- a/personal-hopspot/core/Cargo.toml
+++ b/personal-hopspot/core/Cargo.toml
@@ -14,6 +14,7 @@ build = "build.rs"
 default = []
 host = ["personal-rns/tokio-host"]
 source-archive = ["personal-rns/large-static-responses"]
+android-rns-config = []
 
 [dependencies]
 personal-rns = { path = "../../personal-rns", default-features = false, features = ["flash"] }

--- a/personal-hopspot/core/src/mobile.rs
+++ b/personal-hopspot/core/src/mobile.rs
@@ -46,6 +46,7 @@ impl InvalidMobileInputCode {
 pub enum MobileActionCode {
     None = 0,
     Announce = 1,
+    CopySidebandJoinConfig = 2,
 }
 
 impl MobileActionCode {
@@ -53,6 +54,7 @@ impl MobileActionCode {
     pub const fn encode(action: UiAction) -> Self {
         match action {
             UiAction::Announce => Self::Announce,
+            UiAction::CopySidebandJoinConfig => Self::CopySidebandJoinConfig,
             UiAction::None
             | UiAction::OledOff
             | UiAction::ToggleOledAutoOff
@@ -226,6 +228,10 @@ mod tests {
         assert_eq!(
             MobileActionCode::encode(UiAction::Announce),
             MobileActionCode::Announce
+        );
+        assert_eq!(
+            MobileActionCode::encode(UiAction::CopySidebandJoinConfig),
+            MobileActionCode::CopySidebandJoinConfig
         );
         assert_eq!(
             MobileActionCode::encode(UiAction::Sleep),

--- a/personal-hopspot/core/src/screen/render/menus/mod.rs
+++ b/personal-hopspot/core/src/screen/render/menus/mod.rs
@@ -43,6 +43,26 @@ pub(in crate::screen) const fn station_uplink_action_label(kind: CardKind) -> Op
     }
 }
 
+pub(in crate::screen) fn interface_menu_item_label(card: &Card, index: usize) -> &'static str {
+    let items = interface_menu_items(card.kind);
+    let item = items.get(index).copied().unwrap_or(items[items.len() - 1]);
+    if index == POWER_MENU_ITEM {
+        if card.connection == ConnectionState::Disabled {
+            "Turn On"
+        } else {
+            "Turn Off"
+        }
+    } else if matches!(
+        card.kind,
+        CardKind::WifiStation | CardKind::WifiStationDisabled
+    ) && index == STATION_UPLINK_MENU_ITEM
+    {
+        station_uplink_action_label(card.kind).unwrap_or(item)
+    } else {
+        item
+    }
+}
+
 pub(in crate::screen) fn menu_item_char_width(label: &str) -> i32 {
     if MENU_TEXT_X + label.chars().count() as i32 * FONT_5X8_CHAR_W > WIDTH {
         FONT_4X6_CHAR_W
@@ -401,18 +421,8 @@ pub(in crate::screen) fn draw_interface_menu<D: DrawTarget<Color = BinaryColor>>
     );
 
     let items = interface_menu_items(card.kind);
-    for (index, item) in items.iter().enumerate() {
-        let label = if index == POWER_MENU_ITEM {
-            if card.connection == ConnectionState::Disabled {
-                "Turn On"
-            } else {
-                "Turn Off"
-            }
-        } else if index == STATION_UPLINK_MENU_ITEM {
-            station_uplink_action_label(card.kind).unwrap_or(item)
-        } else {
-            item
-        };
+    for (index, _item) in items.iter().enumerate() {
+        let label = interface_menu_item_label(card, index);
         draw_menu_item(
             display,
             MENU_ITEM_TOP + index as i32 * MENU_ITEM_STEP,

--- a/personal-hopspot/core/src/screen/state/mod.rs
+++ b/personal-hopspot/core/src/screen/state/mod.rs
@@ -33,22 +33,34 @@ const SLEEP_MENU_ITEM_NO_DISPLAY: usize = 2;
 pub(in crate::screen) const RADIO_MENU_ITEM_NO_DISPLAY: usize = 3;
 pub(in crate::screen) const POWER_MENU_ITEM: usize = 0;
 pub(in crate::screen) const POWER_ONLY_MENU_ITEMS: &[&str] = &["Power", "Back"];
+#[cfg(feature = "android-rns-config")]
+pub(in crate::screen) const LOCAL_MENU_ITEMS: &[&str] = &["Power", "RNS Config", "Back"];
+#[cfg(feature = "android-rns-config")]
+pub(in crate::screen) const LOCAL_SHARE_MENU_ITEM: usize = 1;
 pub(in crate::screen) const WIFI_MENU_ITEMS: &[&str] = &["Power", "Station", "Back"];
 pub(in crate::screen) const STATION_UPLINK_MENU_ITEM: usize = 1;
 const LORA_MENU_ITEMS: &[&str] = &["Power", "Tune", "Reset", "Back"];
 pub(in crate::screen) const LORA_TUNE_MENU_ITEM: usize = 1;
 pub(in crate::screen) const LORA_RESET_MENU_ITEM: usize = 2;
 
+#[cfg(feature = "android-rns-config")]
+const fn tcp_interface_menu_items() -> &'static [&'static str] {
+    LOCAL_MENU_ITEMS
+}
+
+#[cfg(not(feature = "android-rns-config"))]
+const fn tcp_interface_menu_items() -> &'static [&'static str] {
+    POWER_ONLY_MENU_ITEMS
+}
+
 pub(in crate::screen) fn interface_menu_items(kind: CardKind) -> &'static [&'static str] {
     match kind {
         CardKind::LoRa => LORA_MENU_ITEMS,
         CardKind::WifiStation | CardKind::WifiStationDisabled => WIFI_MENU_ITEMS,
-        CardKind::Wifi
-        | CardKind::Peer
-        | CardKind::Usb
-        | CardKind::Ble
-        | CardKind::EspNow
-        | CardKind::Tcp => POWER_ONLY_MENU_ITEMS,
+        CardKind::Wifi | CardKind::Peer | CardKind::Usb | CardKind::Ble | CardKind::EspNow => {
+            POWER_ONLY_MENU_ITEMS
+        }
+        CardKind::Tcp => tcp_interface_menu_items(),
     }
 }
 
@@ -75,6 +87,8 @@ pub enum UiAction {
     ResetLoRaProfile,
     SwapRadioMode,
     OpenDocs,
+    /// Copy the Sideband shared-instance template (handled outside the face on mobile).
+    CopySidebandJoinConfig,
 }
 
 prns_macros::iterable_enum! {
@@ -99,6 +113,7 @@ prns_macros::iterable_enum! {
         IdentityUnstable,
         SaveDeferred,
         SaveFailed,
+        Copied,
     }
     #[cfg(test)]
     pub(in crate::screen) const ALL;
@@ -169,6 +184,7 @@ impl UiNotice {
                 NoticeLines::three("Save deferred", "Flash cooldown", "Auto retry")
             }
             Self::SaveFailed => NoticeLines::three("Save failed", "Flash error", "Auto retry"),
+            Self::Copied => NoticeLines::one("Copied"),
         }
     }
 }
@@ -577,6 +593,8 @@ impl UiState {
             ) => {
                 self.mode = UiMode::Cards;
                 match (kind, selected_item) {
+                    #[cfg(feature = "android-rns-config")]
+                    (CardKind::Tcp, LOCAL_SHARE_MENU_ITEM) => UiAction::CopySidebandJoinConfig,
                     (_, POWER_MENU_ITEM) => UiAction::ToggleSelectedInterface,
                     (
                         CardKind::WifiStation | CardKind::WifiStationDisabled,

--- a/personal-hopspot/core/src/screen/tests/mod.rs
+++ b/personal-hopspot/core/src/screen/tests/mod.rs
@@ -29,6 +29,8 @@ use super::render::layout::{
     MENU_REASON_X, NAME_BACKING_X, NAME_BACKING_Y, NAME_ICON_X, NAME_LINE_Y, STAT_ICON_X,
     STAT_TEXT_X, WIDTH,
 };
+#[cfg(feature = "android-rns-config")]
+use super::render::menus::interface_menu_item_label;
 use super::render::menus::lora::{LORA_DOT_X, LORA_EDITOR_TOP};
 use super::render::menus::{
     draw_interface_menu, limits_row_drawable, limits_row_text, menu_item_text_right,

--- a/personal-hopspot/core/src/screen/tests/render/flow.rs
+++ b/personal-hopspot/core/src/screen/tests/render/flow.rs
@@ -334,6 +334,20 @@ fn station_uplink_menu_labels_follow_requested_state() {
     }
 }
 
+#[cfg(feature = "android-rns-config")]
+#[test]
+fn local_interface_menu_labels_sideband_and_power_toggle() {
+    let mut card = test_card("Local");
+    card.kind = CardKind::Tcp;
+    card.connection = ConnectionState::Connected;
+    assert_eq!(interface_menu_item_label(&card, 0), "Turn Off");
+    assert_eq!(interface_menu_item_label(&card, 1), "RNS Config");
+    assert_eq!(interface_menu_item_label(&card, 2), "Back");
+
+    card.connection = ConnectionState::Disabled;
+    assert_eq!(interface_menu_item_label(&card, 0), "Turn On");
+}
+
 #[test]
 fn failed_interface_menu_draws_failure_reason() {
     let mut display = PanelDisplay::new();

--- a/personal-hopspot/desktop/src/desktop/ui.rs
+++ b/personal-hopspot/desktop/src/desktop/ui.rs
@@ -652,6 +652,7 @@ pub(super) fn run_window(handles: WindowHandles) {
         }
         UiAction::SwapRadioMode => {}
         UiAction::OpenDocs => {}
+        UiAction::CopySidebandJoinConfig => {}
     };
 
     let mut ui_state = ui_state();

--- a/personal-hopspot/embedded/esp32/src/s3/firmware.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/firmware.rs
@@ -758,6 +758,7 @@ pub(super) async fn run_core<B: Esp32S3Board>(
                             request_radio_mode(next);
                         }
                         screen::UiAction::OpenDocs => {}
+                        screen::UiAction::CopySidebandJoinConfig => {}
                         screen::UiAction::None => {}
                     }
                 }

--- a/personal-hopspot/embedded/nrf52840/src/runtime/firmware.rs
+++ b/personal-hopspot/embedded/nrf52840/src/runtime/firmware.rs
@@ -567,6 +567,7 @@ pub async fn run(spawner: Spawner) -> ! {
                         hopspot::UiAction::ToggleStationUplink => {}
                         hopspot::UiAction::OledOff => {}
                         hopspot::UiAction::ToggleOledAutoOff => {}
+                        hopspot::UiAction::CopySidebandJoinConfig => {}
                         hopspot::UiAction::None => {}
                     }
                 }

--- a/personal-hopspot/mobile/android/.gitignore
+++ b/personal-hopspot/mobile/android/.gitignore
@@ -8,3 +8,6 @@ local.properties
 app/src/main/jniLibs/
 
 rust/target/
+
+# Debug-signed Sideband rebuilds for Hopspot TCP join; never commit.
+sideband-*-hopspot-tcp.apk

--- a/personal-hopspot/mobile/android/app/src/main/java/org/personal/hopspot/MainActivity.kt
+++ b/personal-hopspot/mobile/android/app/src/main/java/org/personal/hopspot/MainActivity.kt
@@ -2,6 +2,8 @@ package org.personal.hopspot
 
 import android.Manifest
 import android.app.Activity
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
@@ -20,6 +22,7 @@ import android.os.IBinder
 import android.view.GestureDetector
 import android.view.MotionEvent
 import android.view.View
+import android.widget.Toast
 import java.nio.ByteBuffer
 
 class MainActivity : Activity() {
@@ -193,9 +196,21 @@ private class HopspotView(
             }
 
             private fun act(action: Int) {
-                if (action == NativeBridge.ACTION_ANNOUNCE) {
-                    service?.announce()
+                when (action) {
+                    NativeBridge.ACTION_ANNOUNCE -> service?.announce()
+                    NativeBridge.ACTION_COPY_SIDEBAND_JOIN_CONFIG -> copySidebandJoinConfig()
                 }
+            }
+
+            private fun copySidebandJoinConfig() {
+                val config = NativeBridge.nativeSidebandJoinConfig()
+                if (config.isNullOrBlank()) {
+                    Toast.makeText(context, "Hopspot is not ready", Toast.LENGTH_SHORT).show()
+                    return
+                }
+                val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                clipboard.setPrimaryClip(ClipData.newPlainText("RNS config", config))
+                Toast.makeText(context, "RNS config copied", Toast.LENGTH_SHORT).show()
             }
         },
     )

--- a/personal-hopspot/mobile/android/app/src/main/java/org/personal/hopspot/NativeBridge.kt
+++ b/personal-hopspot/mobile/android/app/src/main/java/org/personal/hopspot/NativeBridge.kt
@@ -49,8 +49,11 @@ object NativeBridge {
 
     val INPUT_SHORT_PRESS = nativeInputShortPressCode()
     val INPUT_LONG_PRESS = nativeInputLongPressCode()
+    private external fun nativeActionCopySidebandJoinConfigCode(): Int
+
     val ACTION_NONE = nativeActionNoneCode()
     val ACTION_ANNOUNCE = nativeActionAnnounceCode()
+    val ACTION_COPY_SIDEBAND_JOIN_CONFIG = nativeActionCopySidebandJoinConfigCode()
     val ENGINE_STOPPED = nativeEngineStoppedCode()
     val ENGINE_STARTING = nativeEngineStartingCode()
     val ENGINE_RUNNING = nativeEngineRunningCode()
@@ -71,6 +74,8 @@ object NativeBridge {
     external fun nativePersistenceHealth(): LongArray?
 
     external fun nativeRpcKeyHex(): String?
+
+    external fun nativeSidebandJoinConfig(): String?
 
     external fun nativeNodeIdentityHashHex(): String?
 

--- a/personal-hopspot/mobile/android/rust/Cargo.toml
+++ b/personal-hopspot/mobile/android/rust/Cargo.toml
@@ -18,7 +18,7 @@ name = "personal_hopspot_android"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-personal-hopspot-core = { path = "../../../core", default-features = false, features = ["host"] }
+personal-hopspot-core = { path = "../../../core", default-features = false, features = ["host", "android-rns-config"] }
 personal-rns = { path = "../../../../personal-rns", default-features = false, features = ["tokio-host", "wifi-auto", "wifi-direct", "wifi-aware", "bluetooth-auto", "usb", "shared-instance", "log", "parallel-persistence", "parallel-resource-hash"] }
 prns-ffi = { path = "../../../../prns-ffi", default-features = false, features = ["log"] }
 embedded-graphics = "0.8"

--- a/personal-hopspot/mobile/android/rust/src/engine/local_rpc_key.rs
+++ b/personal-hopspot/mobile/android/rust/src/engine/local_rpc_key.rs
@@ -1,0 +1,87 @@
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::Path;
+
+pub const LOCAL_RPC_KEY_FILE: &str = "local_rpc_key";
+
+#[derive(Debug)]
+pub enum LocalRpcKeyError {
+    Read(std::io::Error),
+    Write(std::io::Error),
+    Length { expected: usize, actual: usize },
+    Random,
+}
+
+impl core::fmt::Display for LocalRpcKeyError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Read(error) => write!(formatter, "could not read local RPC key: {error}"),
+            Self::Write(error) => write!(formatter, "could not write local RPC key: {error}"),
+            Self::Length { expected, actual } => write!(
+                formatter,
+                "local RPC key is {actual} bytes; expected {expected} bytes"
+            ),
+            Self::Random => formatter.write_str("local RPC key entropy unavailable"),
+        }
+    }
+}
+
+pub fn load_or_create_local_rpc_key(storage_dir: &Path) -> Result<[u8; 32], LocalRpcKeyError> {
+    let path = storage_dir.join(LOCAL_RPC_KEY_FILE);
+    match read_key(&path) {
+        Ok(key) => Ok(key),
+        Err(LocalRpcKeyError::Read(error)) if error.kind() == std::io::ErrorKind::NotFound => {
+            create_key(storage_dir, &path)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn read_key(path: &Path) -> Result<[u8; 32], LocalRpcKeyError> {
+    let mut bytes = Vec::new();
+    File::open(path)
+        .map_err(LocalRpcKeyError::Read)?
+        .read_to_end(&mut bytes)
+        .map_err(LocalRpcKeyError::Read)?;
+    bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| LocalRpcKeyError::Length {
+            expected: 32,
+            actual: bytes.len(),
+        })
+}
+
+fn create_key(storage_dir: &Path, path: &Path) -> Result<[u8; 32], LocalRpcKeyError> {
+    std::fs::create_dir_all(storage_dir).map_err(LocalRpcKeyError::Write)?;
+    let mut key = [0u8; 32];
+    getrandom::getrandom(&mut key).map_err(|_| LocalRpcKeyError::Random)?;
+    let mut file = match OpenOptions::new().write(true).create_new(true).open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => return read_key(path),
+        Err(error) => return Err(LocalRpcKeyError::Write(error)),
+    };
+    file.write_all(&key).map_err(LocalRpcKeyError::Write)?;
+    file.sync_all().map_err(LocalRpcKeyError::Write)?;
+    Ok(key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process;
+
+    #[test]
+    fn local_rpc_key_is_created_once_and_reloaded() {
+        let storage_dir =
+            std::env::temp_dir().join(format!("personal-hopspot-local-rpc-{}", process::id()));
+        let _ = std::fs::remove_dir_all(&storage_dir);
+
+        let first = load_or_create_local_rpc_key(&storage_dir).unwrap();
+        let second = load_or_create_local_rpc_key(&storage_dir).unwrap();
+        assert_eq!(first, second);
+        assert_ne!(first, [0u8; 32]);
+
+        let _ = std::fs::remove_dir_all(storage_dir);
+    }
+}

--- a/personal-hopspot/mobile/android/rust/src/engine/mod.rs
+++ b/personal-hopspot/mobile/android/rust/src/engine/mod.rs
@@ -1,3 +1,4 @@
+mod local_rpc_key;
 mod persistence;
 mod worker;
 
@@ -461,6 +462,52 @@ pub(crate) fn rpc_key_hex() -> Option<String> {
     Some(hex(&resources.rpc_key))
 }
 
+/// Sideband Advanced Reticulum settings template with this Hopspot instance's live RPC key.
+pub(crate) fn sideband_join_config() -> Option<String> {
+    let rpc_key_hex = rpc_key_hex()?;
+    Some(format!(
+        "# This template is used to generate a\n\
+         # running configuration for Sideband's\n\
+         # internal RNS instance. Incorrect changes\n\
+         # or addition here may cause Sideband to\n\
+         # fail starting up or working properly.\n\
+         #\n\
+         # If Sideband detects that Reticulum\n\
+         # aborts at startup, due to an error in\n\
+         # configuration, any template changes\n\
+         # will be reset to this default.\n\
+         \n\
+         [reticulum]\n\
+           # Don't change these lines, use the UI\n\
+           # settings instead. Removing them from\n\
+           # the config template will break these\n\
+           # settings controls in the UI.\n\
+           enable_transport = TRANSPORT_IS_ENABLED\n\
+           local_hops_delta = LOCAL_HOPS_DELTA\n\
+         \n\
+           # Changing this setting will cause\n\
+           # Sideband to not work.\n\
+           share_instance = Yes\n\
+         \n\
+           # Personal Hopspot\n\
+           shared_instance_type = tcp\n\
+           instance_control_port = 37429\n\
+           rpc_key = {rpc_key_hex}\n\
+           panic_on_interface_error = No\n\
+         \n\
+         # Logging is controlled by settings\n\
+         # in the UI, so this section is mostly\n\
+         # not relevant in Sideband.\n\
+         [logging]\n\
+           loglevel = 3\n\
+         \n\
+         # No additional interfaces are currently\n\
+         # defined, but you can use this section\n\
+         # to add additional custom interfaces.\n\
+         [interfaces]\n"
+    ))
+}
+
 pub(crate) fn identity_snapshot() -> Option<EngineIdentitySnapshot> {
     let mut manager = lock_manager();
     manager.reap_finished();
@@ -689,6 +736,30 @@ mod tests {
     }
 
     #[test]
+    fn sideband_join_config_includes_the_live_rpc_key() {
+        let storage_dir =
+            std::env::temp_dir().join(format!("personal-hopspot-android-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&storage_dir);
+
+        start_with_ports(storage_dir.clone(), EnginePorts::EPHEMERAL).unwrap();
+        let key = rpc_key_hex().unwrap();
+        assert_eq!(key.len(), 64);
+        let config = sideband_join_config().unwrap();
+        assert!(config.contains(&format!("rpc_key = {key}")));
+        assert!(config.contains("shared_instance_type = tcp"));
+        assert!(config.contains("This template is used to generate a"));
+        assert!(config.contains("# Don't change these lines, use the UI"));
+        assert!(config.contains("# Logging is controlled by settings"));
+        assert!(config.contains("[interfaces]\n"));
+        stop().unwrap();
+
+        start_with_ports(storage_dir.clone(), EnginePorts::EPHEMERAL).unwrap();
+        assert_eq!(rpc_key_hex().unwrap(), key);
+        stop().unwrap();
+        let _ = std::fs::remove_dir_all(storage_dir);
+    }
+
+    #[test]
     fn engine_stops_and_restarts_with_durable_identity_and_runtime_state() {
         let storage_dir =
             std::env::temp_dir().join(format!("personal-hopspot-android-{}", std::process::id()));
@@ -697,6 +768,7 @@ mod tests {
         start_with_ports(storage_dir.clone(), EnginePorts::EPHEMERAL).unwrap();
         assert_eq!(engine_state(), MobileEngineState::Running);
         let first_key = rpc_key_hex().unwrap();
+        assert_eq!(first_key.len(), 64);
         let first_identity = identity_snapshot().unwrap();
         assert_eq!(persistence_snapshot().unwrap().successful_flushes, 1);
         stop().unwrap();

--- a/personal-hopspot/mobile/android/rust/src/engine/worker.rs
+++ b/personal-hopspot/mobile/android/rust/src/engine/worker.rs
@@ -13,7 +13,9 @@ use personal_rns::interfaces::bluetooth_auto::{
     AndroidHost, Endpoint, LinkCapabilities, BLE_HW_MTU,
 };
 use personal_rns::interfaces::wifi_direct::GoIntent;
-use personal_rns::runtime::{Diagnostic, ManuallyAttached, PrnsEvent, PrnsNode, PrnsNodeRecipe};
+use personal_rns::runtime::{
+    Diagnostic, ManuallyAttached, PrnsEvent, PrnsNode, PrnsNodeHandle, PrnsNodeRecipe,
+};
 use personal_rns::shared_instance::rns_rpc::{SharedInstanceCredentials, SharedInstanceRpcServer};
 use personal_rns::shared_instance::SharedInstanceServer;
 use personal_rns::storage::GrowableHeap;
@@ -76,7 +78,15 @@ async fn run_engine(input: WorkerInput) -> WorkerExit {
         return fail_start(ready_tx, EngineStartError::StorageConfiguration);
     }
     let node_identity = node_bootstrap.into_identity();
-    let credentials = SharedInstanceCredentials::from_identity_secret(node_identity.secret());
+    let local_rpc_key = match super::local_rpc_key::load_or_create_local_rpc_key(&storage_dir) {
+        Ok(key) => key,
+        Err(error) => {
+            log::error!("hopspot local RPC key unavailable: {error}");
+            return fail_start(ready_tx, EngineStartError::StorageConfiguration);
+        }
+    };
+    let credentials = SharedInstanceCredentials::from_identity_secret(node_identity.secret())
+        .with_rpc_key(local_rpc_key.to_vec());
     let node_identity_hash = credentials.transport_identity_hash();
     let rpc_key = credentials.rpc_key().as_bytes().to_vec();
     let transport_secret = node_identity.transport_secret();
@@ -149,13 +159,35 @@ async fn run_engine(input: WorkerInput) -> WorkerExit {
     let usb_status = usb.status();
     handle.add_interface(usb);
 
-    let local = match SharedInstanceServer::with_port(ports.local).bind().await {
-        Ok(local) => local,
+    let local_server = SharedInstanceServer::with_port(ports.local);
+    #[cfg(target_os = "android")]
+    let local_server = if ports.local != 0 {
+        local_server.also_listen_on_abstract_unix("default")
+    } else {
+        local_server
+    };
+    let local = match local_server.bind().await {
+        Ok(local) => {
+            #[cfg(target_os = "android")]
+            if ports.local != 0 {
+                if local.listens_on_abstract_unix() {
+                    log::info!(
+                        "hopspot: shared instance bus on TCP 127.0.0.1:{} and abstract unix rns/default",
+                        ports.local
+                    );
+                } else {
+                    log::warn!(
+                        "hopspot: abstract unix rns/default unavailable; stock Sideband will not join this instance"
+                    );
+                }
+            }
+            local
+        }
         Err(_) => return fail_start(ready_tx, EngineStartError::LocalListenerBind),
     };
     handle.supervise(local);
 
-    let rpc = match SharedInstanceRpcServer::tcp(credentials, ports.rpc, handle.clone())
+    let rpc = match SharedInstanceRpcServer::tcp(credentials.clone(), ports.rpc, handle.clone())
         .bind()
         .await
     {
@@ -163,6 +195,7 @@ async fn run_engine(input: WorkerInput) -> WorkerExit {
         Err(_) => return fail_start(ready_tx, EngineStartError::RpcListenerBind),
     };
     tokio::spawn(rpc.run());
+    spawn_android_abstract_unix_rpc(credentials, ports.rpc, handle.clone());
 
     let service_discovery = match platform.service_discovery.take_service_discovery() {
         Ok(service_discovery) => service_discovery,
@@ -256,6 +289,37 @@ async fn run_engine(input: WorkerInput) -> WorkerExit {
                 Err(()) => WorkerExit::Failed(MobileEngineFailure::PersistenceWrite),
             }
         }
+    }
+}
+
+fn spawn_android_abstract_unix_rpc(
+    credentials: SharedInstanceCredentials,
+    rpc_port: u16,
+    handle: PrnsNodeHandle,
+) {
+    #[cfg(target_os = "android")]
+    {
+        if rpc_port == 0 {
+            return;
+        }
+        tokio::spawn(async move {
+            match SharedInstanceRpcServer::abstract_unix(credentials, "default", handle)
+                .bind()
+                .await
+            {
+                Ok(rpc) => {
+                    log::info!("hopspot: shared instance RPC on abstract unix rns/default/rpc");
+                    rpc.run().await;
+                }
+                Err(error) => {
+                    log::warn!("hopspot: abstract unix RPC rns/default/rpc unavailable: {error:?}")
+                }
+            }
+        });
+    }
+    #[cfg(not(target_os = "android"))]
+    {
+        let _ = (credentials, rpc_port, handle);
     }
 }
 

--- a/personal-hopspot/mobile/android/rust/src/face.rs
+++ b/personal-hopspot/mobile/android/rust/src/face.rs
@@ -83,6 +83,7 @@ impl HopspotFace {
                 wake_interfaces();
             }
             UiAction::Announce => self.show_notice(UiNotice::Announcing),
+            UiAction::CopySidebandJoinConfig => self.show_notice(UiNotice::Copied),
             UiAction::None
             | UiAction::OledOff
             | UiAction::ToggleOledAutoOff

--- a/personal-hopspot/mobile/android/rust/src/jni/face.rs
+++ b/personal-hopspot/mobile/android/rust/src/jni/face.rs
@@ -9,7 +9,7 @@ use personal_hopspot_core::{
 use crate::engine::{
     ble_identity_hex, delivery_destination_hex, engine_state, last_failure, node_identity_hash_hex,
     node_page_destination_hex, persistence_snapshot, rpc_key_hex, runtime_health,
-    wifi_aware_failure_reason, wifi_direct_failure_reason,
+    sideband_join_config, wifi_aware_failure_reason, wifi_direct_failure_reason,
 };
 use crate::face::HopspotFace;
 
@@ -140,6 +140,14 @@ pub extern "system" fn Java_org_personal_hopspot_NativeBridge_nativeActionAnnoun
     _class: JClass,
 ) -> jint {
     MobileActionCode::Announce.code()
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_personal_hopspot_NativeBridge_nativeActionCopySidebandJoinConfigCode(
+    _env: JNIEnv,
+    _class: JClass,
+) -> jint {
+    MobileActionCode::CopySidebandJoinConfig.code()
 }
 
 #[no_mangle]
@@ -341,6 +349,16 @@ pub extern "system" fn Java_org_personal_hopspot_NativeBridge_nativeRpcKeyHex(
 ) -> jstring {
     rpc_key_hex()
         .and_then(|key| env.new_string(key).ok())
+        .map_or(core::ptr::null_mut(), JString::into_raw)
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_personal_hopspot_NativeBridge_nativeSidebandJoinConfig(
+    env: JNIEnv,
+    _class: JClass,
+) -> jstring {
+    sideband_join_config()
+        .and_then(|config| env.new_string(config).ok())
         .map_or(core::ptr::null_mut(), JString::into_raw)
 }
 

--- a/personal-hopspot/mobile/ios/rust/src/face.rs
+++ b/personal-hopspot/mobile/ios/rust/src/face.rs
@@ -83,6 +83,7 @@ impl HopspotFace {
                 wake_interfaces();
             }
             UiAction::Announce => self.show_notice(UiNotice::Announcing),
+            UiAction::CopySidebandJoinConfig => self.show_notice(UiNotice::Copied),
             UiAction::None
             | UiAction::OledOff
             | UiAction::ToggleOledAutoOff

--- a/prns-interfaces/impls/tokio/src/shared_instance/supervision.rs
+++ b/prns-interfaces/impls/tokio/src/shared_instance/supervision.rs
@@ -182,7 +182,7 @@ impl SharedInstanceServer {
         self
     }
 
-    /// Set the AF_UNIX `socket_path` to match an app configured with a non-default `local_socket_path` (the abstract socket bound becomes `\0rns/{socket_path}`). Linux only.
+    /// Set the AF_UNIX `socket_path` to match an app configured with a non-default `local_socket_path` (the abstract socket bound becomes `\0rns/{socket_path}`). Linux only. Replaces TCP; use [`Self::also_listen_on_abstract_unix`] to keep loopback TCP.
     #[cfg(any(target_os = "linux", target_os = "android"))]
     #[must_use]
     pub fn with_socket_path(mut self, socket_path: impl Into<String>) -> Self {
@@ -191,6 +191,16 @@ impl SharedInstanceServer {
         self.status = TokioInterfaceStatus::new(self.id(), ConnectionState::Disconnected);
         self.bind_addr = None;
         self.socket_path = Some(socket_path);
+        self
+    }
+
+    /// Also bind `\0rns/{socket_path}` (stock RNS `instance_name`, default `default`) without dropping the TCP loopback listener.
+    ///
+    /// Android Sideband's baked config uses AF_UNIX, not `shared_instance_type = tcp`. If the Unix name is already taken, [`Self::bind`] still keeps TCP.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[must_use]
+    pub fn also_listen_on_abstract_unix(mut self, socket_path: impl Into<String>) -> Self {
+        self.socket_path = Some(socket_path.into());
         self
     }
 
@@ -209,15 +219,19 @@ impl SharedInstanceServer {
             None => None,
         };
         #[cfg(any(target_os = "linux", target_os = "android"))]
+        let tcp_also_bound = tcp_listener.is_some();
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         let abstract_unix = match self.socket_path {
-            Some(socket_path) => {
-                let listener = bind_abstract_unix(&socket_path)
-                    .map_err(|error| SharedInstanceServerBindError::AbstractUnix(error.kind()))?;
-                BoundAbstractUnix::Listening {
+            Some(socket_path) => match bind_abstract_unix(&socket_path) {
+                Ok(listener) => BoundAbstractUnix::Listening {
                     socket_path,
                     listener,
+                },
+                Err(_) if tcp_also_bound => BoundAbstractUnix::Disabled,
+                Err(error) => {
+                    return Err(SharedInstanceServerBindError::AbstractUnix(error.kind()));
                 }
-            }
+            },
             None => BoundAbstractUnix::Disabled,
         };
         self.status.set_connection(ConnectionState::Connected);
@@ -268,6 +282,14 @@ impl InterfaceSupervisor for SharedInstanceServer {
             return;
         };
         server.run(fleet).await;
+    }
+}
+
+impl BoundSharedInstanceServer {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[must_use]
+    pub fn listens_on_abstract_unix(&self) -> bool {
+        matches!(self.abstract_unix, BoundAbstractUnix::Listening { .. })
     }
 }
 
@@ -422,6 +444,62 @@ mod tests {
                 .bind_addr
                 .is_none()
         );
+        let both = SharedInstanceServer::with_port(37_428)
+            .also_listen_on_abstract_unix(shared_instance::DEFAULT_SOCKET_PATH);
+        assert!(both.bind_addr.is_some());
+        assert_eq!(
+            both.socket_path.as_deref(),
+            Some(shared_instance::DEFAULT_SOCKET_PATH)
+        );
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[tokio::test]
+    async fn tcp_and_abstract_unix_can_bind_together() {
+        #[cfg(target_os = "android")]
+        use std::os::android::net::SocketAddrExt;
+        #[cfg(target_os = "linux")]
+        use std::os::linux::net::SocketAddrExt;
+        let probe = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("an ephemeral port binds");
+        let port = probe.local_addr().expect("the probe has an address").port();
+        drop(probe);
+        let socket_path = std::format!("personal-test-dual-{port}");
+        let server = SharedInstanceServer::with_port(port)
+            .also_listen_on_abstract_unix(&socket_path)
+            .bind()
+            .await
+            .expect("TCP and Unix bind together");
+        assert!(server.listens_on_abstract_unix());
+        assert!(tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .is_ok());
+        let name = std::format!("rns/{socket_path}");
+        let addr = std::os::unix::net::SocketAddr::from_abstract_name(name.as_bytes())
+            .expect("the abstract name is valid");
+        assert!(std::os::unix::net::UnixStream::connect_addr(&addr).is_ok());
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[tokio::test]
+    async fn a_taken_unix_name_does_not_drop_tcp_when_both_were_requested() {
+        let probe = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("an ephemeral port binds");
+        let port = probe.local_addr().expect("the probe has an address").port();
+        drop(probe);
+        let socket_path = std::format!("personal-test-unix-taken-{port}");
+        let _holder = bind_abstract_unix(&socket_path).expect("the abstract socket binds");
+        let server = SharedInstanceServer::with_port(port)
+            .also_listen_on_abstract_unix(&socket_path)
+            .bind()
+            .await
+            .expect("TCP still binds when Unix is taken");
+        assert!(!server.listens_on_abstract_unix());
+        assert!(tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .is_ok());
     }
 
     #[cfg(any(target_os = "linux", target_os = "android"))]


### PR DESCRIPTION
## Summary
- Persist a per-device RPC key on Android Hopspot and serve it on the shared-instance RPC port.
- Copy a Sideband-style Reticulum template from the Local card **RNS Config** action so other apps can join without a hardcoded key.
- Keep the menu item behind `android-rns-config` so iOS, desktop, and embedded stay Power/Back only.

## Test plan
- [ ] Hopspot core tests with and without `android-rns-config`
- [ ] Android: Local card → long-press **RNS Config** copies the commented template with the live `rpc_key`
- [ ] Stock Sideband: paste into Utilities → Advanced Reticulum settings and confirm Full RNS Status joins Hopspot
- [ ] Non-Android Hopspot Local menus do not show **RNS Config**


Made with [Cursor](https://cursor.com)