### PR TITLE
fix(release): scope hotfix promotion custody assets

### DIFF
--- a/tools/release/verify-flasher-release-assets.py
+++ b/tools/release/verify-flasher-release-assets.py
@@ -199,6 +199,28 @@ def verify_remote_inventory(assets: Path, inventory_path: Path) -> None:
             raise ValueError(f"downloaded asset bytes differ from GitHub digest: {name}")
 
 
+def required_custody_assets(candidate: Path, version: str) -> set[str]:
+    names = {
+        f"prns-flasher-candidate-v{version}-signed.tar.gz",
+        f"prns-flasher-candidate-run-v{version}.json",
+        f"prns-flasher-attestation-v{version}.json",
+        f"prns-flasher-attestation-v{version}.metadata.json",
+        f"acceptance-v{version}.json",
+        f"acceptance-v{version}.json.minisig",
+        f"qualification-evidence-v{version}.tar.gz",
+        f"flasher-release-record-v{version}.json",
+        f"flasher-release-record-v{version}.json.minisig",
+    }
+    if not (candidate / "metadata" / "hotfix.json").is_file():
+        names.update(
+            {
+                f"release-record-v{version}.json",
+                f"release-record-v{version}.json.minisig",
+            }
+        )
+    return names
+
+
 def verify(
     candidate: Path, assets: Path, version: str, remote_inventory: Path | None = None
 ) -> None:
@@ -208,19 +230,7 @@ def verify(
     release = manifest.get("release")
     if not isinstance(release, dict):
         raise ValueError("signed candidate release identity is unavailable")
-    custody_names = {
-        f"prns-flasher-candidate-v{version}-signed.tar.gz",
-        f"prns-flasher-candidate-run-v{version}.json",
-        f"prns-flasher-attestation-v{version}.json",
-        f"prns-flasher-attestation-v{version}.metadata.json",
-        f"acceptance-v{version}.json",
-        f"acceptance-v{version}.json.minisig",
-        f"qualification-evidence-v{version}.tar.gz",
-        f"release-record-v{version}.json",
-        f"release-record-v{version}.json.minisig",
-        f"flasher-release-record-v{version}.json",
-        f"flasher-release-record-v{version}.json.minisig",
-    }
+    custody_names = required_custody_assets(candidate, version)
     if not assets.is_dir():
         raise ValueError("downloaded GitHub Release asset directory is unavailable")
     entries = list(assets.iterdir())

--- a/tools/tests/test_flasher_release_custody.py
+++ b/tools/tests/test_flasher_release_custody.py
@@ -1721,6 +1721,29 @@ class FlasherReleaseCustodyTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "schema is unsupported"):
             module.expected_candidate_assets(self.fixture.root, VERSION)
 
+    def test_hotfix_asset_contract_does_not_require_a_suite_release_record(self) -> None:
+        script = SCRIPTS / "verify-flasher-release-assets.py"
+        spec = importlib.util.spec_from_file_location(
+            "verify_flasher_release_assets", script
+        )
+        if spec is None or spec.loader is None:
+            self.fail(f"could not import {script}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        suite_record = f"release-record-v{VERSION}.json"
+        flasher_record = f"flasher-release-record-v{VERSION}.json"
+        regular = module.required_custody_assets(self.fixture.root, VERSION)
+        self.assertIn(suite_record, regular)
+        self.assertIn(flasher_record, regular)
+
+        write_json(self.fixture.root / "metadata" / "hotfix.json", {})
+        hotfix = module.required_custody_assets(self.fixture.root, VERSION)
+        self.assertNotIn(suite_record, hotfix)
+        self.assertNotIn(f"{suite_record}.minisig", hotfix)
+        self.assertIn(flasher_record, hotfix)
+        self.assertIn(f"{flasher_record}.minisig", hotfix)
+
     def test_workflows_preserve_exact_candidate_custody_boundaries(self) -> None:
         candidate = (ROOT / ".github/workflows/flasher-candidate.yml").read_text()
         signing = (ROOT / ".github/workflows/flasher-sign.yml").read_text()


### PR DESCRIPTION
Target-scoped flasher hotfixes do not have a unified suite release record. Promotion incorrectly required release-record-vVERSION.json in addition to the signed flasher-release-record-vVERSION.json, so it failed closed before deployment.\n\nThis keeps the suite record mandatory for normal releases while omitting it only when the exact signed candidate contains metadata/hotfix.json. Candidate, acceptance, evidence, attestation, and flasher-record requirements remain unchanged.\n\nTests cover both the normal suite custody set and the hotfix-specific set; the existing full public asset verifier test also passes.