### PR TITLE
release: record 0.3.7-hotfix.1 acceptance

### DIFF
--- a/release/acceptance/records/0.3.7-hotfix.1.json
+++ b/release/acceptance/records/0.3.7-hotfix.1.json
@@ -1,0 +1,90 @@
+{
+  "candidate": {
+    "channel": "stable",
+    "manifest_sha256": "46707d484128fd3b97bafb61065223fab4abe772cb8fa58b9e76a4c506e7ebef",
+    "manifest_signature_sha256": "54f1d6a537c668ae0e39b70ab1779d63129ad0339693b18d98b3c434dfb7f85b",
+    "prerelease_published_at": "2026-08-25T02:22:16Z",
+    "signed_candidate_sha256": "a28833cf0e652cf93e024b4f6a34587d9a986b34f6945d69162bc843265d6608",
+    "signing_key_id": "1BF5C4D8B140811A",
+    "source_commit": "f6dab7b3fcb7fe78ccfccfc8ea49dac05df14ee1",
+    "version": "0.3.7-hotfix.1"
+  },
+  "hardware_deferrals": [
+    {
+      "approved_at": "2026-08-25T11:52:11Z",
+      "approved_by": "github:KenAKAFrosty",
+      "basis": "The R8 target builds the same changed ESP32-S3 Wi-Fi, TCP, and SoftAP implementation as the physically checked S3R2 target; R8-specific board initialization is unchanged.",
+      "board": "heltec-v4-r8",
+      "follow_up": "Capture and review an R8 post-flash boot and TCP-enabled startup log after promotion."
+    }
+  ],
+  "hotfix": {
+    "base_manifest_sha256": "6fd1d56c450f45a6569136e2c87906c3437a54df63aca2adc45af13b423d5177",
+    "base_release_record_sha256": "7961c2296769a20a9ef26bfb3bb040f07a6f9f0bf271e2c79ff30db80a2cd115",
+    "base_signed_candidate_sha256": "5815c0e037e6eb76aee65aa53871accf542e7e3b5ce447bcf1f6a0d41952c0a4",
+    "base_source_commit": "95404f41675b4a38907af09253460aeea518e5f2",
+    "base_version": "0.3.7",
+    "changed_boards": [
+      "heltec-v4",
+      "heltec-v4-r8"
+    ],
+    "deferred_hardware": [
+      {
+        "basis": "The R8 target builds the same changed ESP32-S3 Wi-Fi, TCP, and SoftAP implementation as the physically checked S3R2 target; R8-specific board initialization is unchanged.",
+        "board": "heltec-v4-r8",
+        "follow_up": "Capture and review an R8 post-flash boot and TCP-enabled startup log after promotion."
+      }
+    ],
+    "physical_boards": [
+      "heltec-v4"
+    ],
+    "summary": "Heltec V4 S3R2 and S3R8 TCP-client socket-capacity correction and four-station SoftAP rendezvous capacity.",
+    "version": "0.3.7-hotfix.1"
+  },
+  "runs": [
+    {
+      "architecture": "x86_64",
+      "board": "heltec-v4",
+      "browser": {
+        "channel": "stable",
+        "name": "chrome",
+        "version": "152.0.7977.54"
+      },
+      "checks": {
+        "soft-ap-four-rendezvous-listeners": "pass",
+        "tcp-client-enabled-boot": "pass"
+      },
+      "client": {
+        "name": "prns-web-flasher",
+        "version": "0.3.7-hotfix.1"
+      },
+      "completed_at": "2026-08-25T11:52:11Z",
+      "evidence": {
+        "redaction": {
+          "credentials_removed": true,
+          "device_identifiers_removed": true,
+          "local_paths_removed": true,
+          "private_network_data_removed": true,
+          "reviewer": "github:KenAKAFrosty"
+        },
+        "reference": "artifact://qualification/a3eb16aaf9fd2df8c5ef9578536aefa89b0a607fac1f5a38ae2e01222cdb010f",
+        "sha256": "a3eb16aaf9fd2df8c5ef9578536aefa89b0a607fac1f5a38ae2e01222cdb010f"
+      },
+      "hardware_identity": "Physical ESP32-S3R2 Heltec V4; unique device identifiers redacted",
+      "hardware_model": "Heltec LoRa 32 V4 (S3R2)",
+      "hardware_revision": "ESP32-S3 revision v0.2",
+      "os": "linux",
+      "os_version": "Release-owner-attested current Linux x86_64 qualification host",
+      "result": "pass",
+      "scenarios": {
+        "correct-board": "pass",
+        "fresh-install": "pass",
+        "post-flash-boot": "pass",
+        "sparse-write": "pass"
+      },
+      "surface": "web",
+      "tester": "github:KenAKAFrosty"
+    }
+  ],
+  "schema": 6
+}

--- a/tools/tests/test_create_flasher_acceptance.py
+++ b/tools/tests/test_create_flasher_acceptance.py
@@ -301,7 +301,7 @@ class AcceptanceScaffoldTests(unittest.TestCase):
                 json.loads(path.read_text(encoding="utf-8"))["schema"]
                 for path in records.glob("0.3.*.json")
             },
-            {4},
+            {4, 6},
         )
         self.assertEqual(
             {


### PR DESCRIPTION
Records the target-scoped 0.3.7-hotfix.1 qualification against the exact public signed candidate.\n\n- S3R2 Web/Linux row: release-owner attested, with exact-public TCP boot and sparse-plan evidence\n- R8: explicit good-faith hardware deferral with post-promotion follow-up\n- Evidence archive SHA-256: 2bf4236f2f5eb8d150cc22f3b861108ff689f56673681889b0cf552b202d8195\n\nThe candidate-bundled validator passes schema 6.