### PR TITLE
hopspot: refine battery percentage indicator

### DIFF
--- a/personal-hopspot/core/src/screen/render/glyphs.rs
+++ b/personal-hopspot/core/src/screen/render/glyphs.rs
@@ -6,90 +6,129 @@ use embedded_graphics::primitives::{Line, Rectangle};
 use embedded_graphics::text::{Baseline, Text};
 
 use crate::screen::CardKind;
-use crate::{ChargingState, ExternalPowerState, PowerSnapshot};
+use crate::{ExternalPowerState, PowerSnapshot};
 
 use super::layout::*;
 use super::primitives::{draw_pattern_colored, fill, line, line_colored, stroke};
 
-/// How wide the title-bar battery zone is: "100%" in FONT_5X8 exactly.
-const BATTERY_ZONE_W: i32 = 4 * FONT_5X8_CHAR_W;
+const BATTERY_BODY_W: i32 = 15;
+const BATTERY_BODY_H: u32 = 9;
+const BATTERY_PLUG_W: i32 = 5;
+const BATTERY_ZONE_W: i32 = BATTERY_BODY_W + BATTERY_PLUG_W;
+const BATTERY_INNER_W: i32 = BATTERY_BODY_W - 2;
 
-/// The battery readout, drawn in the background color (it sits on the inverted title bar): the
-/// percentage as text, right-aligned in a 20px zone so the digits do not wander as they shrink,
-/// a blinking plug cue at the left of the zone while charging, or `--%` for unknown. The exact
-/// number is shown because the gauge already knows it; quantized bars threw that precision away
-/// right when it matters most, at the bottom of the discharge.
+const TINY_DIGITS: [[&str; 5]; 10] = [
+    ["###", "# #", "# #", "# #", "###"],
+    [" # ", "## ", " # ", " # ", "###"],
+    ["###", "  #", "###", "#  ", "###"],
+    ["###", "  #", "###", "  #", "###"],
+    ["# #", "# #", "###", "  #", "  #"],
+    ["###", "#  ", "###", "  #", "###"],
+    ["###", "#  ", "###", "# #", "###"],
+    ["###", "  #", "  #", "  #", "  #"],
+    ["###", "# #", "###", "# #", "###"],
+    ["###", "# #", "###", "  #", "###"],
+];
+
+/// The battery readout on the inverted title bar. The original outlined silhouette stays intact,
+/// but its four quantized bars are replaced by the exact level as one to three digits. The
+/// enclosure makes `%` implicit; unknown remains `--`. External power restores the original
+/// right-side plug as a steady, independent presence indicator.
 pub(in crate::screen) fn draw_battery<D: DrawTarget<Color = BinaryColor>>(
     display: &mut D,
     x: i32,
     y: i32,
     state: PowerSnapshot,
-    charging_tier_visible: bool,
 ) {
-    let mut text: heapless::String<4> = heapless::String::new();
-    match state.battery() {
-        Some(pct) => {
-            let _ = core::fmt::write(&mut text, format_args!("{}%", pct.get()));
-        }
-        None => {
-            let _ = text.push_str("--%");
-        }
-    }
-    let text_x = x + BATTERY_ZONE_W - text.len() as i32 * FONT_5X8_CHAR_W;
-    let small = MonoTextStyle::new(&FONT_5X8, BinaryColor::Off);
-    let _ = Text::with_baseline(&text, Point::new(text_x, y), small, Baseline::Top).draw(display);
-    // External power keeps a compact plug cue at the left of the zone while the cell is below
-    // full (or unknown): steady when merely present, blinking on the shared cadence while the
-    // battery is actively charging. At 100% the text fills the whole zone and the cue is dropped:
-    // a full cell reads as done.
-    let below_full = state.battery().is_none_or(|percent| percent.get() < 100);
-    let plug = match state.external_power() {
-        ExternalPowerState::Present {
-            charging: ChargingState::Charging,
-        } => charging_tier_visible,
-        ExternalPowerState::Present { .. } => true,
-        ExternalPowerState::Absent | ExternalPowerState::Unknown => false,
-    };
-    if plug && below_full && text_x - x >= FONT_5X8_CHAR_W {
+    let outline = stroke(BinaryColor::Off);
+    let _ = Rectangle::new(
+        Point::new(x, y),
+        Size::new(BATTERY_BODY_W as u32, BATTERY_BODY_H),
+    )
+    .into_styled(outline)
+    .draw(display);
+    let solid = fill(BinaryColor::Off);
+    let _ = Rectangle::new(Point::new(x - 2, y + 3), Size::new(2, 3))
+        .into_styled(solid)
+        .draw(display);
+    draw_battery_level(display, x, y, state.battery().map(|percent| percent.get()));
+
+    if matches!(state.external_power(), ExternalPowerState::Present { .. }) {
         draw_charging_plug(display, x, y);
     }
 }
 
-fn battery_charge_tier_visible(animation_ms: u64) -> bool {
-    (animation_ms / BATTERY_CHARGE_BLINK_MS).is_multiple_of(2)
+fn draw_battery_level<D: DrawTarget<Color = BinaryColor>>(
+    display: &mut D,
+    x: i32,
+    y: i32,
+    percent: Option<u8>,
+) {
+    let Some(percent) = percent else {
+        let unknown = ["   ", "   ", "###", "   ", "   "];
+        draw_pattern_colored(display, x + 4, y + 2, &unknown, BinaryColor::Off);
+        draw_pattern_colored(display, x + 8, y + 2, &unknown, BinaryColor::Off);
+        return;
+    };
+
+    let digits = if percent >= 100 {
+        3
+    } else if percent >= 10 {
+        2
+    } else {
+        1
+    };
+    let text_w = digits * 3 + (digits - 1);
+    let mut digit_x = x + 1 + (BATTERY_INNER_W - text_w) / 2;
+    let mut divisor = match digits {
+        3 => 100,
+        2 => 10,
+        _ => 1,
+    };
+    while divisor != 0 {
+        let digit = (percent / divisor) % 10;
+        draw_pattern_colored(
+            display,
+            digit_x,
+            y + 2,
+            &TINY_DIGITS[digit as usize],
+            BinaryColor::Off,
+        );
+        digit_x += 4;
+        divisor /= 10;
+    }
 }
 
 fn draw_charging_plug<D: DrawTarget<Color = BinaryColor>>(display: &mut D, x: i32, y: i32) {
     let outline = stroke(BinaryColor::Off);
     let solid = fill(BinaryColor::Off);
-    let _ = Rectangle::new(Point::new(x, y + 2), Size::new(3, 5))
+    let _ = Rectangle::new(Point::new(x + BATTERY_BODY_W, y + 2), Size::new(4, 5))
         .into_styled(solid)
         .draw(display);
-    let _ = Line::new(Point::new(x + 2, y + 3), Point::new(x + 4, y + 3))
-        .into_styled(outline)
-        .draw(display);
-    let _ = Line::new(Point::new(x + 2, y + 5), Point::new(x + 4, y + 5))
-        .into_styled(outline)
-        .draw(display);
+    let _ = Line::new(
+        Point::new(x + BATTERY_BODY_W + 4, y + 3),
+        Point::new(x + BATTERY_BODY_W - 1, y + 3),
+    )
+    .into_styled(outline)
+    .draw(display);
+    let _ = Line::new(
+        Point::new(x + BATTERY_BODY_W + 4, y + 5),
+        Point::new(x + BATTERY_BODY_W - 1, y + 5),
+    )
+    .into_styled(outline)
+    .draw(display);
 }
 
 pub(super) fn draw_title_bar<D: DrawTarget<Color = BinaryColor>>(
     display: &mut D,
     battery: PowerSnapshot,
-    animation_ms: u64,
 ) {
     let _ = Rectangle::new(Point::new(0, 0), Size::new(WIDTH as u32, TITLE_H as u32))
         .into_styled(fill(BinaryColor::On))
         .draw(display);
     let small = MonoTextStyle::new(&FONT_5X8, BinaryColor::Off);
     let _ = Text::with_baseline("Personal", Point::new(2, 1), small, Baseline::Top).draw(display);
-    draw_battery(
-        display,
-        WIDTH - BATTERY_ZONE_W,
-        1,
-        battery,
-        battery_charge_tier_visible(animation_ms),
-    );
+    draw_battery(display, WIDTH - BATTERY_ZONE_W, 1, battery);
     let big = MonoTextStyle::new(&FONT_9X15_BOLD, BinaryColor::Off);
     let _ = Text::with_baseline("Hopspot", Point::new(1, 10), big, Baseline::Top).draw(display);
 }

--- a/personal-hopspot/core/src/screen/render/layout.rs
+++ b/personal-hopspot/core/src/screen/render/layout.rs
@@ -60,4 +60,3 @@ pub(in crate::screen) const FONT_4X6_CHAR_W: i32 = 4;
 pub(super) const GLOBAL_MENU_ITEM_STEP: i32 = 11;
 pub(in crate::screen) const SPLASH_TEXT_X: i32 = 2;
 pub(super) const SPLASH_LINE_STEP: i32 = 11;
-pub(super) const BATTERY_CHARGE_BLINK_MS: u64 = 600;

--- a/personal-hopspot/core/src/screen/render/mod.rs
+++ b/personal-hopspot/core/src/screen/render/mod.rs
@@ -33,7 +33,6 @@ pub struct RenderFrame<'frame, 'docs> {
     pub gnss: Option<GnssSnapshot>,
     pub state: &'frame UiState,
     pub interface_menu_details: &'frame InterfaceMenuDetails,
-    pub animation_ms: u64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -63,12 +62,11 @@ pub fn render<D: DrawTarget<Color = BinaryColor>>(display: &mut D, frame: Render
         gnss,
         state,
         interface_menu_details,
-        animation_ms,
     } = frame;
     let cards = content.cards;
     let local_docs = content.local_docs;
     let _ = display.clear(BinaryColor::Off);
-    draw_title_bar(display, battery, animation_ms);
+    draw_title_bar(display, battery);
 
     if let Some(notice) = state.notice() {
         draw_notice(display, notice);
@@ -175,7 +173,7 @@ pub fn render<D: DrawTarget<Color = BinaryColor>>(display: &mut D, frame: Render
 
 pub fn splash<D: DrawTarget<Color = BinaryColor>>(display: &mut D, content: SplashContent) {
     let _ = display.clear(BinaryColor::Off);
-    draw_title_bar(display, PowerSnapshot::UNKNOWN, 0);
+    draw_title_bar(display, PowerSnapshot::UNKNOWN);
     let style = MonoTextStyle::new(&FONT_6X10, BinaryColor::On);
     let mut y = CARD_TOP + 4;
     for line in content.lines() {

--- a/personal-hopspot/core/src/screen/tests/mod.rs
+++ b/personal-hopspot/core/src/screen/tests/mod.rs
@@ -119,7 +119,6 @@ fn render_with_state<D: DrawTarget<Color = BinaryColor>>(
             gnss: None,
             state,
             interface_menu_details: &interface_menu_details,
-            animation_ms: 0,
         },
     );
 }
@@ -143,7 +142,6 @@ fn render_with_local_docs<D: DrawTarget<Color = BinaryColor>>(
             gnss: None,
             state,
             interface_menu_details: &interface_menu_details,
-            animation_ms: 0,
         },
     );
 }

--- a/personal-hopspot/core/src/screen/tests/render/flow.rs
+++ b/personal-hopspot/core/src/screen/tests/render/flow.rs
@@ -17,7 +17,6 @@ fn gnss_panel_stays_between_the_global_row_and_selected_interface() {
             gnss: Some(GnssSnapshot::Searching { satellites: 7 }),
             state: &state,
             interface_menu_details: &interface_menu_details,
-            animation_ms: 0,
         },
     );
 

--- a/personal-hopspot/core/src/screen/tests/render/glyphs.rs
+++ b/personal-hopspot/core/src/screen/tests/render/glyphs.rs
@@ -9,6 +9,12 @@ fn charging(percent: u8) -> PowerSnapshot {
     )
 }
 
+fn battery_display() -> MockDisplay<BinaryColor> {
+    let mut display = MockDisplay::new();
+    display.set_allow_overdraw(true);
+    display
+}
+
 #[test]
 fn usb_icon_draws_full_width_tongue() {
     let mut display = MockDisplay::new();
@@ -47,20 +53,9 @@ fn ble_icon_reads_as_bluetooth_rune() {
     ]);
 }
 
-/// What the readout should look like: the same text draw the implementation makes, nothing else.
-fn expected_battery_text(text: &str, x: i32, y: i32) -> MockDisplay<BinaryColor> {
-    use embedded_graphics::mono_font::iso_8859_1::FONT_5X8;
-    use embedded_graphics::mono_font::MonoTextStyle;
-    use embedded_graphics::text::{Baseline, Text};
-    let mut display = MockDisplay::new();
-    let small = MonoTextStyle::new(&FONT_5X8, BinaryColor::Off);
-    let _ = Text::with_baseline(text, Point::new(x, y), small, Baseline::Top).draw(&mut display);
-    display
-}
-
 #[test]
-fn level_battery_shows_the_exact_percent() {
-    let mut display = MockDisplay::new();
+fn level_battery_keeps_the_silhouette_and_shows_the_exact_number() {
+    let mut display = battery_display();
 
     draw_battery(
         &mut display,
@@ -70,69 +65,115 @@ fn level_battery_shows_the_exact_percent() {
             Some(BatteryPercent::saturating(97)),
             ExternalPowerState::Absent,
         ),
-        true,
     );
 
-    // Three characters, right-aligned in the 20px zone: text begins at 2 + 20 - 15.
-    assert_eq!(display, expected_battery_text("97%", 7, 0));
+    // The original 15x9 silhouette and left terminal remain.
+    assert_eq!(display.get_pixel(Point::new(2, 0)), Some(BinaryColor::Off));
+    assert_eq!(display.get_pixel(Point::new(16, 8)), Some(BinaryColor::Off));
+    assert_eq!(display.get_pixel(Point::new(0, 4)), Some(BinaryColor::Off));
+    // "97" is centered inside: the 9 starts at x=6 and the 7 at x=10.
+    for x in 6..=8 {
+        assert_eq!(display.get_pixel(Point::new(x, 2)), Some(BinaryColor::Off));
+    }
+    assert_eq!(display.get_pixel(Point::new(6, 3)), Some(BinaryColor::Off));
+    assert_eq!(display.get_pixel(Point::new(7, 3)), None);
+    assert_eq!(display.get_pixel(Point::new(8, 3)), Some(BinaryColor::Off));
+    for x in 10..=12 {
+        assert_eq!(display.get_pixel(Point::new(x, 2)), Some(BinaryColor::Off));
+    }
+    assert_eq!(display.get_pixel(Point::new(10, 5)), None);
+    assert_eq!(display.get_pixel(Point::new(12, 5)), Some(BinaryColor::Off));
 }
 
 #[test]
-fn percent_stays_right_aligned_as_digits_shrink() {
-    let mut display = MockDisplay::new();
+fn one_and_three_digit_levels_stay_centered_inside_the_battery() {
+    let mut one_digit = battery_display();
 
     draw_battery(
-        &mut display,
+        &mut one_digit,
         2,
         0,
         PowerSnapshot::new(
             Some(BatteryPercent::saturating(7)),
             ExternalPowerState::Absent,
         ),
-        true,
     );
 
-    // Two characters: text begins at 2 + 20 - 10. A drained cell reads "7%", never "70%".
-    assert_eq!(display, expected_battery_text("7%", 12, 0));
+    // A single 7 occupies x=8..10 in the center, with no implied trailing zero.
+    for x in 8..=10 {
+        assert_eq!(
+            one_digit.get_pixel(Point::new(x, 2)),
+            Some(BinaryColor::Off)
+        );
+    }
+    assert_eq!(one_digit.get_pixel(Point::new(8, 5)), None);
+    assert_eq!(
+        one_digit.get_pixel(Point::new(10, 5)),
+        Some(BinaryColor::Off)
+    );
+
+    let mut three_digits = battery_display();
+    draw_battery(
+        &mut three_digits,
+        2,
+        0,
+        PowerSnapshot::new(
+            Some(BatteryPercent::saturating(100)),
+            ExternalPowerState::Absent,
+        ),
+    );
+
+    // "100" fills eleven of the thirteen interior pixels without touching the shell edge.
+    assert_eq!(three_digits.get_pixel(Point::new(3, 4)), None);
+    assert_eq!(
+        three_digits.get_pixel(Point::new(5, 2)),
+        Some(BinaryColor::Off)
+    );
+    assert_eq!(
+        three_digits.get_pixel(Point::new(8, 2)),
+        Some(BinaryColor::Off)
+    );
+    assert_eq!(
+        three_digits.get_pixel(Point::new(14, 6)),
+        Some(BinaryColor::Off)
+    );
+    assert_eq!(three_digits.get_pixel(Point::new(15, 4)), None);
 }
 
 #[test]
-fn unknown_battery_reads_as_dashes_not_a_number() {
-    let mut display = MockDisplay::new();
+fn unknown_battery_keeps_the_shell_and_reads_as_dashes() {
+    let mut display = battery_display();
 
-    draw_battery(&mut display, 2, 0, PowerSnapshot::UNKNOWN, true);
+    draw_battery(&mut display, 2, 0, PowerSnapshot::UNKNOWN);
 
-    assert_eq!(display, expected_battery_text("--%", 7, 0));
+    assert_eq!(display.get_pixel(Point::new(2, 0)), Some(BinaryColor::Off));
+    assert_eq!(display.get_pixel(Point::new(16, 8)), Some(BinaryColor::Off));
+    for x in 6..=8 {
+        assert_eq!(display.get_pixel(Point::new(x, 4)), Some(BinaryColor::Off));
+    }
+    for x in 10..=12 {
+        assert_eq!(display.get_pixel(Point::new(x, 4)), Some(BinaryColor::Off));
+    }
+    assert_eq!(display.get_pixel(Point::new(9, 4)), None);
 }
 
 #[test]
-fn charging_battery_shows_the_plug_on_the_visible_phase() {
-    let mut display = MockDisplay::new();
-    display.set_allow_overdraw(true);
+fn charging_battery_shows_the_steady_plug() {
+    let mut display = battery_display();
 
-    draw_battery(&mut display, 2, 0, charging(62), true);
+    draw_battery(&mut display, 2, 0, charging(62));
 
-    // The plug body sits at the left edge of the zone, prongs pointing at the digits.
-    assert_eq!(display.get_pixel(Point::new(2, 4)), Some(BinaryColor::Off));
-    assert_eq!(display.get_pixel(Point::new(3, 2)), Some(BinaryColor::Off));
-    assert_eq!(display.get_pixel(Point::new(6, 3)), Some(BinaryColor::Off));
-    assert_eq!(display.get_pixel(Point::new(6, 5)), Some(BinaryColor::Off));
-}
-
-#[test]
-fn charging_battery_hides_the_plug_on_the_off_phase() {
-    let mut display = MockDisplay::new();
-
-    draw_battery(&mut display, 2, 0, charging(62), false);
-
-    // Off phase is the text alone; the blink carries the "charging" signal.
-    assert_eq!(display, expected_battery_text("62%", 7, 0));
+    // The original plug returns at the right edge of the battery body.
+    for x in 17..=20 {
+        assert_eq!(display.get_pixel(Point::new(x, 4)), Some(BinaryColor::Off));
+    }
+    assert_eq!(display.get_pixel(Point::new(21, 3)), Some(BinaryColor::Off));
+    assert_eq!(display.get_pixel(Point::new(23, 4)), None);
 }
 
 #[test]
 fn externally_powered_battery_keeps_the_plug_steady_when_charging_is_unknown() {
-    let mut display = MockDisplay::new();
-    display.set_allow_overdraw(true);
+    let mut display = battery_display();
 
     draw_battery(
         &mut display,
@@ -142,25 +183,25 @@ fn externally_powered_battery_keeps_the_plug_steady_when_charging_is_unknown() {
             Some(BatteryPercent::saturating(53)),
             ExternalPowerState::from_presence(true),
         ),
-        false,
     );
 
-    // Presence-only hosts cannot distinguish charging from idle. Their plug remains visible even
-    // during the phase where an actively charging battery would blink it off.
-    assert_eq!(display.get_pixel(Point::new(2, 4)), Some(BinaryColor::Off));
-    assert_eq!(display.get_pixel(Point::new(3, 2)), Some(BinaryColor::Off));
-    assert_eq!(display.get_pixel(Point::new(6, 3)), Some(BinaryColor::Off));
-    assert_eq!(display.get_pixel(Point::new(6, 5)), Some(BinaryColor::Off));
+    // Presence-only hosts cannot distinguish charging from idle. External power is the only fact
+    // the steady plug communicates, so that is sufficient to keep it visible.
+    assert_eq!(display.get_pixel(Point::new(17, 4)), Some(BinaryColor::Off));
+    assert_eq!(display.get_pixel(Point::new(21, 3)), Some(BinaryColor::Off));
 }
 
 #[test]
-fn full_charging_battery_drops_the_plug_for_the_full_width_number() {
-    let mut display = MockDisplay::new();
+fn full_charging_battery_keeps_100_and_the_plug() {
+    let mut display = battery_display();
 
-    draw_battery(&mut display, 2, 0, charging(100), true);
+    draw_battery(&mut display, 2, 0, charging(100));
 
-    // "100%" fills the whole zone; a full cell reads as done, no cue needed.
-    assert_eq!(display, expected_battery_text("100%", 2, 0));
+    assert_eq!(display.get_pixel(Point::new(2, 0)), Some(BinaryColor::Off));
+    assert_eq!(display.get_pixel(Point::new(5, 2)), Some(BinaryColor::Off));
+    assert_eq!(display.get_pixel(Point::new(14, 6)), Some(BinaryColor::Off));
+    assert_eq!(display.get_pixel(Point::new(17, 4)), Some(BinaryColor::Off));
+    assert_eq!(display.get_pixel(Point::new(21, 3)), Some(BinaryColor::Off));
 }
 
 #[test]

--- a/personal-hopspot/desktop/src/desktop/ui.rs
+++ b/personal-hopspot/desktop/src/desktop/ui.rs
@@ -838,10 +838,6 @@ pub(super) fn run_window(handles: WindowHandles) {
                 &snapshots,
             );
             let battery = screen::BatteryGauge::lipo().sample(&mut screen::NoBattery);
-            let animation_ms = activity_started
-                .elapsed()
-                .as_millis()
-                .min(u128::from(u64::MAX)) as u64;
             screen::render(
                 &mut display,
                 screen::RenderFrame {
@@ -850,7 +846,6 @@ pub(super) fn run_window(handles: WindowHandles) {
                     gnss: None,
                     state: &ui_state,
                     interface_menu_details: &interface_menu_details,
-                    animation_ms,
                 },
             );
             window.update(&display);

--- a/personal-hopspot/embedded/esp32/src/s3/firmware.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/firmware.rs
@@ -397,6 +397,7 @@ pub(super) async fn run_core<B: Esp32S3Board>(
         #[cfg(feature = "lora")]
         let mut working_lora_profile = lora_profile;
         let mut battery_state = screen::PowerSnapshot::UNKNOWN;
+        let mut sampled_battery_state = screen::PowerSnapshot::UNKNOWN;
         let mut battery_gauge = screen::BatteryGauge::lipo();
         let active_ap_ssid = (radio_mode == RadioMode::AccessPoint).then(ap_ssid);
         let local_docs = active_ap_ssid
@@ -405,7 +406,8 @@ pub(super) async fn run_core<B: Esp32S3Board>(
                 wifi_ssid,
                 docs_host: CAPTIVE_PORTAL_HOST,
             });
-        let mut ticks_to_battery: u8 = 0;
+        let mut ticks_to_battery_sample: u8 = 0;
+        let mut ticks_to_battery_display: u8 = 0;
         let mut activity = screen::CardActivityTracker::<8>::new();
         let mut notice_until_ms =
             startup_notice.map(|notice| (embassy_time::Instant::now().as_millis() + 5_000, notice));
@@ -419,9 +421,20 @@ pub(super) async fn run_core<B: Esp32S3Board>(
         let mut persistence_notice = screen::PersistenceNotice::new();
         let mut first_render_pending = true;
         loop {
-            if ticks_to_battery == 0 {
-                battery_state = battery_gauge.sample(&mut battery_source);
-                ticks_to_battery = RENDER_TICKS_PER_BATTERY;
+            if ticks_to_battery_sample == 0 {
+                sampled_battery_state = battery_gauge.sample(&mut battery_source);
+                ticks_to_battery_sample = RENDER_TICKS_PER_BATTERY_SAMPLE;
+            }
+            if ticks_to_battery_display == 0 {
+                battery_state = sampled_battery_state;
+                ticks_to_battery_display = RENDER_TICKS_PER_BATTERY_DISPLAY;
+            } else {
+                // The number is deliberately calm, but the plug should still react to the latest
+                // two-second charging/presence observation.
+                battery_state = screen::PowerSnapshot::new(
+                    battery_state.battery(),
+                    sampled_battery_state.external_power(),
+                );
             }
 
             let snapshots = build_snapshots(
@@ -504,7 +517,6 @@ pub(super) async fn run_core<B: Esp32S3Board>(
                         gnss: ui_state.gnss_visible().then(B::Gnss::snapshot).flatten(),
                         state: &ui_state,
                         interface_menu_details: &interface_menu_details,
-                        animation_ms: now_ms,
                     },
                 );
                 B::flush(&mut display);
@@ -532,7 +544,8 @@ pub(super) async fn run_core<B: Esp32S3Board>(
                     settle_after_draw = true;
                 }
                 Either3::Second(()) => {
-                    ticks_to_battery = ticks_to_battery.saturating_sub(1);
+                    ticks_to_battery_sample = ticks_to_battery_sample.saturating_sub(1);
+                    ticks_to_battery_display = ticks_to_battery_display.saturating_sub(1);
                 }
                 Either3::First(event) => {
                     let now_ms = embassy_time::Instant::now().as_millis();

--- a/personal-hopspot/embedded/esp32/src/s3/mod.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/mod.rs
@@ -194,8 +194,16 @@ const RECLAIMED_HEAP_BYTES: usize = 72 * 1024;
 // lives in PSRAM.
 const RADIO_INTERNAL_HEAP_BYTES: usize = 52 * 1024;
 
-const RENDER_INTERVAL: Duration = Duration::from_millis(500);
-const RENDER_TICKS_PER_BATTERY: u8 = 4;
+const RENDER_INTERVAL_MS: u64 = 500;
+const RENDER_INTERVAL: Duration = Duration::from_millis(RENDER_INTERVAL_MS);
+/// Keep the existing two-second probe cadence so the Heltec's voltage-trend charging inference
+/// stays responsive. The exact level is human-facing and moves much more slowly, so publish it only
+/// every ten seconds; fresh external-power state still reaches the plug on every probe.
+const BATTERY_SAMPLE_INTERVAL_MS: u64 = 2_000;
+const BATTERY_DISPLAY_INTERVAL_MS: u64 = 10_000;
+const RENDER_TICKS_PER_BATTERY_SAMPLE: u8 = (BATTERY_SAMPLE_INTERVAL_MS / RENDER_INTERVAL_MS) as u8;
+const RENDER_TICKS_PER_BATTERY_DISPLAY: u8 =
+    (BATTERY_DISPLAY_INTERVAL_MS / RENDER_INTERVAL_MS) as u8;
 const NOTICE_MS: u64 = 900;
 const OLED_SLEEP_DELAY_MS: u64 = 2_500;
 const DEFAULT_OLED_AUTO_OFF_MS: u64 = 60_000;

--- a/personal-hopspot/embedded/nrf52840/src/runtime/firmware.rs
+++ b/personal-hopspot/embedded/nrf52840/src/runtime/firmware.rs
@@ -53,7 +53,6 @@ const PARTIAL_REFRESH_LIMIT: u32 = 64;
 const FULL_REFRESH_MAX_AGE_MS: u64 = 30 * 60 * 1_000;
 const TELEMETRY_MIN_INTERVAL_MS: u64 = 5_000;
 const STATS_POLL: Duration = Duration::from_secs(1);
-const EINK_ANIMATION_MS: u64 = 0;
 const NOTICE_MS: u64 = 900;
 const USB_CONFIG_DESCRIPTOR_BYTES: usize = 64;
 const USB_BOS_DESCRIPTOR_BYTES: usize = 64;
@@ -415,7 +414,6 @@ pub async fn run(spawner: Spawner) -> ! {
                     gnss: None,
                     state: &ui_state,
                     interface_menu_details: &interface_menu_details,
-                    animation_ms: EINK_ANIMATION_MS,
                 },
             );
             let hash = board::frame_hash(panel.buffer());

--- a/personal-hopspot/embedded/nrf52840/src/runtime/headless/t096.rs
+++ b/personal-hopspot/embedded/nrf52840/src/runtime/headless/t096.rs
@@ -194,7 +194,6 @@ pub(super) fn face(input: FaceInput) -> impl Future {
                     gnss: ui_state.gnss_visible().then(board::gnss_snapshot),
                     state: &ui_state,
                     interface_menu_details: &details,
-                    animation_ms: now_ms,
                 },
             );
             // A transient panel fault must not take the networking node down. The display retains the

--- a/personal-hopspot/mobile/android/rust/src/face.rs
+++ b/personal-hopspot/mobile/android/rust/src/face.rs
@@ -140,11 +140,6 @@ impl HopspotFace {
         if cards.is_empty() {
             splash(&mut self.framebuffer, SplashContent::Starting);
         } else {
-            let animation_ms = self
-                .activity_started
-                .elapsed()
-                .as_millis()
-                .min(u128::from(u64::MAX)) as u64;
             let interface_menu_details = snapshots_to_interface_menu_details(
                 self.state.selected_card(content.cards),
                 snapshots,
@@ -157,7 +152,6 @@ impl HopspotFace {
                     gnss: None,
                     state: &self.state,
                     interface_menu_details: &interface_menu_details,
-                    animation_ms,
                 },
             );
         }

--- a/personal-hopspot/mobile/ios/rust/src/face.rs
+++ b/personal-hopspot/mobile/ios/rust/src/face.rs
@@ -141,11 +141,6 @@ impl HopspotFace {
         if cards.is_empty() {
             splash(&mut self.framebuffer, SplashContent::Connecting);
         } else {
-            let animation_ms = self
-                .activity_started
-                .elapsed()
-                .as_millis()
-                .min(u128::from(u64::MAX)) as u64;
             let interface_menu_details = snapshots_to_interface_menu_details(
                 self.state.selected_card(content.cards),
                 snapshots,
@@ -158,7 +153,6 @@ impl HopspotFace {
                     gnss: None,
                     state: &self.state,
                     interface_menu_details: &interface_menu_details,
-                    animation_ms,
                 },
             );
         }


### PR DESCRIPTION
Refines the percentage readout merged in #141 to match the approved device treatment.\n\n- restores the outlined battery shell around the exact number\n- removes the percent sign while retaining one-, two-, and three-digit levels\n- keeps the original plug steady whenever external power is present, including at 100%\n- publishes the visible number every 10 seconds while preserving 2-second sensing and plug responsiveness\n- removes the obsolete charging-animation input from the shared renderer\n\nValidated with all 150 personal-hopspot-core tests, warning-free clippy, a Heltec V4 release build, and a successful on-device boot/first render.