### PR TITLE
device: resolve the candidate root before joining artifact paths

### DIFF
--- a/tools/device/developer_flasher_candidate.py
+++ b/tools/device/developer_flasher_candidate.py
@@ -59,7 +59,7 @@ def safe_artifact_path(candidate: Path, wire_path: object) -> tuple[PurePosixPat
     ):
         raise DeveloperCandidateError(f"manifest contains unsafe artifact path: {wire_path!r}")
     root = candidate.resolve(strict=True)
-    path = candidate.joinpath(*relative.parts)
+    path = root.joinpath(*relative.parts)
     try:
         resolved = path.resolve(strict=True)
         resolved.relative_to(root)


### PR DESCRIPTION
`safe_artifact_path` resolves the candidate root, then builds each artifact path from the
*unresolved* candidate, and finally treats any disagreement between `resolve()` and `absolute()` as
proof that a symlink was traversed. That last comparison is the problem: `resolve()` canonicalises
and `absolute()` doesn't, so the two differ whenever the staging path isn't already in canonical
form, with no link involved anywhere.

On Windows that happens through 8.3 short names. Here's it firing with no symlink present:

```
path.resolve()    = C:\Users\jackspace\AppData\Local\Temp\tmp3tfi4zh5\application.bin
path.absolute()   = C:\Users\JACKSP~1\AppData\Local\Temp\tmp3tfi4zh5\application.bin
path.is_symlink() = False
resolved != path.absolute()  -> True, so it raises "contains a link"
```

I want to be exact about who this hits, because my first read was too broad. My interactive `TEMP` is
the long form and accepts fine; the short form came from a service-style environment, which is the
shape a scheduled task or CI runner tends to get. So on Windows it's a subset of users, not all of
them.

**I think macOS is the bigger one, and I can't test it here.** Every `TMPDIR` on macOS lives under
`/var/folders/...`, and `/var` is a symlink to `/private/var`, so `resolve()` and `absolute()` will
disagree for exactly the same reason on every single run. I don't have a Mac on this bench, so rather
than guess I reproduced the shape on Linux, pointing a candidate through a symlinked parent the way
`/var` does:

```
candidate: /tmp/tmp29nf_qib/varlike/candidate     ("varlike" is a symlink, like /var)
  before:  REJECTED: manifest artifact path contains a link: firmware/application.bin
  after:   ACCEPTED
```

If you want to confirm it on your Mac in one line:

```sh
python3 -c "import tempfile,pathlib; p=pathlib.Path(tempfile.mkdtemp()); print(p.resolve()==p.absolute())"
```

If that prints `False`, `tools/prns device hopspot-dev-flasher` can't validate any artifact there.

The reason this got through is that `tools/tests` only ever runs on Linux. `validation/release/contracts.sh`
does the `unittest discover -s tools/tests`, and the `release-contracts` suite is `platform = "linux"`.
Linux `/tmp` is a real directory, so it's the one platform where the two calls agree.

The fix is one line: join onto the already-resolved `root` so the comparison is like with like. The
staged dir reaches this through `temporary_run_directory()`, which is
`tempfile.mkdtemp(prefix="prns-dev-flasher-")`, then `candidate = run_directory / "candidate"`, then
`verify_manifest_artifacts` and `validate_candidate`. It matters that the check is first, because
while it's firing it masks the size, hash, embedding and UF2 failures the later validations exist to
report. Four tests that expected those specific errors were getting "contains a link" instead.

I checked what the fix does and doesn't keep:

| case | before | after |
|---|---|---|
| clean artifact | accepted | accepted |
| symlink inside the candidate (aliases two names to one file) | rejected | rejected |
| symlink escaping the candidate | rejected | rejected |
| candidate root itself reached via a symlink | rejected | **accepted** |

Both link protections survive. The one deliberate change is the last row, and that's the row that was
causing the false positives. The manifest can't influence how the root is spelled, and the escape
check above it still runs against the resolved root, so I don't think anything is lost. Say the word
if you'd rather keep that stricter and I'll do it a different way.

What I ran:

- Windows, Python 3.13: `tools.tests.test_hopspot_dev_flasher` goes from 12 failures/errors to 5. The
  remaining 5 assume POSIX (shebang fixtures Windows can't exec, a `0o700` mode assertion, an exec-bit
  digest test) rather than anything wrong with the tool. Happy to look at those separately.
- Linux control, WSL Ubuntu: 22/22 OK before and after.
- FMT_DOC_CHECK_GATE_OK, TOOLING_REGISTRY_OK, `test_validate_flasher_acceptance` 33/33,
  `test_create_flasher_acceptance` 9/9. `test_flasher_release_custody` has 2 errors on Windows, and I
  A/B'd those against unmodified trunk to be sure: identical both ways, so they're not from this.

The hardening in d84013d5 is solid. This is just the one comparison that stops meaning what it says
once the path isn't already canonical, and I happened to be on a box that shows it.
