### PR TITLE
interop: keep decoded output newline-normalised, and let the rnpath drop race settle

### DIFF
--- a/validation/interop/cases/rnpath_interop_smoke.py
+++ b/validation/interop/cases/rnpath_interop_smoke.py
@@ -25,6 +25,7 @@ PRNSD_MANIFEST = ROOT / "prnsd/Cargo.toml"
 STOCK_SERVER = ROOT / "validation/interop/peers/rns_rnpath_server.py"
 BLACKHOLE_HASH = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 RATE_HASH = "33333333333333333333333333333333"
+PATH_DROP_TIMEOUT_SECONDS = 30.0
 SUCCESS = "PASS: Prnsd path queried and mutated the stock RNS utility surfaces"
 
 
@@ -47,6 +48,29 @@ def require_row(
         if row.get("hash") == expected_hash:
             return row
     raise InteropFailure(FailureKind.EVIDENCE_MISSING, failure)
+
+
+def drop_path_when_present(prnsd: Path, config: Path, destination_hash: str) -> None:
+    """Drop a route the stock instance may still be installing or removing.
+
+    A shared instance does not guarantee that a mutation is visible to the next query, so a
+    route read from the path table can already be gone by the time the drop is issued. Retry
+    the read and the drop together, and re-raise once the deadline passes so a route that is
+    genuinely undroppable still fails the case.
+    """
+    deadline = time.monotonic() + PATH_DROP_TIMEOUT_SECONDS
+    while True:
+        wait_for_path_table(prnsd, config, destination_hash)
+        try:
+            run_checked(
+                (str(prnsd), "path", "--config", str(config), "-d", destination_hash),
+                "Prnsd could not drop a stock RNS path",
+            )
+            return
+        except InteropFailure:
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(0.05)
 
 
 def wait_for_path_table(prnsd: Path, config: Path, destination_hash: str) -> str:
@@ -283,11 +307,7 @@ def run() -> None:
             (str(prnsd), "path", "--config", str(config), "-x", via_hash),
             "Prnsd could not drop stock RNS paths through a transport",
         )
-        wait_for_path_table(prnsd, config, peer_hash)
-        run_checked(
-            (str(prnsd), "path", "--config", str(config), "-d", peer_hash),
-            "Prnsd could not drop a stock RNS path",
-        )
+        drop_path_when_present(prnsd, config, peer_hash)
         run_checked(
             (str(prnsd), "path", "--config", str(config), "-D"),
             "Prnsd could not drop stock RNS announce queues",

--- a/validation/interop/harness.py
+++ b/validation/interop/harness.py
@@ -254,13 +254,23 @@ def _command_environment(
     return configured
 
 
+def translate_newlines(decoded: str) -> str:
+    """Apply the universal-newline translation `text=True` used to provide.
+
+    Decoding bytes keeps the platform line ending, so a child that prints on Windows
+    yields carriage-return line feeds where callers and expected values assume line
+    feeds alone.
+    """
+    return decoded.replace("\r\n", "\n").replace("\r", "\n")
+
+
 def decode_command_output(
     output: bytes,
     stream: CommandStream,
     failure: str,
 ) -> str:
     try:
-        return output.decode(COMMAND_OUTPUT_ENCODING)
+        return translate_newlines(output.decode(COMMAND_OUTPUT_ENCODING))
     except UnicodeDecodeError as error:
         raise InteropFailure(
             FailureKind.COMMAND_OUTPUT_INVALID,
@@ -269,7 +279,7 @@ def decode_command_output(
 
 
 def decode_command_diagnostic(output: bytes) -> str:
-    return output.decode(COMMAND_OUTPUT_ENCODING, errors="replace")
+    return translate_newlines(output.decode(COMMAND_OUTPUT_ENCODING, errors="replace"))
 
 
 def cleanup_temporary_directory(


### PR DESCRIPTION
I took the interop suites for a run on Windows now that most of them are declared `any`, and hit two
things. Both are in `validation/interop/`, neither is an interoperability problem, and the second one
also fails on Linux.

## Decoded command output keeps the platform line ending

`9dea8fd3` dropped `text=True` so the encoding could be pinned explicitly, which is the right call.
It also dropped the universal-newline translation that came with it. Decoding bytes preserves
`\r\n`, so on Windows every reader that used to get `\n` now gets `\r\n`, and three of the harness's
own tests fail on current `trunk`:

```
FAILED test_expected_status_command_preserves_output
  AssertionError: 'expected-evidence\r\n' != 'expected-evidence\n'
FAILED test_checked_command_accepts_an_explicit_environment
  AssertionError: 'configured\r\n' != 'configured\n'
FAILED test_expected_status_command_can_preserve_separate_streams
  AssertionError: 'output\r\n' != 'output\n'
```

I bisected rather than guess at it. At `6ac2692b` all three pass on the same host; at `9dea8fd3`
they fail. The fix restores what `text=True` was doing, in one helper both decoders call, so
`decode_command_output` and `decode_command_diagnostic` stay consistent with each other.

It is a no-op where the line ending is already `\n`, which is why CI has not seen it.

## The rnpath drop races the stock instance

`rnpath_interop_smoke` does `path -x <via>`, waits for the peer route to be in the table, then
`path -d <peer>`. In all 25 measured trials `via_hash == peer_hash`, so `-x` drops the peer's own
route and the wait is really waiting for the stock peer to re-announce it. The drop then fails:

```
prnsd path: Unable to drop path to <d75292ff562171a2d0a19baf1cfe379a>. Does it exist?
FAIL: command failed: Prnsd could not drop a stock RNS path
```

The reason is that a shared instance does not promise a mutation is visible to the next query. After
`path -x` returns having reported a non-zero drop count, `path -t` can still list the route. Polling
the table straight after `-x`, four runs on this host:

```
repeat 1   route already gone at the first poll (t=0.050s)
repeat 2   route still listed through t=0.172s, gone by t=0.216s
repeat 3   route still listed through t=0.112s, gone by t=0.164s
repeat 4   route still listed through t=0.184s, gone by t=0.225s
```

So three of four showed the route surviving the drop that had just been acknowledged, and the
window closed somewhere between 0.11 s and 0.23 s. The fourth had already closed inside the first
poll, which is the same race landing the other way. The route is not expiring while this happens:
its `expires` in those runs sits about 604,800 s out, seven days.

`wait_for_path_table` cannot tell "the route came back" from "the drop has not landed yet", so it
can return on a route that is about to disappear, and the `-d` then finds nothing.

I want to be careful about where I am pointing here. This is the stock instance's behaviour, not
prnsd's. The case runs no prnsd daemon, `rns_rnpath_server.py` serves the shared instance, and
`prnsd path` is a client on both calls. I am not suggesting anything needs to change outside this
test.

**Rates**, both arms invoking the case module directly with no instrumentation, same commit:

| platform | failures |
| --- | --- |
| Windows | 7 of 25 |
| Linux (WSL Ubuntu, stock RNS 1.5.0) | 1 of 25 |

So it is not a Windows-only flake, and `local-interop` can hit it.

The fix retries the read and the drop together instead of trying to sequence the race, and re-raises
at a deadline. **Patched: 0 of 25 on Windows** (Fisher exact against the baseline, p = 0.0096).

I checked the retry cannot paper over a real failure. Pointed at a hash that cannot be dropped, the
same loop still fails the case, three runs out of three:

```
run 1 exit=1 elapsed=14.7s :: FAIL: command failed: CONTROL Prnsd could not drop a stock RNS path
run 2 exit=1 elapsed=14.7s :: FAIL: command failed: CONTROL Prnsd could not drop a stock RNS path
run 3 exit=1 elapsed=14.8s :: FAIL: command failed: CONTROL Prnsd could not drop a stock RNS path
```

I also tried the more obvious fix first, waiting for the route to disappear before waiting for it to
come back. That drops to 2 of 25 but invents a new failure, `stock RNS route survived the transport
drop`, because the absent window can be shorter than the poll. Retrying the pair is the one that
holds.

## What I ran

Windows 11 Pro 10.0.26200, Python 3.13.6, rustc 1.98.0, stock RNS 1.5.0 from the pinned oracles;
Linux arm in WSL Ubuntu against the same pinned version.

- `python -m pytest validation/tests/`: **88 passed, 0 failed** on Windows. Three of those fail on
  `trunk` without the first commit.
- `python validation/run.py run --domain interop --platform current`: **34 suites, 34 passed**. The
  same run on unpatched `trunk` gave 33 of 34, `interop-rnpath` being the one that fell over, so
  please read the green as "with these two commits", not as "the domain is reliably green".
- `python validation/run.py verify`: `VALIDATION_REGISTRY_OK`.
- `bash validation/hygiene/fmt-docs.sh`: `FMT_DOC_CHECK_GATE_OK`.
- Linux: `validation.tests.test_interop_harness` OK, so the newline change is a no-op there.

The control for the platform gate still holds, so a pass here means something: `host-python-contract`
is refused with `suite host-python-contract requires linux, current platform is windows`, exit 1.
