### PR TITLE
security: refresh the unsafe snapshot for the vendored ESP runtime

### DIFF
--- a/audits/unsafe-snapshot.json
+++ b/audits/unsafe-snapshot.json
@@ -5687,7 +5687,7 @@
         ]
       },
       "name": "esp-alloc",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "source": "personal-hopspot/embedded/esp32/vendor/esp-alloc-0.10.0",
       "unsafe": {
         "blocks": 41,
         "externs": 11,
@@ -5729,7 +5729,7 @@
         ]
       },
       "name": "esp-backtrace",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "source": "personal-hopspot/embedded/esp32/vendor/esp-backtrace-0.19.0",
       "unsafe": {
         "blocks": 12,
         "externs": 4,
@@ -6075,11 +6075,11 @@
       "name": "esp-radio",
       "source": "personal-hopspot/embedded/esp32/vendor/esp-radio-0.18.0",
       "unsafe": {
-        "blocks": 439,
+        "blocks": 437,
         "externs": 511,
         "functions": 12,
         "impls": 3,
-        "tokens": 1023
+        "tokens": 1021
       },
       "version": "0.18.0"
     },
@@ -6111,7 +6111,7 @@
         ]
       },
       "name": "esp-radio-rtos-driver",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "source": "personal-hopspot/embedded/esp32/vendor/esp-radio-rtos-driver-0.3.0",
       "unsafe": {
         "blocks": 124,
         "externs": 11,
@@ -6204,13 +6204,13 @@
         ]
       },
       "name": "esp-rtos",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "source": "personal-hopspot/embedded/esp32/vendor/esp-rtos-0.3.0",
       "unsafe": {
-        "blocks": 97,
+        "blocks": 98,
         "externs": 5,
         "functions": 9,
         "impls": 7,
-        "tokens": 124
+        "tokens": 125
       },
       "version": "0.3.0"
     },
@@ -13971,11 +13971,11 @@
       "name": "personal-hopspot-esp32",
       "source": "personal-hopspot/embedded/esp32",
       "unsafe": {
-        "blocks": 491,
-        "externs": 517,
-        "functions": 15,
-        "impls": 15,
-        "tokens": 1100
+        "blocks": 776,
+        "externs": 553,
+        "functions": 121,
+        "impls": 37,
+        "tokens": 1618
       },
       "version": "0.1.0"
     },
@@ -14941,11 +14941,11 @@
       "name": "prns-ffi",
       "source": "prns-ffi",
       "unsafe": {
-        "blocks": 119,
+        "blocks": 123,
         "externs": 3,
         "functions": 0,
         "impls": 22,
-        "tokens": 180
+        "tokens": 184
       },
       "version": "0.3.6"
     },
@@ -23325,7 +23325,7 @@
         ]
       },
       "name": "xtensa-lx-rt",
-      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "source": "personal-hopspot/embedded/esp32/vendor/xtensa-lx-rt-0.22.0",
       "unsafe": {
         "blocks": 2,
         "externs": 5,


### PR DESCRIPTION
The `deny` job is red on trunk, but not because of cargo-deny. That part is clean: `advisories ok,
bans ok, licenses ok, sources ok` on all twenty-four graphs. It fails on the line after, from
`validation/security/deps-audit.sh:55`:

```
unsafe dependency snapshot drifted; review and run validation/security/unsafe-audit.py --write
```

The baseline was last written in `756e3a48`, and three commits since then moved the unsafe surface.
Since that file exists so a human can look at what changed, here is the entire delta, attributed:

- **Four crates moved from the registry to vendored paths, counts unchanged**: `esp-alloc`,
  `esp-backtrace`, `esp-radio-rtos-driver`, `xtensa-lx-rt`. That is `3049814f`. `esp-rtos` made the
  same move with one count change, covered next.
- **`esp-radio` loses 2 unsafe blocks and `esp-rtos` gains 1.** That is `f5135f5e`, your coexistence
  patches.
- **`prns-ffi` gains 4 blocks**, all from `28222cbd`, the macOS Bluetooth rediscovery work. Each one
  carries its own `// SAFETY:` comment.

### The fourth entry is not what it looks like

`personal-hopspot-esp32` appears to gain 285 blocks and 518 unsafe tokens. It did not gain any
unsafe code at all.

`unsafe_counts` walks `package_root.rglob("*.rs")` and skips only `target` and `.git`, so that crate
absorbs everything under its own `vendor/` subtree and counts those crates a second time, once under
their own entries and once under it. Measured on this branch: the crate's own non-vendor code holds
**33** unsafe tokens against the **1618** recorded for it.

The double count predates this change. Vendoring five more crates into that directory is what made
it jump. I have not touched the counting, because changing it changes what the reviewed baseline
means and that is your call, not something to slip into a refresh.

### Verification

- `validation/security/unsafe-audit.py` before: exits **1**, `snapshot drifted`
- after: exits **0**, `unsafe dependency snapshot matches reviewed baseline`
- and with a single number in the regenerated baseline deliberately corrupted: exits **1** again,
  so the check was refreshed rather than silenced

Regenerated on Linux under `RUSTUP_TOOLCHAIN=1.96.0`, the version the `deny` job pins. Worth knowing
for next time: regenerating this file on Windows writes CRLF and produces 23,983 carriage returns.
The content is otherwise byte-identical between 1.96.0 on Linux and 1.98.0 on Windows, so the pin
does not change the answer, but the line endings do.

This should take `deny` itself green, since the snapshot check is its only failing step. The overall
run stays red until the rest is handled: of the six jobs currently failing on trunk, four are the
1.98 chunk lint in workspaces the root clippy run does not reach, and `Release critical` is the
roll-up of the others.
