### PR TITLE
hopspot: show the battery percentage instead of quantized bars

### DIFF
--- a/personal-hopspot/core/src/screen/render/glyphs.rs
+++ b/personal-hopspot/core/src/screen/render/glyphs.rs
@@ -12,7 +12,7 @@ use super::layout::*;
 use super::primitives::{draw_pattern_colored, fill, line, line_colored, stroke};
 
 /// How wide the title-bar battery zone is: "100%" in FONT_5X8 exactly.
-const BATTERY_ZONE_W: i32 = 20;
+const BATTERY_ZONE_W: i32 = 4 * FONT_5X8_CHAR_W;
 
 /// The battery readout, drawn in the background color (it sits on the inverted title bar): the
 /// percentage as text, right-aligned in a 20px zone so the digits do not wander as they shrink,
@@ -35,7 +35,7 @@ pub(in crate::screen) fn draw_battery<D: DrawTarget<Color = BinaryColor>>(
             let _ = text.push_str("--%");
         }
     }
-    let text_x = x + BATTERY_ZONE_W - text.len() as i32 * 5;
+    let text_x = x + BATTERY_ZONE_W - text.len() as i32 * FONT_5X8_CHAR_W;
     let small = MonoTextStyle::new(&FONT_5X8, BinaryColor::Off);
     let _ = Text::with_baseline(&text, Point::new(text_x, y), small, Baseline::Top).draw(display);
     // External power keeps a compact plug cue at the left of the zone while the cell is below
@@ -50,7 +50,7 @@ pub(in crate::screen) fn draw_battery<D: DrawTarget<Color = BinaryColor>>(
         ExternalPowerState::Present { .. } => true,
         ExternalPowerState::Absent | ExternalPowerState::Unknown => false,
     };
-    if plug && below_full && text_x - x >= 5 {
+    if plug && below_full && text_x - x >= FONT_5X8_CHAR_W {
         draw_charging_plug(display, x, y);
     }
 }
@@ -85,7 +85,7 @@ pub(super) fn draw_title_bar<D: DrawTarget<Color = BinaryColor>>(
     let _ = Text::with_baseline("Personal", Point::new(2, 1), small, Baseline::Top).draw(display);
     draw_battery(
         display,
-        44,
+        WIDTH - BATTERY_ZONE_W,
         1,
         battery,
         battery_charge_tier_visible(animation_ms),

--- a/personal-hopspot/core/src/screen/render/glyphs.rs
+++ b/personal-hopspot/core/src/screen/render/glyphs.rs
@@ -11,7 +11,14 @@ use crate::{ChargingState, ExternalPowerState, PowerSnapshot};
 use super::layout::*;
 use super::primitives::{draw_pattern_colored, fill, line, line_colored, stroke};
 
-/// The battery glyph, drawn in the background color (it sits on the inverted title bar): a 15x9 outline + left terminal nub, then four filled segment bars to the nearest quarter, an incoming plug cue for charging, or a dash for unknown.
+/// How wide the title-bar battery zone is: "100%" in FONT_5X8 exactly.
+const BATTERY_ZONE_W: i32 = 20;
+
+/// The battery readout, drawn in the background color (it sits on the inverted title bar): the
+/// percentage as text, right-aligned in a 20px zone so the digits do not wander as they shrink,
+/// a blinking plug cue at the left of the zone while charging, or `--%` for unknown. The exact
+/// number is shown because the gauge already knows it; quantized bars threw that precision away
+/// right when it matters most, at the bottom of the discharge.
 pub(in crate::screen) fn draw_battery<D: DrawTarget<Color = BinaryColor>>(
     display: &mut D,
     x: i32,
@@ -19,75 +26,33 @@ pub(in crate::screen) fn draw_battery<D: DrawTarget<Color = BinaryColor>>(
     state: PowerSnapshot,
     charging_tier_visible: bool,
 ) {
-    let outline = stroke(BinaryColor::Off);
-    let solid = fill(BinaryColor::Off);
-    let _ = Rectangle::new(Point::new(x, y), Size::new(15, 9))
-        .into_styled(outline)
-        .draw(display);
-    let _ = Rectangle::new(Point::new(x - 2, y + 3), Size::new(2, 3))
-        .into_styled(solid)
-        .draw(display);
+    let mut text: heapless::String<4> = heapless::String::new();
     match state.battery() {
-        Some(pct)
-            if matches!(state.external_power(), ExternalPowerState::Present { .. })
-                && pct.get() >= 100 =>
-        {
-            draw_full_battery(display, x, y);
-        }
-        Some(pct)
-            if matches!(
-                state.external_power(),
-                ExternalPowerState::Present {
-                    charging: ChargingState::Charging
-                }
-            ) =>
-        {
-            let pct = pct.get();
-            let filled = (pct as u32 * 4 / 100).min(3);
-            for i in (4 - filled)..4 {
-                draw_battery_segment(display, x, y, i);
-            }
-            if charging_tier_visible {
-                draw_battery_segment(display, x, y, 3 - filled);
-            }
-        }
         Some(pct) => {
-            // Segments fill to the nearest quarter, anchored at the RIGHT so the leftmost bar empties first as the cell drains (matching the panel's orientation).
-            let pct = pct.get();
-            let filled = ((pct as u32 * 4 + 50) / 100).min(4);
-            for i in (4 - filled)..4 {
-                draw_battery_segment(display, x, y, i);
-            }
+            let _ = core::fmt::write(&mut text, format_args!("{}%", pct.get()));
         }
         None => {
-            let _ = Line::new(Point::new(x + 4, y + 4), Point::new(x + 10, y + 4))
-                .into_styled(outline)
-                .draw(display);
+            let _ = text.push_str("--%");
         }
     }
-    if matches!(state.external_power(), ExternalPowerState::Present { .. })
-        && state.battery().is_none_or(|percent| percent.get() < 100)
-    {
+    let text_x = x + BATTERY_ZONE_W - text.len() as i32 * 5;
+    let small = MonoTextStyle::new(&FONT_5X8, BinaryColor::Off);
+    let _ = Text::with_baseline(&text, Point::new(text_x, y), small, Baseline::Top).draw(display);
+    // External power keeps a compact plug cue at the left of the zone while the cell is below
+    // full (or unknown): steady when merely present, blinking on the shared cadence while the
+    // battery is actively charging. At 100% the text fills the whole zone and the cue is dropped:
+    // a full cell reads as done.
+    let below_full = state.battery().is_none_or(|percent| percent.get() < 100);
+    let plug = match state.external_power() {
+        ExternalPowerState::Present {
+            charging: ChargingState::Charging,
+        } => charging_tier_visible,
+        ExternalPowerState::Present { .. } => true,
+        ExternalPowerState::Absent | ExternalPowerState::Unknown => false,
+    };
+    if plug && below_full && text_x - x >= 5 {
         draw_charging_plug(display, x, y);
     }
-}
-
-fn draw_battery_segment<D: DrawTarget<Color = BinaryColor>>(
-    display: &mut D,
-    x: i32,
-    y: i32,
-    segment: u32,
-) {
-    let bar_x = x + 2 + segment as i32 * 3;
-    let _ = Rectangle::new(Point::new(bar_x, y + 2), Size::new(2, 5))
-        .into_styled(fill(BinaryColor::Off))
-        .draw(display);
-}
-
-fn draw_full_battery<D: DrawTarget<Color = BinaryColor>>(display: &mut D, x: i32, y: i32) {
-    let _ = Rectangle::new(Point::new(x, y), Size::new(15, 9))
-        .into_styled(fill(BinaryColor::Off))
-        .draw(display);
 }
 
 fn battery_charge_tier_visible(animation_ms: u64) -> bool {
@@ -97,13 +62,13 @@ fn battery_charge_tier_visible(animation_ms: u64) -> bool {
 fn draw_charging_plug<D: DrawTarget<Color = BinaryColor>>(display: &mut D, x: i32, y: i32) {
     let outline = stroke(BinaryColor::Off);
     let solid = fill(BinaryColor::Off);
-    let _ = Rectangle::new(Point::new(x + 15, y + 2), Size::new(4, 5))
+    let _ = Rectangle::new(Point::new(x, y + 2), Size::new(3, 5))
         .into_styled(solid)
         .draw(display);
-    let _ = Line::new(Point::new(x + 19, y + 3), Point::new(x + 14, y + 3))
+    let _ = Line::new(Point::new(x + 2, y + 3), Point::new(x + 4, y + 3))
         .into_styled(outline)
         .draw(display);
-    let _ = Line::new(Point::new(x + 19, y + 5), Point::new(x + 14, y + 5))
+    let _ = Line::new(Point::new(x + 2, y + 5), Point::new(x + 4, y + 5))
         .into_styled(outline)
         .draw(display);
 }

--- a/personal-hopspot/core/src/screen/tests/render/glyphs.rs
+++ b/personal-hopspot/core/src/screen/tests/render/glyphs.rs
@@ -47,68 +47,96 @@ fn ble_icon_reads_as_bluetooth_rune() {
     ]);
 }
 
+/// What the readout should look like: the same text draw the implementation makes, nothing else.
+fn expected_battery_text(text: &str, x: i32, y: i32) -> MockDisplay<BinaryColor> {
+    use embedded_graphics::mono_font::iso_8859_1::FONT_5X8;
+    use embedded_graphics::mono_font::MonoTextStyle;
+    use embedded_graphics::text::{Baseline, Text};
+    let mut display = MockDisplay::new();
+    let small = MonoTextStyle::new(&FONT_5X8, BinaryColor::Off);
+    let _ = Text::with_baseline(text, Point::new(x, y), small, Baseline::Top).draw(&mut display);
+    display
+}
+
 #[test]
-fn unknown_battery_dash_is_symmetric() {
+fn level_battery_shows_the_exact_percent() {
+    let mut display = MockDisplay::new();
+
+    draw_battery(
+        &mut display,
+        2,
+        0,
+        PowerSnapshot::new(
+            Some(BatteryPercent::saturating(97)),
+            ExternalPowerState::Absent,
+        ),
+        true,
+    );
+
+    // Three characters, right-aligned in the 20px zone: text begins at 2 + 20 - 15.
+    assert_eq!(display, expected_battery_text("97%", 7, 0));
+}
+
+#[test]
+fn percent_stays_right_aligned_as_digits_shrink() {
+    let mut display = MockDisplay::new();
+
+    draw_battery(
+        &mut display,
+        2,
+        0,
+        PowerSnapshot::new(
+            Some(BatteryPercent::saturating(7)),
+            ExternalPowerState::Absent,
+        ),
+        true,
+    );
+
+    // Two characters: text begins at 2 + 20 - 10. A drained cell reads "7%", never "70%".
+    assert_eq!(display, expected_battery_text("7%", 12, 0));
+}
+
+#[test]
+fn unknown_battery_reads_as_dashes_not_a_number() {
     let mut display = MockDisplay::new();
 
     draw_battery(&mut display, 2, 0, PowerSnapshot::UNKNOWN, true);
 
-    assert_eq!(display.get_pixel(Point::new(5, 4)), None);
-    for x in 6..=12 {
-        assert_eq!(display.get_pixel(Point::new(x, 4)), Some(BinaryColor::Off));
-    }
-    assert_eq!(display.get_pixel(Point::new(13, 4)), None);
+    assert_eq!(display, expected_battery_text("--%", 7, 0));
 }
 
 #[test]
-fn charging_battery_blinks_the_current_tier() {
+fn charging_battery_shows_the_plug_on_the_visible_phase() {
     let mut display = MockDisplay::new();
     display.set_allow_overdraw(true);
 
     draw_battery(&mut display, 2, 0, charging(62), true);
 
-    assert_eq!(display.get_pixel(Point::new(7, 4)), Some(BinaryColor::Off));
-    assert_eq!(display.get_pixel(Point::new(10, 4)), Some(BinaryColor::Off));
-    assert_eq!(display.get_pixel(Point::new(13, 4)), Some(BinaryColor::Off));
+    // The plug body sits at the left edge of the zone, prongs pointing at the digits.
+    assert_eq!(display.get_pixel(Point::new(2, 4)), Some(BinaryColor::Off));
+    assert_eq!(display.get_pixel(Point::new(3, 2)), Some(BinaryColor::Off));
+    assert_eq!(display.get_pixel(Point::new(6, 3)), Some(BinaryColor::Off));
+    assert_eq!(display.get_pixel(Point::new(6, 5)), Some(BinaryColor::Off));
 }
 
 #[test]
-fn charging_battery_hides_only_the_current_tier_on_the_off_phase() {
+fn charging_battery_hides_the_plug_on_the_off_phase() {
     let mut display = MockDisplay::new();
-    display.set_allow_overdraw(true);
 
     draw_battery(&mut display, 2, 0, charging(62), false);
 
-    assert_eq!(display.get_pixel(Point::new(7, 4)), None);
-    assert_eq!(display.get_pixel(Point::new(10, 4)), Some(BinaryColor::Off));
-    assert_eq!(display.get_pixel(Point::new(13, 4)), Some(BinaryColor::Off));
+    // Off phase is the text alone; the blink carries the "charging" signal.
+    assert_eq!(display, expected_battery_text("62%", 7, 0));
 }
 
 #[test]
-fn charging_battery_draws_right_side_plug_until_full() {
+fn full_charging_battery_drops_the_plug_for_the_full_width_number() {
     let mut display = MockDisplay::new();
-    display.set_allow_overdraw(true);
 
-    draw_battery(&mut display, 2, 0, charging(62), true);
+    draw_battery(&mut display, 2, 0, charging(100), true);
 
-    for x in 17..=20 {
-        assert_eq!(display.get_pixel(Point::new(x, 4)), Some(BinaryColor::Off));
-    }
-    assert_eq!(display.get_pixel(Point::new(21, 3)), Some(BinaryColor::Off));
-    assert_eq!(display.get_pixel(Point::new(23, 4)), None);
-}
-
-#[test]
-fn full_charging_battery_uses_a_steady_filled_shape_without_the_plug() {
-    let mut display = MockDisplay::new();
-    display.set_allow_overdraw(true);
-
-    draw_battery(&mut display, 2, 0, charging(100), false);
-
-    assert_eq!(display.get_pixel(Point::new(2, 0)), Some(BinaryColor::Off));
-    assert_eq!(display.get_pixel(Point::new(16, 8)), Some(BinaryColor::Off));
-    assert_eq!(display.get_pixel(Point::new(0, 4)), Some(BinaryColor::Off));
-    assert_eq!(display.get_pixel(Point::new(21, 3)), None);
+    // "100%" fills the whole zone; a full cell reads as done, no cue needed.
+    assert_eq!(display, expected_battery_text("100%", 2, 0));
 }
 
 #[test]

--- a/personal-hopspot/core/src/screen/tests/render/glyphs.rs
+++ b/personal-hopspot/core/src/screen/tests/render/glyphs.rs
@@ -130,6 +130,30 @@ fn charging_battery_hides_the_plug_on_the_off_phase() {
 }
 
 #[test]
+fn externally_powered_battery_keeps_the_plug_steady_when_charging_is_unknown() {
+    let mut display = MockDisplay::new();
+    display.set_allow_overdraw(true);
+
+    draw_battery(
+        &mut display,
+        2,
+        0,
+        PowerSnapshot::new(
+            Some(BatteryPercent::saturating(53)),
+            ExternalPowerState::from_presence(true),
+        ),
+        false,
+    );
+
+    // Presence-only hosts cannot distinguish charging from idle. Their plug remains visible even
+    // during the phase where an actively charging battery would blink it off.
+    assert_eq!(display.get_pixel(Point::new(2, 4)), Some(BinaryColor::Off));
+    assert_eq!(display.get_pixel(Point::new(3, 2)), Some(BinaryColor::Off));
+    assert_eq!(display.get_pixel(Point::new(6, 3)), Some(BinaryColor::Off));
+    assert_eq!(display.get_pixel(Point::new(6, 5)), Some(BinaryColor::Off));
+}
+
+#[test]
 fn full_charging_battery_drops_the_plug_for_the_full_width_number() {
     let mut display = MockDisplay::new();
 


### PR DESCRIPTION
The gauge already knows the exact number. `BatteryGauge` folds VBAT into a smoothed 0 to 100 percent, and then the title bar rounds it to the nearest quarter and draws four segment bars. At the bottom of the discharge, that quantization hides exactly the thing you look at the panel to learn.

What put this on my bench: I ran a V4-R8 on a 3000 mAh pack for 23 hours, walked up to it, and the panel showed an empty outline. The board was fine, and some real percent was sitting in the gauge, but the display could not tell me whether I had 2% or 12%, which is the difference between "grab the charger now" and "it can wait until tonight." I plugged it in blind.

The change renders the percent itself, right-aligned in the same 20 px the glyph occupied ("100%" in FONT_5X8 is exactly that wide). It reads the `PowerSnapshot` the renderer already gets: while external power is present and the cell is below full, a compact plug cue sits at the left of the zone, steady when power is merely present and blinking on the existing 600 ms cadence while actually charging; at 100% the cue drops and the full-width number reads as done. Unknown renders `--%`. No layout, state, or gauge changes, so every surface the shared renderer drives (OLED, eink, desktop, the mobile panels) picks it up together.

Tests were rewritten to match: five of the six compare the whole zone against an image produced by the same text draw the implementation makes, so they pin alignment and content without hand-encoded font bitmaps; the sixth probes the plug cue pixels. They cover level, right-alignment as digits shrink, unknown, both charging blink phases, and the 100% no-cue case. At this commit I widened the zone by one pixel and watched five of the six fail before trusting them.

Run here, all at this commit: `cargo test -p personal-hopspot-core --locked` (147 passed) and `cargo clippy -p personal-hopspot-core --all-targets --locked -- -D warnings` on Ubuntu 24.04 at rustc 1.96.0, the toolchain your CI pins; `bash validation/hygiene/fmt-docs.sh` (FMT_DOC_CHECK_GATE_OK) in Git Bash on Windows; the shared-renderer consumers built clean with zero warnings: `cargo heltec-v4-r8` (esp toolchain, Windows), the t-echo firmware with `board-t-echo` on both `softdevice-s140-v6` and `softdevice-s140-v7` (your CI step, WSL), and `cargo clippy --all-targets -- -D warnings` on the desktop face (WSL). On hardware: the Android Hopspot built from this branch runs on an S24 Ultra and a Pixel XL; on the S24 the title bar read 53% against Android's own 53. Not run: on-device rendering on the T-Echo eink or the V4-R8 OLED itself; the mock-display tests cover the renderer, and I will put it on V4-R8 hardware here as soon as you want a photo.
