### PR TITLE
Release T-Beam TCP hotfix scope

### DIFF
--- a/release/flash/hotfixes/0.3.7-hotfix.2.json
+++ b/release/flash/hotfixes/0.3.7-hotfix.2.json
@@ -1,0 +1,33 @@
+{
+  "changed_boards": [
+    "t-beam-supreme"
+  ],
+  "qualification": {
+    "deferred_hardware": [],
+    "physical_boards": [
+      "t-beam-supreme"
+    ],
+    "required_checks": [
+      "tcp-client-enabled-boot"
+    ],
+    "required_scenarios": [
+      "correct-board",
+      "fresh-install",
+      "post-flash-boot",
+      "sparse-write"
+    ],
+    "surfaces": [
+      "cli"
+    ]
+  },
+  "release": {
+    "base_manifest_sha256": "46707d484128fd3b97bafb61065223fab4abe772cb8fa58b9e76a4c506e7ebef",
+    "base_release_record_sha256": "c538f432275ea81f020193698680333bbb0b9765fe928604431eb2ff2bed4069",
+    "base_signed_candidate_sha256": "a28833cf0e652cf93e024b4f6a34587d9a986b34f6945d69162bc843265d6608",
+    "base_source_commit": "f6dab7b3fcb7fe78ccfccfc8ea49dac05df14ee1",
+    "base_version": "0.3.7-hotfix.1",
+    "version": "0.3.7-hotfix.2"
+  },
+  "schema": 1,
+  "summary": "LilyGO T-Beam Supreme TCP-client socket-capacity correction."
+}


### PR DESCRIPTION
## Summary

- declare immutable `0.3.7-hotfix.2`
- rebuild only LilyGO T-Beam Supreme
- inherit all other signed `0.3.7-hotfix.1` artifacts
- require one targeted physical CLI qualification for TCP-enabled boot

## Validation

- `./tools/prns release hotfix -- identity --repository . --version 0.3.7-hotfix.2`
- `python3 -m unittest tools.tests.test_flasher_hotfix tools.tests.test_validate_flasher_acceptance tools.tests.test_flasher_release_custody` (71 tests)
- attached T-Beam Supreme joined Wi-Fi, obtained DHCP, and established the configured TCP session without panic