### PR TITLE
fix(release): resolve chained hotfix roster root

### DIFF
--- a/tools/release/flasher_hotfix.py
+++ b/tools/release/flasher_hotfix.py
@@ -581,7 +581,13 @@ def main() -> int:
     identity.add_argument("--version")
     identity.add_argument(
         "--format",
-        choices=("json", "version", "base-version", "changed-boards"),
+        choices=(
+            "json",
+            "version",
+            "base-version",
+            "roster-version",
+            "changed-boards",
+        ),
         default="json",
     )
     compose_parser = subparsers.add_parser("compose")
@@ -613,6 +619,8 @@ def main() -> int:
                 print(version)
             elif arguments.format == "base-version":
                 print(spec.base_version if spec is not None else version)
+            elif arguments.format == "roster-version":
+                print(spec.roster_version if spec is not None else version)
             else:
                 for board in spec.changed_boards if spec is not None else ():
                     print(board)

--- a/tools/release/verify-flasher-candidate.sh
+++ b/tools/release/verify-flasher-candidate.sh
@@ -30,7 +30,7 @@ roster_version="$version"
 if [[ -f "$candidate/qualification/hotfix.json" ]]; then
     roster_version="$(
         "$root/tools/prns" release hotfix -- identity \
-            --repository "$root" --version "$version" --format base-version
+            --repository "$root" --version "$version" --format roster-version
     )"
 fi
 python3 "$root/tools/release/validate-flasher-tester-roster.py" \

--- a/tools/tests/test_flasher_hotfix.py
+++ b/tools/tests/test_flasher_hotfix.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 from pathlib import Path
 import shutil
+import subprocess
 import tempfile
 import unittest
 
@@ -297,11 +298,34 @@ class HotfixCustodyTests(unittest.TestCase):
     def test_later_hotfix_may_inherit_an_earlier_hotfix(self) -> None:
         self.spec["release"]["version"] = "0.3.7-hotfix.2"
         self.spec["release"]["base_version"] = HOTFIX_VERSION
-        path = self.root / "0.3.7-hotfix.2.json"
+        path = (
+            self.repository
+            / "release"
+            / "flash"
+            / "hotfixes"
+            / "0.3.7-hotfix.2.json"
+        )
         write_json(path, self.spec)
         parsed = parse_spec(path, {"heltec-v4", "heltec-v4-r8"})
         self.assertEqual(parsed.roster_version, BASE_VERSION)
         self.assertEqual(parsed.base_version, HOTFIX_VERSION)
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPTS / "flasher_hotfix.py"),
+                "identity",
+                "--repository",
+                str(self.repository),
+                "--version",
+                "0.3.7-hotfix.2",
+                "--format",
+                "roster-version",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.stdout.strip(), BASE_VERSION)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- keep chained-hotfix inheritance pinned to the immediate base release
- resolve tester-roster authority to the suite root for signed candidate verification
- add a hotfix.2 → hotfix.1 → suite-root regression

## Validation
- `python3 -m unittest tools.tests.test_flasher_hotfix tools.tests.test_flasher_release_custody tools.tests.test_validate_flasher_acceptance tools.tests.test_flasher_rollback` (80 tests)
- exact repository identity: base `0.3.7-hotfix.1`, roster `0.3.7`
- repository pre-push validation