### PR TITLE
Fix first schema 3 website history migration

### DIFF
--- a/tools/release/flasher_website_history.py
+++ b/tools/release/flasher_website_history.py
@@ -8,11 +8,12 @@ from pathlib import Path, PurePosixPath
 import re
 import shutil
 
-from flasher_manifest import FLASH_MANIFEST_SCHEMA, require_schema
+from flasher_manifest import FLASH_MANIFEST_SCHEMA
 
 
 FLASHER_RELEASE_RECORD_NAME = re.compile(r"flasher-release-record-v.+\.json")
 SIGNED_CANDIDATE_NAME = re.compile(r"prns-flasher-candidate-v.+-signed\.tar\.gz")
+RETAINED_FLASH_MANIFEST_SCHEMAS = frozenset({2, FLASH_MANIFEST_SCHEMA})
 
 
 def sha256(path: Path) -> str:
@@ -173,6 +174,14 @@ def load_object(path: Path, label: str) -> dict:
     return value
 
 
+def require_retained_schema(manifest: dict) -> None:
+    if manifest.get("schema") not in RETAINED_FLASH_MANIFEST_SCHEMAS:
+        supported = ", ".join(
+            str(schema) for schema in sorted(RETAINED_FLASH_MANIFEST_SCHEMAS)
+        )
+        raise ValueError(f"retained flash manifest must use schema {supported}")
+
+
 def validate_metadata_identity(
     metadata: dict,
     *,
@@ -227,7 +236,7 @@ def validate_metadata_identity(
                 raise ValueError(f"retained release {version} lacks {required}")
         manifest = load_object(directory / "flash-manifest.json", "retained manifest")
         release = manifest.get("release")
-        require_schema(manifest)
+        require_retained_schema(manifest)
         if not isinstance(release, dict) or release.get("version") != version:
             raise ValueError(f"retained release directory {version} has the wrong manifest")
 
@@ -256,10 +265,18 @@ def load_history(root: Path) -> dict:
     return metadata
 
 
-def candidate_version(candidate: Path) -> tuple[str, dict]:
+def candidate_version(
+    candidate: Path, *, allow_retained_schema: bool = False
+) -> tuple[str, dict]:
     manifest = load_object(candidate / "flash-manifest.json", "candidate manifest")
     release = manifest.get("release")
-    if manifest.get("schema") != FLASH_MANIFEST_SCHEMA or not isinstance(release, dict):
+    schema = manifest.get("schema")
+    supported_schemas = (
+        RETAINED_FLASH_MANIFEST_SCHEMAS
+        if allow_retained_schema
+        else frozenset({FLASH_MANIFEST_SCHEMA})
+    )
+    if schema not in supported_schemas or not isinstance(release, dict):
         raise ValueError(f"candidate manifest is not schema {FLASH_MANIFEST_SCHEMA}")
     return canonical_version(release.get("version")), manifest
 
@@ -279,8 +296,12 @@ def historical_release_root(candidate: Path, current_version: str) -> Path:
     return source
 
 
-def validate_candidate_history(candidate: Path) -> dict:
-    current_version, _ = candidate_version(candidate)
+def validate_candidate_history(
+    candidate: Path, *, allow_retained_schema: bool = False
+) -> dict:
+    current_version, _ = candidate_version(
+        candidate, allow_retained_schema=allow_retained_schema
+    )
     metadata = load_object(
         candidate / "metadata" / "release-history.json", "candidate release-history metadata"
     )
@@ -355,8 +376,8 @@ def stable_descriptor_identity(path: Path) -> dict[str, str] | None:
 
 def prepare_retained(candidate: Path, release_record: Path, output: Path) -> dict:
     require_empty_output(output)
-    version, manifest = candidate_version(candidate)
-    validate_candidate_history(candidate)
+    version, manifest = candidate_version(candidate, allow_retained_schema=True)
+    validate_candidate_history(candidate, allow_retained_schema=True)
     record = load_object(release_record, "release record")
     release = record.get("release")
     archive = record.get("candidate", {}).get("archive") if isinstance(record.get("candidate"), dict) else None

--- a/tools/tests/test_flasher_rollback.py
+++ b/tools/tests/test_flasher_rollback.py
@@ -76,10 +76,12 @@ def bootstrap_metadata() -> dict:
     }
 
 
-def signed_candidate(root: Path, version: str = VERSION) -> tuple[Path, Path]:
+def signed_candidate(
+    root: Path, version: str = VERSION, *, manifest_schema: int = 3
+) -> tuple[Path, Path]:
     root.mkdir(parents=True)
     manifest = {
-        "schema": 3,
+        "schema": manifest_schema,
         "release": {
             "version": version,
             "channel": "stable",
@@ -190,7 +192,9 @@ class FlasherRollbackTests(unittest.TestCase):
             validate_candidate_history(bootstrap_candidate)
 
             prior = workspace / "prior"
-            _, record = signed_candidate(prior)
+            _, record = signed_candidate(prior, manifest_schema=2)
+            with self.assertRaisesRegex(ValueError, "candidate manifest is not schema 3"):
+                validate_candidate_history(prior)
             retained = workspace / "retained"
             retained_metadata = prepare_retained(prior, record, retained)
             self.assertEqual(retained_metadata["mode"], "retained")

--- a/validation/qualifications/t114-qualification.md
+++ b/validation/qualifications/t114-qualification.md
@@ -5,6 +5,13 @@ Observed independently on 2026-08-19 against commit `c40e8cb0`, using the exact
 `./tools/prns build hopspot t114`. The device was a stock Heltec Mesh Node T114
 Rev. 2.x restored to its factory bootloader:
 
+The T114 combines the nRF52840 and SX1262 already represented in the embedded
+stack, but it needs its own board authority for pins, external crystal startup,
+TCXO and DIO2 RF-switch control, storage ranges, and UF2 memory layout. That
+initial target, shared SX126x receive-reentry fix, and hardware qualification
+were contributed by [Markik](https://github.com/mark-ik) in
+[PR #111](https://github.com/KenAKAFrosty/Prns/pull/111).
+
 ```text
 UF2 Bootloader 0.9.0-2-g836c8dc-dirty
 Model: HT-n5262


### PR DESCRIPTION
## Summary

- permit signed schema-2 manifests only when retaining immutable release history
- continue requiring schema 3 for the outgoing candidate
- cover the schema-2 to schema-3 transition with a regression test
- preserve Markik authorship for the original T114 board authority and link PR #111 from the qualification record

The T114 addition is documentation-only in this PR; the shipping firmware and catalog remain unchanged from the reviewed 0.3.7 main state.

## Validation

- exact v0.3.6 signed candidate and release-record retention
- python3 -m unittest tools.tests.test_flasher_rollback (7/7)
- bash validation/release/contracts.sh (239/239)
- git diff --check