### PR TITLE
interop: decode harness command output as UTF-8 and let the workspace release

### DIFF
--- a/validation/interop/harness.py
+++ b/validation/interop/harness.py
@@ -22,6 +22,7 @@ from validation.interop.peers.rns_protocol_evidence import (
 
 ROOT = Path(__file__).resolve().parents[2]
 PEER_STOP_TIMEOUT_SECONDS = 5
+WORKSPACE_CLEANUP_TIMEOUT_SECONDS = 10.0
 
 
 class FailureKind(Enum):
@@ -168,6 +169,8 @@ def run_expect_status_with_streams(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             check=False,
             env=command_environment,
         )
@@ -196,6 +199,8 @@ def _run_text_command(
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             check=False,
             env=command_environment,
         )
@@ -626,6 +631,17 @@ class InteropCase:
             print(f"{peer.spec.name} log:", file=sys.stderr)
             print(contents, file=sys.stderr, end="" if contents.endswith("\n") else "\n")
 
+    def _cleanup_workspace(self) -> None:
+        deadline = time.monotonic() + WORKSPACE_CLEANUP_TIMEOUT_SECONDS
+        while True:
+            try:
+                self._temporary.cleanup()
+                return
+            except OSError:
+                if time.monotonic() >= deadline:
+                    raise
+                time.sleep(0.05)
+
     def __enter__(self) -> InteropCase:
         return self
 
@@ -640,7 +656,7 @@ class InteropCase:
             self.stop(peer)
         if kind is not None or evidence_failure is not None:
             self.print_logs()
-        self._temporary.cleanup()
+        self._cleanup_workspace()
         if evidence_failure is not None:
             raise evidence_failure
 


### PR DESCRIPTION
I took the new interop checklist for a run on a Windows host and hit two things in the harness
itself. Both are in `validation/interop/harness.py` and nothing else changes. Neither is an
interoperability problem: the two teardown failures came after their cases had already exchanged
traffic and stock RNS had reported a clean protocol, and the third failed while reading a utility's
output, not on the wire.

**Command output is decoded with the host locale.** `run_expect_status_with_streams` and
`_run_text_command` pass `text=True` with no `encoding`, so Python falls back to the locale codec.
That is UTF-8 on Linux, and Python coerces a C/POSIX locale to UTF-8 as well, so Linux never sees
it. On Windows the codec is cp1252, which Python does not coerce, and
`rnid_local_interop_smoke` dies reading the RSG bytes it exists to check:

```
File "validation/interop/harness.py", line 193, in _run_text_command
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 195
```

`run_checked_bytes` and `read_log` a few lines away already decode UTF-8 with `errors="replace"`,
so this brings the other two readers in line with what the file already does.

**The case workspace is deleted the instant the peers are stopped.** `InteropCase.__exit__`
stops every peer and then calls `self._temporary.cleanup()` with no grace, and on Windows that
raises:

```
FAIL: [WinError 32] The process cannot access the file because it is being used by another
process: '...\tmpd1rb0y86\00-stock-RNS-TCP-server.log'
```

It is peer `00`'s log because peer 0 is created first and `reversed(self._peers)` stops it last, so
it gets the least time of any peer. Whether a case meets this comes down to peer lifetime:
`rns_tcp_server_peer.py` announces in a loop for 90 seconds and has to be stopped, while
`rns_announce_app_data_peer.py` and `rns_plain_group_peer.py` return 0 on success and are long gone
by teardown.

I could not pin what holds the handle, and I would rather say so than guess. What I can say is
that at the moment the delete fails, both peers have already exited and been reaped
(`returncode=1`, observed on three separate runs), so it is not the peer processes themselves and
stopping them harder would not help. What I can measure is that the hold is brief: sampling the retry across six teardowns,
two had to wait at all, and the longest wait was **18.6 ms**. Cleanup now retries for a bounded
10 seconds, then re-raises, so a workspace that is genuinely stuck still fails the case.

## What I ran

Windows 11 Pro 10.0.26200, Python 3.13.6, rustc 1.98.0, stock RNS 1.5.0 from
`validation/interop/requirements.txt`. `python validation/run.py prepare-oracles` builds all four
pinned environments on Windows unchanged.

`interop-plain-group-destinations` is the one interop suite currently declared `any`, so it is the
one the runner will execute here. It passes on Windows, before and after this change:

```
RNS_PROTOCOL_CLEAN peer="stock RNS PLAIN/GROUP peer" interfaces=2
PASS: stock RNS and Prns exchanged exact PLAIN and GROUP payloads in both directions
VALIDATION_SUITE interop-plain-group-destinations passed
```

with `result.json` recording `"platform": "windows"`, `"required_platform": "any"`,
`"status": "passed"`, `"worktree_clean": true`.

To reach the two defects I invoked five `linux`-declared cases directly, with `SMOKE_PYTHON` and
`RPC_SMOKE_PYTHON` set the way `ci.yml` sets them for its interop lane. **That bypasses the
platform gate deliberately and is not a registered suite run**, so please read it as diagnosis, not
as evidence of Windows support:

| case | before | after |
| --- | --- | --- |
| `announce_app_data_interop_smoke` | pass | pass |
| `link_packet_interop_smoke` | pass | pass |
| `tcp_interop_smoke` | WinError 32 | pass |
| `udp_interop_smoke` | WinError 32 | pass |
| `rnid_local_interop_smoke` | UnicodeDecodeError | pass |

One run each way is not enough to say the change is what fixed anything, so I ran the real
`tcp_interop_smoke` six times with the old bare cleanup and six times with the retry:

```
[unpatched] 6/6 WinError-32 failures, 0 clean
[patched]   0/6 WinError-32 failures, 6 clean
```

Worth flagging honestly: one earlier instrumented run cleaned up on the first attempt, so it is not
absolutely deterministic, just reliably reproducible.

I also checked the retry cannot paper over a real failure. Holding an open handle on a file inside
the case workspace, cleanup still raises:

```
CONTROL_BIT after 10.03s (timeout 10.0s): [WinError 32] ... 'held-open.log'
```

The same four cases on Linux with this patch, in WSL Ubuntu against the same pinned RNS 1.5.0, all
pass, so it should be a no-op where CI runs. `FMT_DOC_CHECK_GATE_OK`, `VALIDATION_REGISTRY_OK` and
`TOOLING_REGISTRY_OK` are green on the branch.

I am not asking you to change any suite's `platform`. Those are yours to set, and I have not run
enough of them to have a view. This is just the two things in the way, in case a Windows host is
useful to you or to whoever picks the harness up.
