### PR TITLE
fix(release): keep finalizer candidate immutable

### DIFF
--- a/.github/workflows/flasher-finalize-evidence.yml
+++ b/.github/workflows/flasher-finalize-evidence.yml
@@ -35,6 +35,7 @@ jobs:
       RELEASE_VERSION: ${{ inputs.version }}
       ACCEPTANCE_COMMIT: ${{ inputs.acceptance_commit }}
       QUALIFICATION_EVIDENCE_SHA256: ${{ inputs.qualification_evidence_sha256 }}
+      PYTHONDONTWRITEBYTECODE: "1"
       RUSTUP_TOOLCHAIN: 1.96.0
     steps:
       - name: Checkout reviewed release implementation

--- a/tools/tests/test_flasher_release_custody.py
+++ b/tools/tests/test_flasher_release_custody.py
@@ -1772,6 +1772,7 @@ class FlasherReleaseCustodyTests(unittest.TestCase):
         ):
             self.assertNotIn(forbidden, signing)
         self.assertIn("release/acceptance/records/${RELEASE_VERSION}.json", evidence)
+        self.assertIn('PYTHONDONTWRITEBYTECODE: "1"', evidence)
         self.assertIn("./tools/prns release record -- create", evidence)
         self.assertIn("./tools/prns release record -- verify", evidence)
         self.assertIn("published-evidence", evidence)

--- a/validation/release/workflow-contracts.py
+++ b/validation/release/workflow-contracts.py
@@ -807,6 +807,7 @@ def validate() -> list[str]:
     ).read_text(encoding="utf-8")
     for finalization_gate in (
         "qualification_evidence_sha256:",
+        'PYTHONDONTWRITEBYTECODE: "1"',
         "qualification-evidence-v${RELEASE_VERSION}.tar.gz",
         "target/candidate/qualification/tester-roster.json",
         "--evidence-root target/qualification-evidence",


### PR DESCRIPTION
The schema-6 finalizer executes the candidate-bundled Python validator. Without disabling bytecode writes, Python adds qualification/__pycache__ inside the extracted signed candidate and the subsequent byte-for-byte release-record binding correctly fails.\n\nThis sets PYTHONDONTWRITEBYTECODE=1 for the finalization job and adds custody-contract assertions.\n\nTargeted proof:\n- candidate-bundled schema-6 acceptance validator passes\n- no __pycache__ is created\n- flasher-release-record.py binds the post-validation directory to the exact signed archive\n- workflow contract and custody unit test pass