### PR TITLE
fix(release): preserve historical rollback assets

### DIFF
--- a/tools/release/verify-flasher-release-assets.py
+++ b/tools/release/verify-flasher-release-assets.py
@@ -122,7 +122,6 @@ def expected_candidate_assets(candidate: Path, version: str) -> dict[str, Path]:
         / "qualification"
         / "flasher_acceptance_contract.py",
         "flasher_tester_roster.py": candidate / "qualification" / "flasher_tester_roster.py",
-        "flasher_hotfix.py": candidate / "qualification" / "flasher_hotfix.py",
         "package-flasher-qualification-evidence.py": candidate
         / "qualification"
         / "package-flasher-qualification-evidence.py",
@@ -144,9 +143,15 @@ def expected_candidate_assets(candidate: Path, version: str) -> dict[str, Path]:
         sources["flasher_manifest.py"] = (
             candidate / "qualification" / "flasher_manifest.py"
         )
-    if (candidate / "metadata" / "hotfix.json").is_file():
+    hotfix_metadata = candidate / "metadata" / "hotfix.json"
+    hotfix_helper = candidate / "qualification" / "flasher_hotfix.py"
+    if hotfix_helper.is_file():
+        sources["flasher_hotfix.py"] = hotfix_helper
+    elif hotfix_metadata.is_file():
+        raise ValueError("signed hotfix candidate release asset is missing: flasher_hotfix.py")
+    if hotfix_metadata.is_file():
         sources[f"hotfix-inheritance-v{version}.json"] = (
-            candidate / "metadata" / "hotfix.json"
+            hotfix_metadata
         )
         sources[f"hotfix-spec-v{version}.json"] = (
             candidate / "qualification" / "hotfix.json"

--- a/tools/tests/test_flasher_release_custody.py
+++ b/tools/tests/test_flasher_release_custody.py
@@ -1744,6 +1744,26 @@ class FlasherReleaseCustodyTests(unittest.TestCase):
         self.assertIn(flasher_record, hotfix)
         self.assertIn(f"{flasher_record}.minisig", hotfix)
 
+    def test_historical_candidate_need_not_contain_the_new_hotfix_helper(self) -> None:
+        self.assertEqual(self.sign_candidate().returncode, 0)
+        script = SCRIPTS / "verify-flasher-release-assets.py"
+        spec = importlib.util.spec_from_file_location(
+            "verify_flasher_release_assets", script
+        )
+        if spec is None or spec.loader is None:
+            self.fail(f"could not import {script}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        helper = self.fixture.root / "qualification" / "flasher_hotfix.py"
+        helper.unlink()
+        historical = module.expected_candidate_assets(self.fixture.root, VERSION)
+        self.assertNotIn("flasher_hotfix.py", historical)
+
+        write_json(self.fixture.root / "metadata" / "hotfix.json", {})
+        with self.assertRaisesRegex(ValueError, "flasher_hotfix.py"):
+            module.expected_candidate_assets(self.fixture.root, VERSION)
+
     def test_workflows_preserve_exact_candidate_custody_boundaries(self) -> None:
         candidate = (ROOT / ".github/workflows/flasher-candidate.yml").read_text()
         signing = (ROOT / ".github/workflows/flasher-sign.yml").read_text()


### PR DESCRIPTION
Promotion now reaches rollback-baseline verification, where current asset policy incorrectly requires the newly introduced flasher_hotfix.py helper from the already-published 0.3.7 candidate that predates it.\n\nThe helper is now exact-candidate-driven:\n- included and verified whenever the signed candidate contains it\n- mandatory whenever signed hotfix metadata exists\n- not retroactively required from historical non-hotfix candidates\n\nTargeted tests cover the historical absence, hotfix mandatory boundary, hotfix suite-record scope, and full public asset inventory.