### PR TITLE
lint: migrate the three fuzz targets off chunks_exact as well

### DIFF
--- a/validation/fuzz/fuzz_targets/egress_reemit_round_trip.rs
+++ b/validation/fuzz/fuzz_targets/egress_reemit_round_trip.rs
@@ -13,8 +13,8 @@ const RAW_ANNOUNCE_HEX: &[u8] =
 
 fn decode_hex(bytes: &[u8]) -> Option<Vec<u8>> {
     let mut decoded = Vec::with_capacity(bytes.len() / 2);
-    let chunks = bytes.chunks_exact(2);
-    if !chunks.remainder().is_empty() {
+    let (chunks, remainder) = bytes.as_chunks::<2>();
+    if !remainder.is_empty() {
         return None;
     }
 

--- a/validation/fuzz/fuzz_targets/link_handshake_parse.rs
+++ b/validation/fuzz/fuzz_targets/link_handshake_parse.rs
@@ -30,8 +30,8 @@ fn exercise_handshake(bytes: &[u8]) {
 
 fn decode_hex(bytes: &[u8]) -> Option<Vec<u8>> {
     let mut decoded = Vec::with_capacity(bytes.len() / 2);
-    let chunks = bytes.chunks_exact(2);
-    if !chunks.remainder().is_empty() {
+    let (chunks, remainder) = bytes.as_chunks::<2>();
+    if !remainder.is_empty() {
         return None;
     }
 

--- a/validation/fuzz/fuzz_targets/wire_announce_parse.rs
+++ b/validation/fuzz/fuzz_targets/wire_announce_parse.rs
@@ -16,8 +16,8 @@ fn exercise_packet(bytes: &[u8]) {
 
 fn decode_hex(bytes: &[u8]) -> Option<Vec<u8>> {
     let mut decoded = Vec::with_capacity(bytes.len() / 2);
-    let chunks = bytes.chunks_exact(2);
-    if !chunks.remainder().is_empty() {
+    let (chunks, remainder) = bytes.as_chunks::<2>();
+    if !remainder.is_empty() {
         return None;
     }
 


### PR DESCRIPTION
`991446ab` cleaned every `chunks_exact` site the root workspace can reach, and your CI jobs are
correctly reporting the ones it can't: `feature-configs`, `android-service`, `macos-ble` and
`windows-desktop` are each red on this lint right now, in four different crates. The catch is that
`cargo clippy --workspace` from the root exits 0 while they burn, because the root `Cargo.toml`
excludes twelve crates (`prnsd` and `prns-ffi` among them) and `personal-hopspot/desktop`, the two
mobile crates, `prns-config` and `validation/fuzz` are their own workspaces entirely. So the local
gate says done while the jobs say otherwise, and each job only reports the first crate it dies in.

Sixteen sites in eight crates, all rewritten to `as_chunks::<N>()` to match the shape you already
set. The three fuzz targets were doing `chunks_exact(2)` and then checking `.remainder()`, so they
take `as_chunks`'s second return value instead, which fits better than what they had.

### The one I'd flag

`prnsd/control/src/record.rs:218` is inside a `cfg(windows)` function. Linux clippy compiles it out,
and the Windows CI job runs `cargo check` on `prnsd` rather than `clippy`, so it evaluates no lints
at all. No job in the repository could have reported that line. I found it by running
`cargo clippy --workspace --all-features --all-targets` in `prnsd` on an actual Windows box.

The sweep took three rounds, because each fixed crate reveals the next one behind it:
`prnsd/src/utilities/arguments.rs:80` and `prnsd/src/utilities/rnid/encoding.rs:95` only became
visible once `prnsd-control` compiled, and two of the three fuzz targets only appeared after the
first one did. The fuzz workspace is in the same boat coverage-wise: `deep-validation` builds it
monthly but nothing runs clippy over it.

### Verification

All numbers are cargo's process exit code from a direct invocation, so a clean run is 0 and a lint
failure is 101. The GitHub checks page shows some of these as exit 1 because the runner shell remaps
them.

Windows 11, rustc 1.98.0, trunk versus this branch:

| command, in | trunk | branch |
|---|---|---|
| `cargo clippy --all-targets --locked -- -D warnings`, `prns-ffi` | 101 | **0** |
| `cargo clippy --workspace --all-features --all-targets --locked -- -D warnings`, `prnsd` | 101 (3 errors) | **0** |
| `cargo check --locked --no-default-features --features tokio-host,observability,tray`, `prnsd` | 0 | **0** |
| `cargo clippy --all-targets --locked -- -D warnings`, `personal-hopspot/desktop` | 0 | **0** |
| `cargo build --locked`, `personal-hopspot/desktop` | � | **0** |

The `check` and the two desktop rows pass on trunk too (the desktop lint site is inside the
Linux-only tray module, so Windows compiles it out): those rows are regression evidence, not proof
of the defect. Together they make the whole `windows-desktop` job green here, on the host CI is
currently failing it on.

Ubuntu 24.04 under WSL, rustc 1.98.0, same command shape:

| workspace | trunk | branch |
|---|---|---|
| `prns-config` | 101 | **0**, and `cargo test --locked` ok |
| `validation/fuzz` (`--workspace`) | 101 | **0** |
| `prnsd` (`--workspace --all-features`) | 101 | **0** |
| `personal-hopspot/mobile/android/rust` | 101, both `face.rs` errors | **0**, and `cargo test --locked` ok |
| `personal-hopspot/desktop` | 101, `ui.rs:249:27` | **0** |
| repo root (`--workspace`) | 0 | **0**, confirming I didn't disturb what you'd already fixed |

The Linux `prnsd` run is the one that covers `prnsd/src/tray/mod.rs:208`, which lives in the
Linux-only `ksni` module and is invisible to the Windows runs above.

Also green on this branch: `bash validation/hygiene/fmt-docs.sh` (`FMT_DOC_CHECK_GATE_OK`),
`python3 validation/run.py verify`, `./tools/prns verify`, and `cargo test --workspace --locked` at
the root.

One control worth stating because it nearly cost me the whole result: this machine's stable was
1.97.1 until tonight, and 1.97 does not have this lint, so every local green would have been
meaningless. I updated both toolchains to 1.98.0 first, then confirmed the lint reproduces at the
pre-fix trunk commit `5a85cb18` (root-workspace clippy on Linux, exit 101, 5 lint errors in
`prns-core`) before trusting any pass.

### What I did not run

macOS and iOS, at all. The iOS crate does not compile off-platform, for a reason unrelated to this
change: `AutoBle::prepare` and `AutoBle::unavailable` are only defined for Apple targets, so
`src/engine.rs:509` and `:516` fail with `E0599` on Linux, identically on trunk and on this branch.
That failure surfaces alongside any other compile error in the crate, and nothing pointed at
`face.rs`, but the two `face.rs:200,208` edits still have only your `macos-ble` log (which names
`face.rs:200:21` and `208:21` exactly) as evidence the originals fire. Yours is the only gate that
can judge the fixed versions.

`cargo build` on the desktop face fails to link here with `unable to find library -lSDL2`, a missing
system package on my box rather than a code problem; clippy stops before the link and passes, and the
Windows build of the same crate links fine in the table above.

One same-shape site I deliberately left alone: `personal-hopspot/embedded/esp32/src/flash.rs:137`
does `chunk.chunks_exact(WORD_LEN)` with `WORD_LEN` a const 4 and fixed indexing. That crate builds
only under the esp toolchain and no job runs clippy over it, so it isn't red anywhere and I couldn't
run the gate that would judge a rewrite. Flagging it rather than changing code I can't verify.

### Two things I did not touch

`rust-toolchain.toml` is an unpinned `stable` while `msrv`, `flasher-contracts` and `deny` each pin a
version, so the floating jobs pick up new lints the day they ship. You clearly already decided to fix
rather than pin, so I followed that rather than changing it.

And there's no gate that would catch the next one of these. If you want a CI step that runs clippy
across the excluded workspaces, I'm happy to write it, but it changes what the `clippy` job means and
that felt like your call rather than something to slip into a lint fix.
