### PR TITLE
security: regenerate the unsafe snapshot so trunk's audit matches its tree

### DIFF
--- a/audits/unsafe-snapshot.json
+++ b/audits/unsafe-snapshot.json
@@ -13900,14 +13900,24 @@
         "engine": [
           "default"
         ],
-        "esp32-c6": [],
-        "esp32-s3-heltec": [],
-        "esp32-s3-heltec-r8": [],
-        "esp32-s3-tbeam": [],
+        "esp32-c6": [
+          "embedded"
+        ],
+        "esp32-s3-heltec": [
+          "embedded"
+        ],
+        "esp32-s3-heltec-r8": [
+          "embedded"
+        ],
+        "esp32-s3-tbeam": [
+          "embedded"
+        ],
         "ios": [
           "host"
         ],
-        "nrf52840": [],
+        "nrf52840": [
+          "embedded"
+        ],
         "wasm": []
       },
       "name": "personal-hopspot-core",


### PR DESCRIPTION
Trunk is failing `ci` at `55857a75`, on `deny` and `Release critical`. It looks like a dependency problem at first glance, but cargo-deny itself passes. Advisories, bans, licenses and sources are all ok, and the job dies at the later step:

```
unsafe dependency snapshot drifted; review and run validation/security/unsafe-audit.py --write
```

`audits/unsafe-snapshot.json` on trunk still records empty target arrays for `personal-hopspot-core` where the tree now has unsafe code, so the audit and the source disagree. The same regeneration landed on main as `f13a6d0d`, and that commit is not an ancestor of trunk, so trunk never picked it up.

This regenerates the file from trunk's own tree. I did not copy main's, and I would recommend against it: main records 282 unsafe blocks for `prns-host-c`, but `prns-host/abi/c/src/lib.rs` is 4587 lines on trunk against 4454 on main, so trunk genuinely has 295. Copying main's file over would write the wrong count and fail again for a new reason.

How I checked it rather than assuming the write worked:

```
validation/security/unsafe-audit.py --self-test   -> unsafe lexer self-test passed
validation/security/unsafe-audit.py               -> exit 1, snapshot drifted    (reproduces CI)
validation/security/unsafe-audit.py --write
validation/security/unsafe-audit.py               -> exit 0, matches reviewed baseline
```

The self-test runs first on purpose, so the tool is known good before its output is trusted.

It is also already confirmed on your CI rather than only locally. The identical file is carried on #128, and both of the jobs failing here pass there: `deny` in 18m20s and `Release critical`, on run 32935193422. That PR had been red for four days on this and nothing else, and it is green now. The blob in this PR is byte-for-byte the one in that run.

Worth flagging beyond this branch: every PR based on trunk is currently red on `deny` for a reason unrelated to its content, so this is a precondition for anything cut from trunk rather than tidying.

I have not tried to identify which commit introduced the drift. The last green `ci` on trunk was `b52933be` and the first red was `c4e0471a`, but that commit only touches two benchmark files and `benchmarks/` is not in the audit's graph list, so I do not think it is the cause and I would rather say so than guess.
