### PR TITLE
Fix catalog-driven all-board release builds

### DIFF
--- a/tools/release/build-flash-artifact.sh
+++ b/tools/release/build-flash-artifact.sh
@@ -6,41 +6,48 @@ TARGET="${1:-}"
 OUT_ROOT="${2:-$ROOT/target/flash-artifacts}"
 
 usage() {
-    echo "usage: $0 <board-slug> [out-root]" >&2
-    echo "supported board-slugs: heltec-v4, heltec-v4-r8, t-beam-supreme, xiao-esp32-c6, t-echo, t114" >&2
+    echo "usage: $0 <board-slug|--all> [out-root]" >&2
+    echo "board slugs come from the shipping entries in release/flash/boards.json" >&2
+}
+
+cd "$ROOT"
+shipping_targets="$(
+    cargo run --quiet --locked -p hopspot-flash -- list |
+        awk '{print $1}'
+)"
+if [[ -z "$shipping_targets" ]]; then
+    echo "shipping board catalog is empty" >&2
+    exit 2
+fi
+
+build_target() {
+    local board="$1"
+    cargo run --locked -p hopspot-flash -- build "$board" --out-root "$OUT_ROOT"
 }
 
 case "$TARGET" in
-    heltec-v4)
-        cd "$ROOT"
-        cargo run --locked -p hopspot-flash -- build heltec-v4 --out-root "$OUT_ROOT"
-        ;;
-    heltec-v4-r8)
-        cd "$ROOT"
-        cargo run --locked -p hopspot-flash -- build heltec-v4-r8 --out-root "$OUT_ROOT"
-        ;;
-    t-beam-supreme)
-        cd "$ROOT"
-        cargo run --locked -p hopspot-flash -- build t-beam-supreme --out-root "$OUT_ROOT"
-        ;;
-    xiao-esp32-c6)
-        cd "$ROOT"
-        cargo run --locked -p hopspot-flash -- build xiao-esp32-c6 --out-root "$OUT_ROOT"
-        ;;
-    t-echo)
-        cd "$ROOT"
-        cargo run --locked -p hopspot-flash -- build t-echo --out-root "$OUT_ROOT"
-        ;;
-    t114)
-        cd "$ROOT"
-        cargo run --locked -p hopspot-flash -- build t114 --out-root "$OUT_ROOT"
+    --all)
+        while IFS= read -r board; do
+            build_target "$board"
+        done <<< "$shipping_targets"
         ;;
     "")
         usage
         exit 2
         ;;
     *)
-        usage
-        exit 2
+        shipping=false
+        while IFS= read -r board; do
+            if [[ "$TARGET" == "$board" ]]; then
+                shipping=true
+                break
+            fi
+        done <<< "$shipping_targets"
+        if [[ "$shipping" != true ]]; then
+            echo "not a shipping board slug: $TARGET" >&2
+            usage
+            exit 2
+        fi
+        build_target "$TARGET"
         ;;
 esac

--- a/tools/release/build-flasher-candidate.sh
+++ b/tools/release/build-flasher-candidate.sh
@@ -177,9 +177,7 @@ if find "$boundary_root/embedded" \( -path '*/firmware/*' -o -path '*/assets/fla
 fi
 
 cd "$root"
-for board in heltec-v4 heltec-v4-r8 t-beam-supreme xiao-esp32-c6 t-echo; do
-    cargo run --locked -p hopspot-flash -- build "$board" --out-root "$candidate"
-done
+"$root/tools/prns" release firmware build -- --all "$candidate"
 cargo run --locked -p hopspot-flash -- assemble-manifest \
     --out-root "$candidate" \
     --channel "$channel" \

--- a/tools/tests/test_flasher_reproducibility.py
+++ b/tools/tests/test_flasher_reproducibility.py
@@ -361,7 +361,7 @@ class FlasherReproducibilityTests(unittest.TestCase):
         self.assertLess(
             candidate_build.index("package-source-snapshot.py"),
             candidate_build.index(
-                'cargo run --locked -p hopspot-flash -- build "$board"'
+                'release firmware build -- --all "$candidate"'
             ),
         )
         self.assertLess(
@@ -758,14 +758,27 @@ class FlasherReproducibilityTests(unittest.TestCase):
             self.assertIn("--coff-debug-directory", workflow)
             self.assertIn("PDBFileName:", workflow)
 
-    def test_shipping_firmware_builds_each_shipping_board(self) -> None:
+    def test_release_builds_use_catalog_driven_all_board_selection(self) -> None:
         shipping = (
             ROOT / "validation" / "platforms" / "shipping-firmware.sh"
         ).read_text(encoding="utf-8")
+        candidate = (
+            ROOT / "tools" / "release" / "build-flasher-candidate.sh"
+        ).read_text(encoding="utf-8")
+        builder = (
+            ROOT / "tools" / "release" / "build-flash-artifact.sh"
+        ).read_text(encoding="utf-8")
+        all_board_build = 'release firmware build -- --all'
+        self.assertIn(all_board_build, shipping)
+        self.assertIn(all_board_build, candidate)
         self.assertIn(
-            "for board in heltec-v4 heltec-v4-r8 t-beam-supreme xiao-esp32-c6 t-echo t114 t096 t1000-e",
-            shipping,
+            "cargo run --quiet --locked -p hopspot-flash -- list",
+            builder,
         )
+        self.assertIn("awk '{print $1}'", builder)
+        self.assertIn("--all)", builder)
+        self.assertNotIn("for board in heltec-v4", shipping)
+        self.assertNotIn("for board in heltec-v4", candidate)
         self.assertNotIn("PRNS_EMBEDDED_SITE", shipping)
 
     def test_embedded_captive_portal_is_a_bounded_static_asset(self) -> None:

--- a/validation/platforms/shipping-firmware.sh
+++ b/validation/platforms/shipping-firmware.sh
@@ -5,8 +5,6 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 artifact_root="${PRNS_VALIDATION_ARTIFACTS:-$root/validation-artifacts}"
 out_root="$artifact_root/shipping-firmware"
 
-for board in heltec-v4 heltec-v4-r8 t-beam-supreme xiao-esp32-c6 t-echo t114 t096 t1000-e; do
-    "$root/tools/prns" release firmware build -- "$board" "$out_root"
-done
+"$root/tools/prns" release firmware build -- --all "$out_root"
 
 echo "SHIPPING_FIRMWARE_GATE_OK"


### PR DESCRIPTION
Fix the 0.3.7 candidate failure where manifest assembly expected all eight shipping boards, but release production built from stale hand-maintained lists.
- Add a catalog-driven --all firmware-build path.
- Use it for flasher candidates and shipping-firmware validation.
- Cover T114, T096, T-1000E, and future shipping boards automatically.
- Update the release-contract assertions.
Validation: 239 release-contract tests and 21 flasher reproducibility tests pass.