### PR TITLE
Stabilize Mac↔Android BLE Auto and mDNS UDP flaps

### DIFF
--- a/personal-hopspot/core/src/lib.rs
+++ b/personal-hopspot/core/src/lib.rs
@@ -125,6 +125,11 @@ pub fn snapshots_to_cards<const N: usize>(
         let mut links = snapshot.links;
         let mut transported_links = snapshot.transported_links;
         let mut peers = 0u32;
+        let mut tx_bytes = snapshot.tx_bytes;
+        let mut rx_bytes = snapshot.rx_bytes;
+        let mut member_rate_rx_bps = 0u32;
+        let mut member_rate_tx_bps = 0u32;
+        let mut has_member_rates = false;
         for member in snapshots {
             if let Membership::FleetMember { supervisor_id } = member.membership {
                 if supervisor_id == snapshot.id {
@@ -132,24 +137,40 @@ pub fn snapshots_to_cards<const N: usize>(
                     destinations = destinations.saturating_add(member.destinations);
                     links = links.saturating_add(member.links);
                     transported_links = transported_links.saturating_add(member.transported_links);
+                    tx_bytes = tx_bytes.saturating_add(member.tx_bytes);
+                    rx_bytes = rx_bytes.saturating_add(member.rx_bytes);
+                    if let Some(rates) = member.transfer_rates {
+                        member_rate_rx_bps = member_rate_rx_bps.saturating_add(rates.rx_bps);
+                        member_rate_tx_bps = member_rate_tx_bps.saturating_add(rates.tx_bps);
+                        has_member_rates = true;
+                    }
                 }
             }
         }
+        let rate_bytes_per_sec = if peers > 0 {
+            has_member_rates.then_some(
+                member_rate_rx_bps
+                    .saturating_add(member_rate_tx_bps)
+                    .saturating_div(8),
+            )
+        } else {
+            snapshot
+                .transfer_rates
+                .map(|rates| rates.rx_bps.saturating_add(rates.tx_bps) / 8)
+        }
+        .unwrap_or(0);
         let _ = cards.push(Card {
             id: snapshot.id,
             kind,
             label,
             connection: snapshot.connection,
             failure_reason: snapshot.failure_reason,
-            tx_bytes: snapshot.tx_bytes,
-            rx_bytes: snapshot.rx_bytes,
+            tx_bytes,
+            rx_bytes,
             links: links.saturating_add(transported_links),
             peers: interface_kind_shows_supervisor_peers(snapshot.id).then_some(peers),
             destinations,
-            rate_bytes_per_sec: snapshot
-                .transfer_rates
-                .map(|rates| rates.rx_bps.saturating_add(rates.tx_bps) / 8)
-                .unwrap_or(0),
+            rate_bytes_per_sec,
             last_activity_secs: None,
         });
     }
@@ -329,6 +350,44 @@ mod tests {
 
         assert_eq!(cards.len(), 1);
         assert_eq!(cards[0].connection, ConnectionState::Disconnected);
+    }
+
+    #[test]
+    fn snapshots_to_cards_rolls_up_fleet_member_traffic_bytes() {
+        let supervisor_id =
+            InterfaceId::new([InterfaceKind::BluetoothAuto as u8, 0, 0, 0, 0, 0, 0, 0]);
+        let member_id = InterfaceId::new([
+            InterfaceKind::BluetoothPeer as u8,
+            0x78,
+            0xa8,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]);
+        let mut supervisor = snapshot(InterfaceKind::BluetoothAuto);
+        supervisor.id = supervisor_id;
+        supervisor.tx_bytes = 0;
+        supervisor.rx_bytes = 0;
+        let mut member = snapshot(InterfaceKind::BluetoothPeer);
+        member.id = member_id;
+        member.tx_bytes = 20;
+        member.rx_bytes = 183;
+        member.transfer_rates = Some(TransferRates {
+            rx_bps: 800,
+            tx_bps: 160,
+        });
+        member.membership = Membership::FleetMember { supervisor_id };
+
+        let cards: heapless::Vec<Card, 4> = snapshots_to_cards(&[supervisor, member], |id| {
+            (id == supervisor_id).then_some((CardKind::Ble, card_label("BLE")))
+        });
+
+        assert_eq!(cards.len(), 1);
+        assert_eq!(cards[0].tx_bytes, 20);
+        assert_eq!(cards[0].rx_bytes, 183);
+        assert_eq!(cards[0].rate_bytes_per_sec, 120);
     }
 
     #[test]

--- a/personal-hopspot/mobile/android/app/src/main/java/org/personal/hopspot/BleLink.kt
+++ b/personal-hopspot/mobile/android/app/src/main/java/org/personal/hopspot/BleLink.kt
@@ -223,6 +223,10 @@ class BleLink(private val context: Context) {
 
     private val gattServerCallback = object : BluetoothGattServerCallback() {
         override fun onConnectionStateChange(device: BluetoothDevice, status: Int, newState: Int) {
+            if (newState == BluetoothProfile.STATE_CONNECTED) {
+                rememberDevice(device)
+                return
+            }
             if (newState == BluetoothProfile.STATE_DISCONNECTED) {
                 val connId = inboundByAddr.remove(device.address) ?: return
                 Log.i(TAG, "listener[$connId] ${device.address} disconnected")
@@ -905,6 +909,21 @@ class BleLink(private val context: Context) {
             while (running) {
                 if (!radioActive) {
                     generation = NativeBridge.nativeBleWaitForWork(generation, 0)
+                    continue
+                }
+                // Policy Reject queues closes before redials; drain them first so inbound
+                // occupancy does not block the opener from dialing as central.
+                var closed = false
+                while (true) {
+                    val connId = NativeBridge.nativeBleNextClose()
+                    if (connId < 0) {
+                        break
+                    }
+                    Log.i(TAG, "policy close[$connId]")
+                    closeLink(connId)
+                    closed = true
+                }
+                if (closed) {
                     continue
                 }
                 direct.clear()

--- a/personal-hopspot/mobile/android/app/src/main/java/org/personal/hopspot/NativeBridge.kt
+++ b/personal-hopspot/mobile/android/app/src/main/java/org/personal/hopspot/NativeBridge.kt
@@ -216,6 +216,8 @@ object NativeBridge {
 
     external fun nativeBleDisconnected(connId: Int)
 
+    external fun nativeBleNextClose(): Int
+
     external fun nativeBleNextDial(buffer: ByteBuffer): Boolean
 
     external fun nativeBleNextL2capOpen(buffer: ByteBuffer): Boolean

--- a/personal-hopspot/mobile/android/rust/src/jni/bluetooth_auto.rs
+++ b/personal-hopspot/mobile/android/rust/src/jni/bluetooth_auto.rs
@@ -365,6 +365,17 @@ pub extern "system" fn Java_org_personal_hopspot_NativeBridge_nativeBleDisconnec
 }
 
 #[no_mangle]
+pub extern "system" fn Java_org_personal_hopspot_NativeBridge_nativeBleNextClose(
+    _env: JNIEnv,
+    _class: JClass,
+) -> jint {
+    match ble_bridge().next_close() {
+        Some(conn_id) => conn_id as jint,
+        None => -1,
+    }
+}
+
+#[no_mangle]
 pub extern "system" fn Java_org_personal_hopspot_NativeBridge_nativeBleNextDial(
     env: JNIEnv,
     _class: JClass,

--- a/prns-core/src/interfaces/bluetooth_auto/handshake.rs
+++ b/prns-core/src/interfaces/bluetooth_auto/handshake.rs
@@ -259,14 +259,25 @@ pub fn is_keeper(
         == we_should_be_central(l2cap_arrangement, ours, our_endpoint, theirs)
 }
 
+/// True when this handshake landed in the wrong GATT role for an `Opens(E)` arrangement.
+///
+/// The designated opener must be GATT central to open CoC. Either side may dial for discovery,
+/// but a settle in the wrong role must drop so the opener can dial (or re-dial) as central:
+/// - opener stuck as listener/peripheral → drop and dial
+/// - non-opener who dialed (wrong central) → drop and wait for the opener's dial
 pub fn needs_redial(
     l2cap_arrangement: L2capArrangement,
     our_role: HandshakeRole,
     our_endpoint: Endpoint,
 ) -> bool {
-    let we_open =
-        matches!(l2cap_arrangement, L2capArrangement::Opens(opener) if opener == our_endpoint);
-    we_open && matches!(our_role, HandshakeRole::Listener)
+    match l2cap_arrangement {
+        L2capArrangement::Opens(opener) => {
+            let we_open = opener == our_endpoint;
+            (we_open && matches!(our_role, HandshakeRole::Listener))
+                || (!we_open && matches!(our_role, HandshakeRole::Dialer))
+        }
+        L2capArrangement::GattOnly | L2capArrangement::EitherOpens => false,
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/prns-core/src/interfaces/bluetooth_auto/policy.rs
+++ b/prns-core/src/interfaces/bluetooth_auto/policy.rs
@@ -221,10 +221,21 @@ impl<const MAX_PEERS: usize, const DIAL_TRACK: usize> ConnectionPolicy<MAX_PEERS
             && self.find_settled_by_identity(identity).is_none()
             && self.settled_count() < MAX_PEERS
         {
-            emit(PolicyAction::Reject {
-                address,
-                dialed: false,
-            });
+            let we_open = matches!(
+                plan,
+                super::handshake::L2capArrangement::Opens(opener) if opener == self.local.endpoint
+            );
+            if dialed {
+                // Non-opener who dialed: pause outbound so the designated opener can take central.
+                self.upsert_backoff(address, BackoffKind::Suppressed, now_ms);
+                self.dial_pause_until_ms = now_ms.saturating_add(DIAL_PAUSE_MS);
+            }
+            emit(PolicyAction::Reject { address, dialed });
+            if we_open && !dialed {
+                // Opener was peripheral: redial as central on the address we already have.
+                self.upsert_backoff(address, BackoffKind::Dialing, now_ms);
+                emit(PolicyAction::Dial(address));
+            }
             return;
         }
         let keeper = is_keeper(
@@ -716,21 +727,79 @@ mod tests {
 
         assert_eq!(
             actions,
+            std::vec![
+                PolicyAction::Reject {
+                    address: addr(2),
+                    dialed: false,
+                },
+                PolicyAction::Dial(addr(2)),
+            ]
+        );
+        assert_eq!(manager.settled_count(), 0);
+    }
+
+    #[test]
+    fn a_non_opener_who_dialed_rejects_and_pauses_outbound() {
+        use crate::interfaces::bluetooth_auto::{AndroidHost, AppleHost, Psm};
+
+        let capabilities = LinkCapabilities {
+            l2cap: Psm::new(0x00c0),
+            link_mtu: 500,
+        };
+
+        let mut manager = ConnectionPolicy::<2, 8>::new(LocalPeer {
+            identity: BleIdentity::new([1; 16]),
+            endpoint: Endpoint::CoreBluetooth(AppleHost::MacOs),
+            capabilities,
+        });
+        manager.start(&mut |_| {});
+
+        let actions = collect(
+            &mut manager,
+            PolicyInput::Settled {
+                address: addr(2),
+                origin: Origin::Dialed,
+                established: EstablishedPeer {
+                    identity: BleIdentity::new([2; 16]),
+                    transport: EstablishedTransport::Native {
+                        endpoint: Endpoint::Android(AndroidHost::Android),
+                        capabilities,
+                    },
+                    peer_rssi: None,
+                },
+                now_ms: 5,
+            },
+        );
+
+        assert_eq!(
+            actions,
             std::vec![PolicyAction::Reject {
                 address: addr(2),
-                dialed: false,
+                dialed: true,
             }]
         );
         assert_eq!(manager.settled_count(), 0);
 
-        let redial = collect(
+        let while_paused = collect(
             &mut manager,
             PolicyInput::Sighting {
                 address: addr(2),
                 now_ms: 6,
             },
         );
-        assert_eq!(redial, std::vec![PolicyAction::Dial(addr(2))]);
+        assert!(
+            while_paused.is_empty(),
+            "non-opener must pause dialing so the opener can take central"
+        );
+
+        let after_pause = collect(
+            &mut manager,
+            PolicyInput::Sighting {
+                address: addr(2),
+                now_ms: 5 + DIAL_PAUSE_MS,
+            },
+        );
+        assert_eq!(after_pause, std::vec![PolicyAction::Dial(addr(2))]);
     }
 
     #[test]

--- a/prns-core/src/interfaces/bluetooth_auto/policy.rs
+++ b/prns-core/src/interfaces/bluetooth_auto/policy.rs
@@ -62,6 +62,7 @@ pub enum PolicyAction {
         slot: usize,
         address: BleAddress,
         lane: L2capPlan,
+        peer_rssi: Option<i8>,
     },
     Evict {
         identity: BleIdentity,
@@ -304,6 +305,7 @@ impl<const MAX_PEERS: usize, const DIAL_TRACK: usize> ConnectionPolicy<MAX_PEERS
             slot,
             address,
             lane,
+            peer_rssi: established.peer_rssi,
         });
         self.reconcile(emit);
     }
@@ -621,6 +623,7 @@ mod tests {
                     slot: 0,
                     address: addr(2),
                     lane: L2capPlan::None,
+                    peer_rssi: None,
                 },
                 PolicyAction::SetAdvertising(AdvertisingMode::Off),
                 PolicyAction::SetScanning(ScanningMode::Off),

--- a/prns-core/src/interfaces/bluetooth_auto/tests.rs
+++ b/prns-core/src/interfaces/bluetooth_auto/tests.rs
@@ -455,7 +455,7 @@ fn both_ends_keep_the_same_connection_for_an_either_opens_pair() {
 }
 
 #[test]
-fn only_the_designated_opener_stuck_as_peripheral_redials() {
+fn opens_arrangement_rejects_either_wrong_gatt_role() {
     let opens_android = l2cap_arrangement(mac(), android());
     assert!(needs_redial(
         opens_android,
@@ -468,7 +468,7 @@ fn only_the_designated_opener_stuck_as_peripheral_redials() {
         android()
     ));
     assert!(!needs_redial(opens_android, HandshakeRole::Listener, mac()));
-    assert!(!needs_redial(opens_android, HandshakeRole::Dialer, mac()));
+    assert!(needs_redial(opens_android, HandshakeRole::Dialer, mac()));
 
     let either = l2cap_arrangement(linux(), android());
     assert!(!needs_redial(either, HandshakeRole::Listener, linux()));

--- a/prns-core/src/interfaces/rns_management/interface_stats.rs
+++ b/prns-core/src/interfaces/rns_management/interface_stats.rs
@@ -35,6 +35,8 @@ pub struct RnsInterfaceStatsEntry {
     name: Option<String>,
     snapshot: InterfaceSnapshot,
     access_code: Option<RnsInterfaceAccessCode>,
+    rssi: Option<i8>,
+    fleet_peers: Vec<RnsInterfaceStatsEntry>,
 }
 
 impl RnsInterfaceStatsEntry {
@@ -47,7 +49,19 @@ impl RnsInterfaceStatsEntry {
             name,
             snapshot,
             access_code,
+            rssi: None,
+            fleet_peers: Vec::new(),
         }
+    }
+
+    pub fn with_rssi(mut self, rssi: Option<i8>) -> Self {
+        self.rssi = rssi;
+        self
+    }
+
+    pub fn with_fleet_peers(mut self, fleet_peers: Vec<RnsInterfaceStatsEntry>) -> Self {
+        self.fleet_peers = fleet_peers;
+        self
     }
 }
 
@@ -170,7 +184,14 @@ fn encode_interface_entry(
         rx_bps: 0,
         tx_bps: 0,
     });
-    encoder.map(14)?;
+    let mut fields = 14usize;
+    if entry.rssi.is_some() {
+        fields = fields.saturating_add(1);
+    }
+    if !entry.fleet_peers.is_empty() {
+        fields = fields.saturating_add(1);
+    }
+    encoder.map(fields)?;
     encoder.string_field(interface::NAME, &name)?;
     encoder.string_field(interface::SHORT_NAME, &name)?;
     encoder.string_field(interface::TYPE, &interface_type(entry.snapshot.id))?;
@@ -206,6 +227,45 @@ fn encode_interface_entry(
     {
         Some(network_name) => encoder.string(network_name)?,
         None => encoder.nil(),
+    }
+    if let Some(rssi) = entry.rssi {
+        encoder.field(interface::RSSI)?;
+        encoder.signed(i64::from(rssi));
+    }
+    if !entry.fleet_peers.is_empty() {
+        encoder.field(interface::FLEET_PEERS)?;
+        encoder.array(entry.fleet_peers.len())?;
+        for peer in &entry.fleet_peers {
+            encode_fleet_peer_entry(encoder, peer)?;
+        }
+    }
+    Ok(())
+}
+
+fn encode_fleet_peer_entry(
+    encoder: &mut MessagePackEncoder,
+    entry: &RnsInterfaceStatsEntry,
+) -> Result<(), RnsManagementEncodeError> {
+    let name = entry
+        .name
+        .clone()
+        .unwrap_or_else(|| interface_name(entry.snapshot.id));
+    let rates = entry.snapshot.transfer_rates.unwrap_or(TransferRates {
+        rx_bps: 0,
+        tx_bps: 0,
+    });
+    let fields = if entry.rssi.is_some() { 7usize } else { 6usize };
+    encoder.map(fields)?;
+    encoder.string_field(interface::NAME, &name)?;
+    encoder.field(interface::STATUS)?;
+    encoder.boolean(is_online(entry.snapshot.connection));
+    encoder.unsigned_field(interface::RECEIVE_BYTES, entry.snapshot.rx_bytes)?;
+    encoder.unsigned_field(interface::TRANSMIT_BYTES, entry.snapshot.tx_bytes)?;
+    encoder.unsigned_field(interface::RECEIVE_SPEED, u64::from(rates.rx_bps))?;
+    encoder.unsigned_field(interface::TRANSMIT_SPEED, u64::from(rates.tx_bps))?;
+    if let Some(rssi) = entry.rssi {
+        encoder.field(interface::RSSI)?;
+        encoder.signed(i64::from(rssi));
     }
     Ok(())
 }

--- a/prns-core/src/interfaces/rns_management/mod.rs
+++ b/prns-core/src/interfaces/rns_management/mod.rs
@@ -31,7 +31,7 @@ pub use remote_request::{
     RnsRemoteStatusRequest,
 };
 pub use status_report::{
-    RnsInterfaceMode, RnsInterfaceStatsDecodeError, RnsInterfaceStatsReport,
+    RnsFleetPeerReport, RnsInterfaceMode, RnsInterfaceStatsDecodeError, RnsInterfaceStatsReport,
     RnsInterfaceStatusReport, RnsOptionalField, RnsRemoteInterfaceStatsReport, RnsStatsFieldPath,
     RnsStatsFieldScope,
 };

--- a/prns-core/src/interfaces/rns_management/status_report/decode.rs
+++ b/prns-core/src/interfaces/rns_management/status_report/decode.rs
@@ -1,4 +1,5 @@
 use alloc::collections::BTreeSet;
+use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::fmt;
@@ -11,8 +12,8 @@ use crate::interfaces::rns_management::wire_names::{interface, transport};
 use crate::wire::DestinationHash;
 
 use super::{
-    RnsInterfaceMode, RnsInterfaceStatsReport, RnsInterfaceStatusReport, RnsOptionalField,
-    RnsRemoteInterfaceStatsReport,
+    RnsFleetPeerReport, RnsInterfaceMode, RnsInterfaceStatsReport, RnsInterfaceStatusReport,
+    RnsOptionalField, RnsRemoteInterfaceStatsReport,
 };
 
 const MAXIMUM_DEPTH: usize = 8;
@@ -237,6 +238,8 @@ struct InterfaceBuilder {
     endpoint_id: RnsOptionalField<String>,
     via_switch_id: RnsOptionalField<String>,
     blocked_ip_list: RnsOptionalField<Vec<String>>,
+    rssi: RnsOptionalField<i64>,
+    fleet_peers: Vec<RnsFleetPeerReport>,
 }
 
 impl InterfaceBuilder {
@@ -299,6 +302,8 @@ impl InterfaceBuilder {
             endpoint_id: self.endpoint_id,
             via_switch_id: self.via_switch_id,
             blocked_ip_list: self.blocked_ip_list,
+            rssi: self.rssi,
+            fleet_peers: self.fleet_peers,
         })
     }
 }
@@ -571,10 +576,91 @@ fn read_interface(
             interface::BLOCKED_IP_LIST => {
                 interface_report.blocked_ip_list = read_optional_string_array(reader, path)?
             }
+            interface::RSSI => interface_report.rssi = read_optional_i64(reader, path)?,
+            interface::FLEET_PEERS => {
+                interface_report.fleet_peers = read_fleet_peers(reader, index)?
+            }
             _ => skip(reader)?,
         }
     }
     interface_report.finish(index)
+}
+
+fn read_fleet_peers(
+    reader: &mut MessagePackReader<'_>,
+    parent_index: usize,
+) -> Result<Vec<RnsFleetPeerReport>, RnsInterfaceStatsDecodeError> {
+    let marker = marker(reader)?;
+    let length = reader
+        .array_length(marker)
+        .map_err(|_| RnsInterfaceStatsDecodeError::InvalidMessagePack)?
+        .ok_or(RnsInterfaceStatsDecodeError::ExpectedInterfacesArray)?;
+    let mut peers = Vec::new();
+    peers
+        .try_reserve_exact(length)
+        .map_err(|_| RnsInterfaceStatsDecodeError::AllocationFailed { entries: length })?;
+    for peer_index in 0..length {
+        peers.push(read_fleet_peer(reader, parent_index, peer_index)?);
+    }
+    Ok(peers)
+}
+
+fn read_fleet_peer(
+    reader: &mut MessagePackReader<'_>,
+    parent_index: usize,
+    peer_index: usize,
+) -> Result<RnsFleetPeerReport, RnsInterfaceStatsDecodeError> {
+    let marker = marker(reader)?;
+    let length = reader
+        .map_length(marker)
+        .map_err(|_| RnsInterfaceStatsDecodeError::InvalidMessagePack)?
+        .ok_or(RnsInterfaceStatsDecodeError::ExpectedInterfaceMap {
+            index: parent_index,
+        })?;
+    let mut fields = BTreeSet::new();
+    let mut name = None;
+    let mut online = None;
+    let mut receive_bytes = None;
+    let mut transmit_bytes = None;
+    let mut receive_speed_bps = None;
+    let mut transmit_speed_bps = None;
+    let mut rssi = RnsOptionalField::Absent;
+    for _ in 0..length {
+        let key = read_key(reader, RnsStatsFieldScope::Interface(parent_index))?;
+        let path = RnsStatsFieldPath::interface(parent_index, &format!("fleet_peers[{peer_index}].{key}"));
+        ensure_unique(&mut fields, path.clone())?;
+        match key.as_str() {
+            interface::NAME => name = Some(read_string(reader, path)?),
+            interface::STATUS => online = Some(read_bool(reader, path)?),
+            interface::RECEIVE_BYTES => receive_bytes = Some(read_u64(reader, path)?),
+            interface::TRANSMIT_BYTES => transmit_bytes = Some(read_u64(reader, path)?),
+            interface::RECEIVE_SPEED => receive_speed_bps = Some(read_number(reader, path)?),
+            interface::TRANSMIT_SPEED => transmit_speed_bps = Some(read_number(reader, path)?),
+            interface::RSSI => rssi = read_optional_i64(reader, path)?,
+            _ => skip(reader)?,
+        }
+    }
+    Ok(RnsFleetPeerReport {
+        name: required(name, RnsStatsFieldPath::interface(parent_index, interface::NAME))?,
+        online: required(online, RnsStatsFieldPath::interface(parent_index, interface::STATUS))?,
+        receive_bytes: required(
+            receive_bytes,
+            RnsStatsFieldPath::interface(parent_index, interface::RECEIVE_BYTES),
+        )?,
+        transmit_bytes: required(
+            transmit_bytes,
+            RnsStatsFieldPath::interface(parent_index, interface::TRANSMIT_BYTES),
+        )?,
+        receive_speed_bps: required(
+            receive_speed_bps,
+            RnsStatsFieldPath::interface(parent_index, interface::RECEIVE_SPEED),
+        )?,
+        transmit_speed_bps: required(
+            transmit_speed_bps,
+            RnsStatsFieldPath::interface(parent_index, interface::TRANSMIT_SPEED),
+        )?,
+        rssi,
+    })
 }
 
 fn required<T>(

--- a/prns-core/src/interfaces/rns_management/status_report/mod.rs
+++ b/prns-core/src/interfaces/rns_management/status_report/mod.rs
@@ -136,6 +136,19 @@ pub struct RnsInterfaceStatusReport {
     pub endpoint_id: RnsOptionalField<String>,
     pub via_switch_id: RnsOptionalField<String>,
     pub blocked_ip_list: RnsOptionalField<Vec<String>>,
+    pub rssi: RnsOptionalField<i64>,
+    pub fleet_peers: Vec<RnsFleetPeerReport>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RnsFleetPeerReport {
+    pub name: String,
+    pub online: bool,
+    pub receive_bytes: u64,
+    pub transmit_bytes: u64,
+    pub receive_speed_bps: f64,
+    pub transmit_speed_bps: f64,
+    pub rssi: RnsOptionalField<i64>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/prns-core/src/interfaces/rns_management/tests.rs
+++ b/prns-core/src/interfaces/rns_management/tests.rs
@@ -91,6 +91,70 @@ fn interface_stats_preserve_live_counters_and_access_code_fields() {
 }
 
 #[test]
+fn interface_stats_encode_nested_fleet_peers_with_rssi() {
+    let supervisor = InterfaceId::from_channel_tag(InterfaceKind::BluetoothAuto, b"ble");
+    let peer = InterfaceId::from_channel_tag(InterfaceKind::BluetoothPeer, b"peer");
+    let stats = RnsInterfaceStats::new(vec![RnsInterfaceStatsEntry::new(
+        Some(String::from("Bluetooth Auto")),
+        InterfaceSnapshot {
+            id: supervisor,
+            mode: crate::interfaces::InterfaceMode::Full,
+            gravity: crate::interfaces::InterfaceGravity::ZERO,
+            connection: ConnectionState::Connected,
+            failure_reason: None,
+            rx_bytes: 100,
+            tx_bytes: 50,
+            transfer_rates: Some(TransferRates {
+                rx_bps: 10,
+                tx_bps: 5,
+            }),
+            destinations: 0,
+            links: 0,
+            transported_links: 0,
+            membership: Membership::Independent,
+        },
+        None,
+    )
+    .with_fleet_peers(vec![RnsInterfaceStatsEntry::new(
+        Some(String::from("ab12… @ AA:BB:CC:DD:EE:FF")),
+        InterfaceSnapshot {
+            id: peer,
+            mode: crate::interfaces::InterfaceMode::Full,
+            gravity: crate::interfaces::InterfaceGravity::ZERO,
+            connection: ConnectionState::Connected,
+            failure_reason: None,
+            rx_bytes: 40,
+            tx_bytes: 20,
+            transfer_rates: Some(TransferRates {
+                rx_bps: 4,
+                tx_bps: 2,
+            }),
+            destinations: 0,
+            links: 0,
+            transported_links: 0,
+            membership: Membership::FleetMember {
+                supervisor_id: supervisor,
+            },
+        },
+        None,
+    )
+    .with_rssi(Some(-61))])]);
+    let Ok(encoded) = stats.encode_message_pack() else {
+        panic!("interface stats must encode");
+    };
+    let report = RnsInterfaceStatsReport::decode_message_pack(&encoded)
+        .expect("encoded fleet peers must decode");
+    assert_eq!(report.interfaces.len(), 1);
+    assert_eq!(report.interfaces[0].fleet_peers.len(), 1);
+    let nested = &report.interfaces[0].fleet_peers[0];
+    assert_eq!(nested.name, "ab12… @ AA:BB:CC:DD:EE:FF");
+    assert!(nested.online);
+    assert_eq!(nested.receive_bytes, 40);
+    assert_eq!(nested.transmit_bytes, 20);
+    assert_eq!(nested.rssi, RnsOptionalField::Value(-61));
+}
+
+#[test]
 fn local_interface_fallback_names_match_stock_rnstatus_categories() {
     let server = InterfaceId::from_channel_tag(InterfaceKind::LocalServer, b"server");
     let client = InterfaceId::from_channel_tag(InterfaceKind::LocalClient, b"client");

--- a/prns-core/src/interfaces/rns_management/wire_names.rs
+++ b/prns-core/src/interfaces/rns_management/wire_names.rs
@@ -41,6 +41,8 @@ pub mod interface {
     pub const PARENT_HASH: &str = "parent_interface_hash";
     pub const BITRATE: &str = "bitrate";
     pub const PEERS: &str = "peers";
+    pub const FLEET_PEERS: &str = "fleet_peers";
+    pub const RSSI: &str = "rssi";
     pub const AUTOCONNECT_SOURCE: &str = "autoconnect_source";
     pub const ANNOUNCE_QUEUE: &str = "announce_queue";
     pub const HELD_ANNOUNCES: &str = "held_announces";

--- a/prns-ffi/src/bluetooth_auto/android/backend.rs
+++ b/prns-ffi/src/bluetooth_auto/android/backend.rs
@@ -103,4 +103,8 @@ impl BleBackend<{ AndroidBleBackend::MAX_PEERS }> for AndroidBleBackend {
             DialOutcome::Busy
         }
     }
+
+    async fn on_link_closed(&mut self, address: BleAddress) {
+        self.bridge.close_by_address(*address.octets());
+    }
 }

--- a/prns-ffi/src/bluetooth_auto/android/bridge.rs
+++ b/prns-ffi/src/bluetooth_auto/android/bridge.rs
@@ -73,6 +73,7 @@ impl WorkSignal {
 }
 
 pub(super) struct Endpoints {
+    address: BleAddress,
     control_in_tx: Sender<Vec<u8>>,
     l2cap_in_tx: Sender<Vec<u8>>,
     data_in_tx: Sender<Vec<u8>>,
@@ -150,6 +151,7 @@ pub(super) struct Shared {
     pub(super) events: Mutex<VecDeque<Event>>,
     pub(super) events_ready: Notify,
     pub(super) dial_requests: Mutex<VecDeque<[u8; 6]>>,
+    pub(super) close_requests: Mutex<VecDeque<u32>>,
     pub(super) l2cap_opens: Arc<Mutex<VecDeque<(u32, u16)>>>,
     work: Arc<WorkSignal>,
     ingress_pressure_events: AtomicU64,
@@ -180,6 +182,7 @@ impl AndroidBleBridge {
                 events: Mutex::new(VecDeque::new()),
                 events_ready: Notify::new(),
                 dial_requests: Mutex::new(VecDeque::new()),
+                close_requests: Mutex::new(VecDeque::new()),
                 l2cap_opens: Arc::new(Mutex::new(VecDeque::new())),
                 work: Arc::new(WorkSignal::default()),
                 ingress_pressure_events: AtomicU64::new(0),
@@ -385,6 +388,7 @@ impl AndroidBleBridge {
             if let Some(replaced) = links.insert(
                 conn_id,
                 Endpoints {
+                    address: BleAddress::new(address),
                     control_in_tx: control_tx,
                     l2cap_in_tx: l2cap_tx,
                     data_in_tx: data_tx,
@@ -526,7 +530,46 @@ impl AndroidBleBridge {
                 link.close();
             }
         }
+        if let Ok(mut closes) = self.shared.close_requests.lock() {
+            closes.retain(|pending| *pending != conn_id);
+        }
         self.shared.work.wake();
+    }
+
+    /// Policy rejected a link: drop Rust endpoints and ask Java to tear down the physical radio.
+    pub fn close_by_address(&self, address: [u8; 6]) {
+        let target = BleAddress::new(address);
+        let mut closed = Vec::new();
+        if let Ok(mut links) = self.shared.links.lock() {
+            links.retain(|conn_id, endpoints| {
+                if endpoints.address == target {
+                    endpoints.close();
+                    closed.push(*conn_id);
+                    false
+                } else {
+                    true
+                }
+            });
+        }
+        if closed.is_empty() {
+            return;
+        }
+        if let Ok(mut requests) = self.shared.close_requests.lock() {
+            for conn_id in closed {
+                if !requests.contains(&conn_id) {
+                    requests.push_back(conn_id);
+                }
+            }
+        }
+        self.shared.work.wake();
+    }
+
+    pub fn next_close(&self) -> Option<u32> {
+        self.shared
+            .close_requests
+            .lock()
+            .ok()
+            .and_then(|mut requests| requests.pop_front())
     }
 
     pub fn push_dial(&self, address: [u8; 6]) -> bool {

--- a/prns-ffi/src/bluetooth_auto/macos/backend.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/backend.rs
@@ -34,6 +34,36 @@ use super::{
 
 const POWER_ON_TIMEOUT: Duration = Duration::from_secs(10);
 const DIAL_TIMEOUT: Duration = Duration::from_secs(15);
+/// CoreBluetooth can leave `isScanning == true` while delivering no advertisements.
+/// Periodically bounce the scan (and re-assert advertising) so late peers stay visible
+/// without requiring a process restart.
+const RADIO_REFRESH_INTERVAL: Duration = Duration::from_secs(60);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ScanOp {
+    Start,
+    Restart,
+    Stop,
+    None,
+}
+
+pub(super) const fn scan_op(enabled: bool, is_scanning: bool, restart: bool) -> ScanOp {
+    if enabled {
+        if is_scanning {
+            if restart {
+                ScanOp::Restart
+            } else {
+                ScanOp::None
+            }
+        } else {
+            ScanOp::Start
+        }
+    } else if is_scanning {
+        ScanOp::Stop
+    } else {
+        ScanOp::None
+    }
+}
 
 #[derive(Default)]
 pub(super) struct StartupReadiness {
@@ -67,11 +97,20 @@ impl StartupReadiness {
 pub(super) enum DialAdmission {
     AttachCentralSession,
     YieldToSystemConnection,
+    /// Android (and other dual-role peers) keep advertising under a rotating RPA while already
+    /// connected to us as a GATT central. Outbound dials to that advertisement thrash the live
+    /// inbound link, so yield while any peripheral session is active.
+    YieldToInboundSession,
 }
 
-pub(super) const fn dial_admission(already_system_connected: bool) -> DialAdmission {
+pub(super) const fn dial_admission(
+    already_system_connected: bool,
+    inbound_sessions_active: bool,
+) -> DialAdmission {
     if already_system_connected {
         DialAdmission::YieldToSystemConnection
+    } else if inbound_sessions_active {
+        DialAdmission::YieldToInboundSession
     } else {
         DialAdmission::AttachCentralSession
     }
@@ -83,7 +122,33 @@ fn cancel_connection(central: &SendCentralManager, peripheral: &SendPeripheral) 
     unsafe { central.0.cancelPeripheralConnection(&peripheral.0) };
 }
 
-fn begin_dial(command: DialCommand) {
+fn apply_scanning(central: SendCentralManager, enabled: bool, restart: bool) {
+    // SAFETY: this authoritative CoreBluetooth state query runs on the retained manager's
+    // serial dispatch queue.
+    let is_scanning = unsafe { central.0.isScanning() };
+    match scan_op(enabled, is_scanning, restart) {
+        ScanOp::Restart => {
+            // SAFETY: the retained central manager is only messaged on its serial dispatch queue.
+            unsafe { central.0.stopScan() };
+            start_scan(&central.0);
+            crate::diagnostic_log::debug!(
+                "bluetooth: restarted Prns scan so late-arriving peers can be sighted"
+            );
+        }
+        ScanOp::Start => {
+            start_scan(&central.0);
+            crate::diagnostic_log::debug!("bluetooth: scanning for Prns peers");
+        }
+        ScanOp::Stop => {
+            // SAFETY: the retained central manager is only messaged on its serial dispatch queue.
+            unsafe { central.0.stopScan() };
+            crate::diagnostic_log::debug!("bluetooth: scanning stopped — at connection capacity");
+        }
+        ScanOp::None => {}
+    }
+}
+
+fn begin_dial(command: DialCommand, inbound_sessions_active: bool) {
     let DialCommand {
         central,
         delegate,
@@ -91,15 +156,27 @@ fn begin_dial(command: DialCommand) {
         peer_id,
         session,
     } = command;
-    if dial_admission(is_system_connected(&central, peer_id))
-        == DialAdmission::YieldToSystemConnection
-    {
-        crate::diagnostic_log::debug!(
-            "bluetooth: yielding dial to {:02x?} — peer is already connected system-wide; inbound session retains connection ownership",
-            peer_id.address().octets()
-        );
-        session.reject();
-        return;
+    match dial_admission(
+        is_system_connected(&central, peer_id),
+        inbound_sessions_active,
+    ) {
+        DialAdmission::YieldToSystemConnection => {
+            crate::diagnostic_log::debug!(
+                "bluetooth: yielding dial to {:02x?} — peer is already connected system-wide; inbound session retains connection ownership",
+                peer_id.address().octets()
+            );
+            session.reject();
+            return;
+        }
+        DialAdmission::YieldToInboundSession => {
+            crate::diagnostic_log::debug!(
+                "bluetooth: yielding dial to {:02x?} — inbound peripheral session owns the radio; Android RPA ads must not dual-role thrash the live link",
+                peer_id.address().octets()
+            );
+            session.reject();
+            return;
+        }
+        DialAdmission::AttachCentralSession => {}
     }
     // SAFETY: both retained Objective-C objects stay alive for the delegate assignment, which runs
     // on the CoreBluetooth serial dispatch queue.
@@ -143,6 +220,9 @@ pub struct MacosBleBackend {
     restored: RestoredPeripherals,
     dials: JoinSet<DialTaskOutcome>,
     queue: DispatchRetained<DispatchQueue>,
+    scan_enabled: bool,
+    advertise_enabled: bool,
+    radio_refresh_at: tokio::time::Instant,
 }
 
 struct NativeThread {
@@ -349,6 +429,9 @@ impl PreparedMacosBleBackend {
             restored: self.restored,
             dials: JoinSet::new(),
             queue,
+            scan_enabled: false,
+            advertise_enabled: false,
+            radio_refresh_at: tokio::time::Instant::now() + RADIO_REFRESH_INTERVAL,
         })
     }
 }
@@ -358,29 +441,17 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
     type Link = GattLink;
 
     async fn set_advertising(&mut self, mode: AdvertisingMode) -> Result<(), MacosBleError> {
+        self.advertise_enabled = mode.is_on();
         self.peripheral_delegate.0.set_advertising(mode);
         Ok(())
     }
 
     async fn set_scanning(&mut self, mode: ScanningMode) -> Result<(), MacosBleError> {
-        let enabled = mode.is_on();
+        self.scan_enabled = mode.is_on();
+        let restart = cfg!(target_os = "macos") && self.scan_enabled;
         let central = SendCentralManager(self.central.0.clone());
         self.queue.exec_async(move || {
-            let central = central;
-            // SAFETY: this authoritative CoreBluetooth state query runs on the retained manager's
-            // serial dispatch queue.
-            let is_scanning = unsafe { central.0.isScanning() };
-            if enabled && !is_scanning {
-                start_scan(&central.0);
-                crate::diagnostic_log::debug!("bluetooth: scanning for Prns peers");
-            } else if !enabled && is_scanning {
-                // SAFETY: the retained central manager is only messaged on its serial dispatch
-                // queue.
-                unsafe { central.0.stopScan() };
-                crate::diagnostic_log::debug!(
-                    "bluetooth: scanning stopped — at connection capacity"
-                );
-            }
+            apply_scanning(central, mode.is_on(), restart);
         });
         Ok(())
     }
@@ -399,6 +470,8 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
                 };
             }
             let pending_dials = !self.dials.is_empty();
+            let refresh_radio =
+                cfg!(target_os = "macos") && (self.scan_enabled || self.advertise_enabled);
             tokio::select! {
                 event = self.events.recv() => match event {
                     Some(Event::Sighting { address, rssi }) => {
@@ -409,6 +482,13 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
                         return BleEvent::Sighting { address, rssi };
                     }
                     Some(Event::Inbound(link)) => return BleEvent::Inbound(link),
+                    Some(Event::CentralPowered) if self.scan_enabled => {
+                        let central = SendCentralManager(self.central.0.clone());
+                        self.queue.exec_async(move || {
+                            apply_scanning(central, true, true);
+                        });
+                        continue;
+                    }
                     Some(_) => continue,
                     None => core::future::pending().await,
                 },
@@ -426,6 +506,24 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
                         }
                         Err(_) => continue,
                     }
+                }
+                _ = tokio::time::sleep_until(self.radio_refresh_at), if refresh_radio => {
+                    if self.scan_enabled {
+                        let central = SendCentralManager(self.central.0.clone());
+                        self.queue.exec_async(move || {
+                            apply_scanning(central, true, true);
+                        });
+                    }
+                    // Re-assert advertising only when no inbound sessions are live — bouncing
+                    // stop/startAdvertising drops connected centrals on some stacks.
+                    if self.advertise_enabled {
+                        self.peripheral_delegate
+                            .0
+                            .refresh_advertising_if_idle();
+                    }
+                    self.radio_refresh_at =
+                        tokio::time::Instant::now() + RADIO_REFRESH_INTERVAL;
+                    continue;
                 }
             }
         }
@@ -456,8 +554,11 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
             session: CentralPeerSession::new(address, control_tx, completion_tx, data_inbound_tx),
         };
         crate::diagnostic_log::debug!("bluetooth: dialing {token:02x?} over LE (central role)");
+        let peripheral_for_admission =
+            SendPeripheralDelegate(self.peripheral_delegate.0.clone());
         self.queue.exec_async(move || {
-            begin_dial(command);
+            let inbound = peripheral_for_admission.has_inbound_sessions();
+            begin_dial(command, inbound);
         });
         let send_peripheral = SendPeripheral(peripheral);
         let send_peripheral_manager = SendPeripheralDelegate(self.peripheral_delegate.0.clone());

--- a/prns-ffi/src/bluetooth_auto/macos/data_plane.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/data_plane.rs
@@ -2,6 +2,7 @@ use core::cell::RefCell;
 use core::ffi::c_void;
 use core::ptr::NonNull;
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use dispatch2::{DispatchQueue, DispatchRetained};
@@ -36,7 +37,22 @@ pub(super) struct StreamPump {
     output: Retained<NSOutputStream>,
     inbound_tx: RefCell<Option<tokio_mpsc::Sender<Box<[u8]>>>>,
     outbound: Arc<Mutex<Outbound>>,
+    on_dead: RefCell<Option<(super::SendPeripheralDelegate, CoreBluetoothPeerId)>>,
+    dead_fired: AtomicBool,
     _channel: Retained<CBL2CAPChannel>,
+}
+
+fn mark_data_plane_dead(pump: &StreamPump) {
+    if pump.dead_fired.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    if let Ok(mut out) = pump.outbound.lock() {
+        out.closed = true;
+    }
+    pump.inbound_tx.borrow_mut().take();
+    if let Some((delegate, peer_id)) = pump.on_dead.borrow_mut().take() {
+        delegate.end_inbound_session(peer_id);
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -108,8 +124,7 @@ pub(super) fn flush(pump: &StreamPump) {
                 crate::diagnostic_log::warn!(
                     "bluetooth: L2CAP write returned {written} — data plane down"
                 );
-                out.closed = true;
-                pump.inbound_tx.borrow_mut().take();
+                mark_data_plane_dead(pump);
             }
             break;
         }
@@ -140,10 +155,7 @@ unsafe extern "C-unwind" fn read_cb(
                     .as_ref()
                     .is_some_and(|tx| tx.try_send(Box::from(&buf[..read as usize])).is_ok());
                 if !accepted {
-                    pump.inbound_tx.borrow_mut().take();
-                    if let Ok(mut out) = pump.outbound.lock() {
-                        out.closed = true;
-                    }
+                    mark_data_plane_dead(pump);
                     break;
                 }
             } else {
@@ -155,7 +167,7 @@ unsafe extern "C-unwind" fn read_cb(
         crate::diagnostic_log::warn!(
             "bluetooth: L2CAP read stream closed/errored — inbound data plane down"
         );
-        pump.inbound_tx.borrow_mut().take();
+        mark_data_plane_dead(pump);
     }
 }
 
@@ -174,16 +186,14 @@ unsafe extern "C-unwind" fn write_cb(
         crate::diagnostic_log::warn!(
             "bluetooth: L2CAP write stream closed/errored — outbound data plane down"
         );
-        if let Ok(mut out) = pump.outbound.lock() {
-            out.closed = true;
-        }
-        pump.inbound_tx.borrow_mut().take();
+        mark_data_plane_dead(pump);
     }
 }
 
 pub(super) fn wire_l2cap(
     channel: &CBL2CAPChannel,
     queue: &DispatchRetained<DispatchQueue>,
+    on_dead: impl FnOnce(CoreBluetoothPeerId) -> Option<(super::SendPeripheralDelegate, CoreBluetoothPeerId)>,
 ) -> Option<(CoreBluetoothPeerId, DataPlane)> {
     // SAFETY: CoreBluetooth supplied a live retained channel, and its accessors return retained
     // objects whose runtime types match the generated bindings.
@@ -200,11 +210,14 @@ pub(super) fn wire_l2cap(
         pending: VecDeque::new(),
         closed: false,
     }));
+    let on_dead = on_dead(peer_id);
     let pump = Box::into_raw(Box::new(StreamPump {
         input,
         output,
         inbound_tx: RefCell::new(Some(inbound_tx)),
         outbound: outbound.clone(),
+        on_dead: RefCell::new(on_dead),
+        dead_fired: AtomicBool::new(false),
         _channel: channel.retain(),
     }));
     // SAFETY: `pump` is a live Box allocation kept by PumpHandle. NSInputStream/NSOutputStream are

--- a/prns-ffi/src/bluetooth_auto/macos/gatt_link.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/gatt_link.rs
@@ -434,6 +434,10 @@ impl BleLink for GattLink {
                         }
                     }
                 }
+                drop(frames);
+                crate::diagnostic_log::debug!(
+                    "bluetooth: L2CAP reader exited — merged data lane closing"
+                );
             });
             write_rx
         });

--- a/prns-ffi/src/bluetooth_auto/macos/mod.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/mod.rs
@@ -186,6 +186,7 @@ struct SendCentralDelegate(Retained<CentralDelegate>);
 // dispatch queue before and after transfer.
 unsafe impl Send for SendCentralDelegate {}
 
+#[derive(Clone)]
 struct SendPeripheralDelegate(Retained<PeripheralDelegate>);
 // SAFETY: the retained delegate's RefCell-backed state is accessed only by the serial CoreBluetooth
 // dispatch queue before and after transfer.
@@ -195,6 +196,10 @@ impl SendPeripheralDelegate {
     /// Queue-confined: call only from the CoreBluetooth serial dispatch queue.
     fn has_inbound_sessions(&self) -> bool {
         self.0.has_inbound_sessions()
+    }
+
+    fn end_inbound_session(&self, peer_id: CoreBluetoothPeerId) {
+        self.0.end_inbound_session(peer_id);
     }
 }
 

--- a/prns-ffi/src/bluetooth_auto/macos/mod.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/mod.rs
@@ -191,6 +191,14 @@ struct SendPeripheralDelegate(Retained<PeripheralDelegate>);
 // dispatch queue before and after transfer.
 unsafe impl Send for SendPeripheralDelegate {}
 
+impl SendPeripheralDelegate {
+    /// Queue-confined: call only from the CoreBluetooth serial dispatch queue.
+    fn has_inbound_sessions(&self) -> bool {
+        self.0.has_inbound_sessions()
+    }
+}
+
+
 enum Event {
     CentralPowered,
     GattServicePublished,

--- a/prns-ffi/src/bluetooth_auto/macos/peripheral.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/peripheral.rs
@@ -275,7 +275,10 @@ define_class!(
                 );
                 return;
             };
-            let Some((peer_id, data)) = wire_l2cap(channel, &self.ivars().queue) else {
+            let delegate = SendPeripheralDelegate(self.retain());
+            let Some((peer_id, data)) = wire_l2cap(channel, &self.ivars().queue, move |peer_id| {
+                Some((delegate, peer_id))
+            }) else {
                 crate::diagnostic_log::warn!(
                     "bluetooth: L2CAP channel exposes no streams — dropping"
                 );
@@ -438,8 +441,7 @@ define_class!(
                 .get(&peer_id)
                 .is_some_and(|session| Some(session.protocol) == unsubscribed_protocol);
             if remove {
-                self.ivars().sessions.borrow_mut().remove(&peer_id);
-                self.ivars().pending_l2cap.borrow_mut().remove(&peer_id);
+                self.end_inbound_session(peer_id);
             }
         }
 
@@ -456,6 +458,17 @@ impl PeripheralDelegate {
     /// Queue-confined: call only from the CoreBluetooth serial dispatch queue.
     pub(super) fn has_inbound_sessions(&self) -> bool {
         !self.ivars().sessions.borrow().is_empty()
+    }
+
+    /// Queue-confined: call only from the CoreBluetooth serial dispatch queue.
+    pub(super) fn end_inbound_session(&self, peer_id: CoreBluetoothPeerId) {
+        if self.ivars().sessions.borrow_mut().remove(&peer_id).is_some() {
+            self.ivars().pending_l2cap.borrow_mut().remove(&peer_id);
+            crate::diagnostic_log::warn!(
+                "bluetooth: inbound session ended for {:02x?} — link teardown starting",
+                peer_id.address().octets()
+            );
+        }
     }
 
     pub(super) fn new(

--- a/prns-ffi/src/bluetooth_auto/macos/peripheral.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/peripheral.rs
@@ -453,6 +453,11 @@ define_class!(
 );
 
 impl PeripheralDelegate {
+    /// Queue-confined: call only from the CoreBluetooth serial dispatch queue.
+    pub(super) fn has_inbound_sessions(&self) -> bool {
+        !self.ivars().sessions.borrow().is_empty()
+    }
+
     pub(super) fn new(
         events: tokio_mpsc::UnboundedSender<Event>,
         queue: DispatchRetained<DispatchQueue>,
@@ -657,6 +662,50 @@ impl PeripheralDelegate {
         });
     }
 
+    /// Periodic watchdog path: bounce advertising only when idle. A stop/start while a central is
+    /// subscribed tears down the live inbound GATT/L2CAP link on dual-role peers.
+    pub(super) fn refresh_advertising_if_idle(&self) {
+        let queue = self.ivars().queue.clone();
+        let this = SendPeripheralDelegate(self.retain());
+        queue.exec_async(move || {
+            let this = this;
+            if this.has_inbound_sessions() {
+                crate::diagnostic_log::debug!(
+                    "bluetooth: skipped advertising refresh — inbound session active"
+                );
+                return;
+            }
+            let Some(manager) = this
+                .0
+                .ivars()
+                .manager
+                .borrow()
+                .as_ref()
+                .map(|m| m.0.clone())
+            else {
+                return;
+            };
+            // SAFETY: this authoritative CoreBluetooth state query runs on the retained manager's
+            // serial dispatch queue.
+            let is_advertising = unsafe { manager.isAdvertising() };
+            if is_advertising {
+                // SAFETY: the retained manager is messaged only on its serial dispatch queue.
+                unsafe { manager.stopAdvertising() };
+            }
+            let uuid = service_uuid();
+            let services = NSArray::from_slice(&[&*uuid]);
+            let data = advertisement_data(&services);
+            // SAFETY: the retained manager is messaged on its serial dispatch queue and the
+            // advertisement dictionary remains live for the synchronous call.
+            unsafe { manager.startAdvertising(Some(&data)) };
+            if is_advertising {
+                crate::diagnostic_log::debug!(
+                    "bluetooth: restarted advertising — discoverable as Prns"
+                );
+            }
+        });
+    }
+
     pub(super) fn set_advertising(&self, mode: AdvertisingMode) {
         let queue = self.ivars().queue.clone();
         let this = SendPeripheralDelegate(self.retain());
@@ -675,14 +724,18 @@ impl PeripheralDelegate {
             // SAFETY: this authoritative CoreBluetooth state query runs on the retained manager's
             // serial dispatch queue.
             let is_advertising = unsafe { manager.isAdvertising() };
-            if mode.is_on() && !is_advertising {
+            if mode.is_on() {
+                // Policy only toggles On when currently Off; do not bounce while subscribed.
+                if is_advertising {
+                    return;
+                }
                 let uuid = service_uuid();
                 let services = NSArray::from_slice(&[&*uuid]);
                 let data = advertisement_data(&services);
                 // SAFETY: the retained manager is messaged on its serial dispatch queue and the
                 // advertisement dictionary remains live for the synchronous call.
                 unsafe { manager.startAdvertising(Some(&data)) };
-            } else if !mode.is_on() && is_advertising {
+            } else if is_advertising {
                 // SAFETY: the retained manager is messaged only on its serial dispatch queue.
                 unsafe { manager.stopAdvertising() };
                 crate::diagnostic_log::debug!(

--- a/prns-ffi/src/bluetooth_auto/macos/tests.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/tests.rs
@@ -6,7 +6,7 @@ use prns_core::interfaces::bluetooth_auto::{
 };
 use tokio::sync::{mpsc, oneshot};
 
-use super::backend::{dial_admission, DialAdmission, StartupReadiness};
+use super::backend::{dial_admission, scan_op, DialAdmission, ScanOp, StartupReadiness};
 use super::central::CentralPeerSession;
 use super::discovery::{
     candidate_strength, discover_disposition, CandidateStrength, DiscoverDisposition,
@@ -166,9 +166,34 @@ fn startup_requires_central_gatt_and_l2cap_readiness() {
 }
 
 #[test]
-fn dial_yields_only_when_peer_is_already_system_connected() {
-    assert_eq!(dial_admission(true), DialAdmission::YieldToSystemConnection);
-    assert_eq!(dial_admission(false), DialAdmission::AttachCentralSession);
+fn dial_yields_for_system_connection_or_live_inbound_session() {
+    assert_eq!(
+        dial_admission(true, false),
+        DialAdmission::YieldToSystemConnection
+    );
+    assert_eq!(
+        dial_admission(false, true),
+        DialAdmission::YieldToInboundSession
+    );
+    assert_eq!(
+        dial_admission(true, true),
+        DialAdmission::YieldToSystemConnection
+    );
+    assert_eq!(
+        dial_admission(false, false),
+        DialAdmission::AttachCentralSession
+    );
+}
+
+#[test]
+fn scan_op_starts_restarts_and_stops_without_spurious_work() {
+    assert_eq!(scan_op(true, false, false), ScanOp::Start);
+    assert_eq!(scan_op(true, false, true), ScanOp::Start);
+    assert_eq!(scan_op(true, true, false), ScanOp::None);
+    assert_eq!(scan_op(true, true, true), ScanOp::Restart);
+    assert_eq!(scan_op(false, true, false), ScanOp::Stop);
+    assert_eq!(scan_op(false, true, true), ScanOp::Stop);
+    assert_eq!(scan_op(false, false, true), ScanOp::None);
 }
 
 #[test]

--- a/prns-interfaces/impls/embassy/src/bluetooth_auto/runtime.rs
+++ b/prns-interfaces/impls/embassy/src/bluetooth_auto/runtime.rs
@@ -1414,6 +1414,7 @@ async fn apply_settled<
                 slot,
                 address,
                 lane,
+                ..
             } => {
                 if let Some(mut link) = held.take() {
                     if !matches!(lane, L2capPlan::None) {

--- a/prns-interfaces/impls/tokio/src/bluetooth_auto/runtime.rs
+++ b/prns-interfaces/impls/tokio/src/bluetooth_auto/runtime.rs
@@ -719,6 +719,7 @@ async fn apply_settle<B, const MAX_PEERS: usize>(
                 identity,
                 address,
                 lane,
+                peer_rssi,
                 ..
             } => {
                 if let Some(mut held) = link.take() {
@@ -727,7 +728,8 @@ async fn apply_settle<B, const MAX_PEERS: usize>(
                     let member = BluetoothPeer::with_policy(identity, source, sink, policy)
                         .report_close_to(address, closed.clone());
                     let status = member.status();
-                    let attached = fleet.add(member);
+                    let name = format_ble_peer_name(identity, address);
+                    let attached = fleet.add_named(member, name, peer_rssi);
                     members.insert(
                         identity,
                         TokioMember {
@@ -817,6 +819,15 @@ async fn drive_handshake<L: BleLink>(
         Ok(result) => result,
         Err(_) => Err(HandshakeFailure::Timeout),
     }
+}
+
+fn format_ble_peer_name(identity: BleIdentity, address: BleAddress) -> String {
+    let id = identity.as_bytes();
+    let addr = address.octets();
+    format!(
+        "{:02x}{:02x}{:02x}{:02x}… @ {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
+        id[0], id[1], id[2], id[3], addr[0], addr[1], addr[2], addr[3], addr[4], addr[5]
+    )
 }
 
 async fn arm_fast_lane<L: BleLink>(link: &mut L, lane: &L2capPlan) {

--- a/prns-interfaces/impls/tokio/src/weave/supervision/mod.rs
+++ b/prns-interfaces/impls/tokio/src/weave/supervision/mod.rs
@@ -338,7 +338,8 @@ fn ensure_peer(
         outbound.clone(),
     );
     let peer_status = peer.status();
-    let attached = fleet.add(peer);
+    let endpoint_name = format_weave_peer_name(endpoint);
+    let attached = fleet.add_named(peer, endpoint_name, None);
     peers.insert(
         endpoint,
         ManagedPeer {
@@ -381,6 +382,14 @@ fn teardown_peers(peers: &mut HashMap<EndpointId, ManagedPeer>, status: &WeaveIn
 
 fn publish_members(peers: &HashMap<EndpointId, ManagedPeer>, status: &WeaveInterfaceStatus) {
     status.set_members(peers.values().map(|peer| peer.status.clone()).collect());
+}
+
+fn format_weave_peer_name(endpoint: EndpointId) -> String {
+    let bytes = endpoint.as_bytes();
+    format!(
+        "endpoint {:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7]
+    )
 }
 
 fn encoding_error(error: weave::EncodeError) -> io::Error {

--- a/prns-interfaces/impls/tokio/src/wifi_auto/mdns.rs
+++ b/prns-interfaces/impls/tokio/src/wifi_auto/mdns.rs
@@ -26,6 +26,11 @@ use super::{
 
 const RETRY_INTERVAL: Duration = Duration::from_secs(5);
 const RECONCILE_INTERVAL: Duration = Duration::from_secs(1);
+/// Keep a previously registered UDP (or TCP) service alive across brief windows where
+/// `collect_eligible_ip_addresses` returns no publishable addresses — e.g. transient
+/// link-local IPv6 flicker — so Bonjour browsers do not see goodbye/re-register flaps
+/// every second.
+const PUBLICATION_EMPTY_GRACE: Duration = Duration::from_secs(15);
 pub(crate) const DISCOVERY_CAPACITY: NonZeroU8 = contract::DEFAULT_DISCOVERY_SERVICE_CAPACITY;
 
 /// Starts the native DNS-SD provider behind a bounded AutoWifi discovery channel.
@@ -501,6 +506,7 @@ struct NativeMdnsSession {
     daemon: ServiceDaemon,
     browsed_transports: BTreeSet<DiscoveryTransport>,
     registered_services: BTreeMap<DiscoveryTransport, RegisteredService>,
+    empty_publication_since: BTreeMap<DiscoveryTransport, std::time::Instant>,
 }
 
 impl NativeMdnsSession {
@@ -509,6 +515,7 @@ impl NativeMdnsSession {
             daemon: ServiceDaemon::new().map_err(MdnsDiscoveryError::Mdns)?,
             browsed_transports: BTreeSet::new(),
             registered_services: BTreeMap::new(),
+            empty_publication_since: BTreeMap::new(),
         };
         native_mdns_session
             .daemon
@@ -552,6 +559,18 @@ impl NativeMdnsSession {
         let advertised_ip_addresses =
             advertised_ip_addresses(ephemeral_publication.transport, eligible_ip_addresses);
         if advertised_ip_addresses.is_empty() {
+            let previously_registered = self
+                .registered_services
+                .contains_key(&ephemeral_publication.transport);
+            if previously_registered {
+                let empty_since = self
+                    .empty_publication_since
+                    .entry(ephemeral_publication.transport)
+                    .or_insert_with(std::time::Instant::now);
+                if empty_since.elapsed() < PUBLICATION_EMPTY_GRACE {
+                    return Ok(());
+                }
+            }
             if let Some(previously_registered_service) = self
                 .registered_services
                 .remove(&ephemeral_publication.transport)
@@ -560,8 +579,12 @@ impl NativeMdnsSession {
                     .daemon
                     .unregister(&previously_registered_service.service_fullname);
             }
+            self.empty_publication_since
+                .remove(&ephemeral_publication.transport);
             return Ok(());
         }
+        self.empty_publication_since
+            .remove(&ephemeral_publication.transport);
 
         let desired_service = RegisteredService {
             service_fullname: ephemeral_publication.service_name.as_str().to_owned(),

--- a/prns-interfaces/impls/tokio/src/wifi_auto/mod.rs
+++ b/prns-interfaces/impls/tokio/src/wifi_auto/mod.rs
@@ -1017,7 +1017,8 @@ impl DiscoveredTcpDials {
                 RENDEZVOUS_RECONNECT,
             );
             let client_status = tcp_client.status();
-            let attached_client = fleet.add(tcp_client);
+            let attached_client =
+                fleet.add_named(tcp_client, desired_endpoint.to_string(), None);
             self.members.insert(
                 desired_endpoint,
                 AttachedStatus {
@@ -1279,7 +1280,8 @@ impl Supervisor {
                         self.policy,
                     );
                     let connection_status = tcp_connection.status();
-                    let attached_connection = self.fleet.add(tcp_connection);
+                    let attached_connection =
+                        self.fleet.add_named(tcp_connection, peer_address.to_string(), None);
                     self.accepted.push(AttachedStatus {
                         attached: attached_connection,
                         status: connection_status,
@@ -1559,7 +1561,8 @@ impl Supervisor {
             &self.settings.instance_tag,
         );
         let status = member.status();
-        let attached = self.fleet.add(member);
+        let peer_name = format!("{}%{}", peer_address.ip_address, peer_address.scope_id);
+        let attached = self.fleet.add_named(member, peer_name, None);
         crate::diagnostic_log::debug!(
             "wifi-auto: peer {}%{} discovered",
             peer_address.ip_address,
@@ -1693,9 +1696,9 @@ impl Supervisor {
             return;
         }
         let target = std::format!("127.0.0.1:{}", contract::TCP_RENDEZVOUS_PORT);
-        let client = TcpClientInterface::with_policy(target, self.policy, RENDEZVOUS_RECONNECT);
+        let client = TcpClientInterface::with_policy(target.clone(), self.policy, RENDEZVOUS_RECONNECT);
         let status = client.status();
-        let attached = self.fleet.add(client);
+        let attached = self.fleet.add_named(client, target, None);
         self.loopback = Some(AttachedStatus { attached, status });
         self.publish_status();
     }
@@ -1801,9 +1804,10 @@ impl Supervisor {
             crate::diagnostic_log::debug!(
                 "wifi-auto: dialing gateway rendezvous {target} on ifindex {index}"
             );
-            let client = TcpClientInterface::with_policy(target, self.policy, RENDEZVOUS_RECONNECT);
+            let client =
+                TcpClientInterface::with_policy(target.clone(), self.policy, RENDEZVOUS_RECONNECT);
             let status = client.status();
-            let attached = self.fleet.add(client);
+            let attached = self.fleet.add_named(client, target, None);
             self.gateways.insert(
                 index,
                 GatewayDial {

--- a/prns-runtime/core/src/runtime/node_introspection/core.rs
+++ b/prns-runtime/core/src/runtime/node_introspection/core.rs
@@ -4,6 +4,9 @@ use prns_core::interfaces::{
     InterfaceSnapshot, Membership, TransferRates,
 };
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InterfaceIfacSnapshot<Label> {
     pub signature: [u8; 64],
@@ -17,6 +20,11 @@ pub struct InterfaceInventoryEntry<Label> {
     pub origin: InterfaceOriginKind,
     pub snapshot: InterfaceSnapshot,
     pub ifac: Option<InterfaceIfacSnapshot<Label>>,
+    /// Link-up RSSI in dBm when the interface recorded one (Bluetooth Auto peers).
+    pub rssi: Option<i8>,
+    /// Fleet members nested under a folded supervisor. Always empty on leaf entries.
+    #[cfg(feature = "alloc")]
+    pub members: Vec<InterfaceInventoryEntry<Label>>,
 }
 
 struct FoldedInterface<Label> {
@@ -25,6 +33,9 @@ struct FoldedInterface<Label> {
     origin: InterfaceOriginKind,
     root: Option<InterfaceSnapshot>,
     ifac: Option<InterfaceIfacSnapshot<Label>>,
+    rssi: Option<i8>,
+    #[cfg(feature = "alloc")]
+    members: Vec<InterfaceInventoryEntry<Label>>,
     member_connection: ConnectionState,
     member_mode: Option<InterfaceMode>,
     member_gravity: Option<InterfaceGravity>,
@@ -46,6 +57,9 @@ impl<Label> FoldedInterface<Label> {
             origin,
             root: None,
             ifac: None,
+            rssi: None,
+            #[cfg(feature = "alloc")]
+            members: Vec::new(),
             member_connection: ConnectionState::Unknown,
             member_mode: None,
             member_gravity: None,
@@ -60,7 +74,10 @@ impl<Label> FoldedInterface<Label> {
         }
     }
 
-    fn add(&mut self, entry: &mut InterfaceInventoryEntry<Label>) {
+    fn add(&mut self, entry: &mut InterfaceInventoryEntry<Label>)
+    where
+        Label: Clone,
+    {
         let snapshot = entry.snapshot;
         self.destinations = self.destinations.saturating_add(snapshot.destinations);
         self.links = self.links.saturating_add(snapshot.links);
@@ -77,6 +94,7 @@ impl<Label> FoldedInterface<Label> {
                 if entry.ifac.is_some() {
                     self.ifac = entry.ifac.take();
                 }
+                self.rssi = entry.rssi.or(self.rssi);
             }
             Membership::FleetMember { .. } => {
                 if self.root.is_none() && entry.origin == InterfaceOriginKind::Discovered {
@@ -98,11 +116,28 @@ impl<Label> FoldedInterface<Label> {
                     aggregate.rx_bps = aggregate.rx_bps.saturating_add(rates.rx_bps);
                     aggregate.tx_bps = aggregate.tx_bps.saturating_add(rates.tx_bps);
                 }
-                if self.name.is_none() {
-                    self.name = entry.name.take();
+                #[cfg(feature = "alloc")]
+                {
+                    if self.ifac.is_none() {
+                        self.ifac = entry.ifac.clone();
+                    }
+                    self.members.push(InterfaceInventoryEntry {
+                        name: entry.name.take(),
+                        origin: entry.origin,
+                        snapshot,
+                        ifac: entry.ifac.take(),
+                        rssi: entry.rssi,
+                        members: Vec::new(),
+                    });
                 }
-                if self.ifac.is_none() {
-                    self.ifac = entry.ifac.take();
+                #[cfg(not(feature = "alloc"))]
+                {
+                    if self.name.is_none() {
+                        self.name = entry.name.take();
+                    }
+                    if self.ifac.is_none() {
+                        self.ifac = entry.ifac.take();
+                    }
                 }
             }
         }
@@ -153,12 +188,15 @@ impl<Label> FoldedInterface<Label> {
                 membership: Membership::Independent,
             },
             ifac: self.ifac,
+            rssi: self.rssi,
+            #[cfg(feature = "alloc")]
+            members: self.members,
         }
     }
 }
 
 #[must_use]
-pub fn fold_logical_interface_inventory<Label: Ord>(
+pub fn fold_logical_interface_inventory<Label: Clone + Ord>(
     inventory: &mut [InterfaceInventoryEntry<Label>],
 ) -> &mut [InterfaceInventoryEntry<Label>] {
     inventory.sort_unstable_by(|left, right| {
@@ -263,6 +301,9 @@ mod tests {
                 membership,
             },
             ifac: None,
+            rssi: None,
+            #[cfg(feature = "alloc")]
+            members: Vec::new(),
         }
     }
 
@@ -275,7 +316,7 @@ mod tests {
             supervisor_id: supervisor,
         };
         let mut snapshots = [
-            snapshot(second, membership, 60, 3, 2, None),
+            snapshot(second, membership, 60, 3, 2, Some("second-peer")),
             snapshot(
                 supervisor,
                 Membership::Independent,
@@ -284,7 +325,11 @@ mod tests {
                 0,
                 Some("Public server"),
             ),
-            snapshot(first, membership, 40, 2, 1, None),
+            {
+                let mut peer = snapshot(first, membership, 40, 2, 1, Some("first-peer"));
+                peer.rssi = Some(-61);
+                peer
+            },
         ];
 
         let logical = fold_logical_interface_inventory(&mut snapshots);
@@ -297,6 +342,27 @@ mod tests {
         assert_eq!(logical[0].snapshot.destinations, 5);
         assert_eq!(logical[0].snapshot.links, 3);
         assert_eq!(logical[0].snapshot.membership, Membership::Independent);
+        #[cfg(feature = "alloc")]
+        {
+            assert_eq!(logical[0].members.len(), 2);
+            let member_names: alloc::vec::Vec<_> =
+                logical[0].members.iter().map(|peer| peer.name).collect();
+            assert!(member_names.contains(&Some("first-peer")));
+            assert!(member_names.contains(&Some("second-peer")));
+            let first_peer = logical[0]
+                .members
+                .iter()
+                .find(|peer| peer.snapshot.id == first)
+                .expect("first peer retained");
+            assert_eq!(first_peer.snapshot.rx_bytes, 40);
+            assert_eq!(first_peer.rssi, Some(-61));
+            let second_peer = logical[0]
+                .members
+                .iter()
+                .find(|peer| peer.snapshot.id == second)
+                .expect("second peer retained");
+            assert_eq!(second_peer.snapshot.rx_bytes, 60);
+        }
     }
 
     #[test]

--- a/prns-runtime/core/src/runtime/node_introspection/impls/heap.rs
+++ b/prns-runtime/core/src/runtime/node_introspection/impls/heap.rs
@@ -92,7 +92,7 @@ pub trait NodeIntrospection {
 }
 
 #[must_use]
-pub fn logical_interface_inventory<Label: Ord>(
+pub fn logical_interface_inventory<Label: Clone + Ord>(
     mut inventory: Vec<InterfaceInventoryEntry<Label>>,
 ) -> Vec<InterfaceInventoryEntry<Label>> {
     let logical_len = fold_logical_interface_inventory(&mut inventory).len();

--- a/prns-runtime/core/src/runtime/rns_management.rs
+++ b/prns-runtime/core/src/runtime/rns_management.rs
@@ -14,18 +14,29 @@ pub fn interface_stats(inventory: Vec<InterfaceInventoryEntry<String>>) -> RnsIn
     RnsInterfaceStats::new(
         logical_interface_inventory(inventory)
             .into_iter()
-            .map(|entry| {
-                let access_code = entry.ifac.map(|access_code| {
-                    RnsInterfaceAccessCode::new(
-                        access_code.signature,
-                        access_code.size,
-                        access_code.network_name,
-                    )
-                });
-                RnsInterfaceStatsEntry::new(entry.name, entry.snapshot, access_code)
-            })
+            .map(stats_entry_from_inventory)
             .collect(),
     )
+}
+
+fn stats_entry_from_inventory(entry: InterfaceInventoryEntry<String>) -> RnsInterfaceStatsEntry {
+    let access_code = entry.ifac.map(|access_code| {
+        RnsInterfaceAccessCode::new(
+            access_code.signature,
+            access_code.size,
+            access_code.network_name,
+        )
+    });
+    let fleet_peers = entry
+        .members
+        .into_iter()
+        .map(|member| {
+            RnsInterfaceStatsEntry::new(member.name, member.snapshot, None).with_rssi(member.rssi)
+        })
+        .collect();
+    RnsInterfaceStatsEntry::new(entry.name, entry.snapshot, access_code)
+        .with_rssi(entry.rssi)
+        .with_fleet_peers(fleet_peers)
 }
 
 pub fn announce_rate_table(entries: Vec<AnnounceRateSnapshot>) -> RnsAnnounceRateTable {

--- a/prns-runtime/core/src/runtime/rns_rpc/tests/routes.rs
+++ b/prns-runtime/core/src/runtime/rns_rpc/tests/routes.rs
@@ -113,6 +113,8 @@ async fn interface_stats_renders_each_held_interface_with_its_live_counters() {
                     size: prns_core::interfaces::IfacSize::WIDE,
                     network_name: Some("private-net".into()),
                 }),
+                rssi: None,
+                members: std::vec::Vec::new(),
             },
             InterfaceInventoryEntry {
                 name: Some("Remote bridge".into()),
@@ -135,6 +137,8 @@ async fn interface_stats_renders_each_held_interface_with_its_live_counters() {
                     membership: prns_core::interfaces::Membership::Independent,
                 },
                 ifac: None,
+                rssi: None,
+                members: std::vec::Vec::new(),
             },
         ],
     };

--- a/prns-runtime/impls/tokio/src/runtime/node_facade/interface_lifecycle/mod.rs
+++ b/prns-runtime/impls/tokio/src/runtime/node_facade/interface_lifecycle/mod.rs
@@ -173,6 +173,7 @@ impl PrnsNodeHandle {
                 gravity: descriptor.gravity,
                 ifac: ifac.as_ref().map(RuntimeIfac::snapshot),
                 name,
+                rssi: None,
                 byte_accounting: ByteAccounting::OwnTraffic,
                 retired_member_bytes: RetiredMemberBytes::default(),
             }),
@@ -220,6 +221,8 @@ impl PrnsNodeHandle {
                             membership: placement.membership,
                         },
                         ifac: ifac.clone(),
+                        rssi: registered.rssi,
+                        members: std::vec::Vec::new(),
                     }
                 })
             })
@@ -318,6 +321,7 @@ impl PrnsNodeHandle {
                 gravity: policy.gravity,
                 ifac: ifac_status,
                 name: None,
+                rssi: None,
                 byte_accounting: ByteAccounting::FleetAggregate,
                 retired_member_bytes: RetiredMemberBytes::default(),
             }),
@@ -513,6 +517,31 @@ impl Fleet {
     where
         I: Interface + ReportsStatus + Send + 'static,
     {
+        self.add_with_peer_status(interface, None, None)
+    }
+
+    /// Stand up a named fleet member, optionally recording link-up RSSI for status nesting.
+    pub fn add_named<I>(
+        &self,
+        interface: I,
+        name: impl Into<String>,
+        rssi: Option<i8>,
+    ) -> AttachedInterface
+    where
+        I: Interface + ReportsStatus + Send + 'static,
+    {
+        self.add_with_peer_status(interface, Some(name.into()), rssi)
+    }
+
+    fn add_with_peer_status<I>(
+        &self,
+        interface: I,
+        name: Option<String>,
+        rssi: Option<i8>,
+    ) -> AttachedInterface
+    where
+        I: Interface + ReportsStatus + Send + 'static,
+    {
         let view = interface.status_view();
         let connection = interface.connection_view();
         let descriptor = interface.descriptor();
@@ -543,7 +572,8 @@ impl Fleet {
                 mode: descriptor.mode,
                 gravity: descriptor.gravity,
                 ifac: self.ifac.as_ref().map(RuntimeIfac::snapshot),
-                name: None,
+                name,
+                rssi,
                 byte_accounting: ByteAccounting::OwnTraffic,
                 retired_member_bytes: RetiredMemberBytes::default(),
             }),
@@ -705,6 +735,7 @@ pub(super) struct RegisteredInterface {
     gravity: crate::interfaces::InterfaceGravity,
     ifac: Option<InterfaceIfacSnapshot>,
     name: Option<String>,
+    rssi: Option<i8>,
     byte_accounting: ByteAccounting,
     retired_member_bytes: RetiredMemberBytes,
 }

--- a/prns-runtime/impls/tokio/src/runtime/node_facade/interface_lifecycle/tests.rs
+++ b/prns-runtime/impls/tokio/src/runtime/node_facade/interface_lifecycle/tests.rs
@@ -155,6 +155,8 @@ async fn runtime_attachment_carries_ifac_wire_and_status_metadata() {
                 size: IfacSize::WIDE,
                 network_name: Some("private-net".into()),
             }),
+            rssi: None,
+            members: std::vec::Vec::new(),
         }]
     );
 }
@@ -201,6 +203,7 @@ fn registered_status(view: StatusView, membership: Membership) -> RegisteredInte
         gravity: crate::interfaces::InterfaceGravity::new(-27),
         ifac: None,
         name: None,
+        rssi: None,
         byte_accounting: ByteAccounting::OwnTraffic,
         retired_member_bytes: RetiredMemberBytes::default(),
     }

--- a/prnsd/src/utilities/rnstatus/json.rs
+++ b/prnsd/src/utilities/rnstatus/json.rs
@@ -1,6 +1,6 @@
 use personal_rns::interfaces::rns_management::wire_names::{interface, transport};
 use personal_rns::interfaces::rns_management::{
-    RnsInterfaceStatsReport, RnsInterfaceStatusReport, RnsOptionalField,
+    RnsFleetPeerReport, RnsInterfaceStatsReport, RnsInterfaceStatusReport, RnsOptionalField,
 };
 use serde_json::{Map, Value};
 
@@ -260,6 +260,37 @@ fn interface_value(status: &RnsInterfaceStatusReport) -> Value {
         &status.blocked_ip_list,
         |values| Value::Array(values.iter().cloned().map(Value::String).collect()),
     );
+    insert_optional_i64(&mut fields, interface::RSSI, &status.rssi);
+    if !status.fleet_peers.is_empty() {
+        fields.insert(
+            String::from(interface::FLEET_PEERS),
+            Value::Array(status.fleet_peers.iter().map(fleet_peer_value).collect()),
+        );
+    }
+    Value::Object(fields)
+}
+
+fn fleet_peer_value(peer: &RnsFleetPeerReport) -> Value {
+    let mut fields = Map::new();
+    fields.insert(String::from(interface::NAME), Value::String(peer.name.clone()));
+    fields.insert(String::from(interface::STATUS), peer.online.into());
+    fields.insert(
+        String::from(interface::RECEIVE_BYTES),
+        peer.receive_bytes.into(),
+    );
+    fields.insert(
+        String::from(interface::TRANSMIT_BYTES),
+        peer.transmit_bytes.into(),
+    );
+    fields.insert(
+        String::from(interface::RECEIVE_SPEED),
+        number(peer.receive_speed_bps),
+    );
+    fields.insert(
+        String::from(interface::TRANSMIT_SPEED),
+        number(peer.transmit_speed_bps),
+    );
+    insert_optional_i64(&mut fields, interface::RSSI, &peer.rssi);
     Value::Object(fields)
 }
 
@@ -393,6 +424,8 @@ mod tests {
                 String::from("192.0.2.10"),
                 String::from("2001:db8::1"),
             ]),
+            rssi: RnsOptionalField::Absent,
+            fleet_peers: vec![],
         };
         let Value::Object(fields) = interface_value(&status) else {
             unreachable!();

--- a/prnsd/src/utilities/rnstatus/render.rs
+++ b/prnsd/src/utilities/rnstatus/render.rs
@@ -154,6 +154,34 @@ fn render_interface(
     render_access(output, status);
     render_announce_state(output, status, args, now);
     render_traffic(output, status);
+    render_fleet_peers(output, status);
+}
+
+fn render_fleet_peers(output: &mut String, status: &RnsInterfaceStatusReport) {
+    if status.fleet_peers.is_empty() {
+        return;
+    }
+    let count = status.fleet_peers.len();
+    let _ = writeln!(output, "    Peers     : {count} connected");
+    for peer in &status.fleet_peers {
+        let state = if peer.online { "Up" } else { "Down" };
+        let mut line = format!("      {}  {state}", peer.name);
+        if let Some(rssi) = peer.rssi.value() {
+            line.push_str(&format!("  rssi {rssi}"));
+        }
+        let _ = writeln!(output, "{line}");
+        let tx = format!(
+            "↑{}  {}",
+            pretty_size(peer.transmit_bytes as f64, "B"),
+            pretty_speed(peer.transmit_speed_bps)
+        );
+        let rx = format!(
+            "↓{}  {}",
+            pretty_size(peer.receive_bytes as f64, "B"),
+            pretty_speed(peer.receive_speed_bps)
+        );
+        let _ = writeln!(output, "        Traffic   : {tx}\n                    {rx}");
+    }
 }
 
 fn render_clients(output: &mut String, status: &RnsInterfaceStatusReport, clients: u64) {
@@ -720,5 +748,79 @@ mod tests {
         assert_eq!(output, "    Gravity   : -7\n");
         assert_eq!(optional_i64(&RnsOptionalField::Value(-7)), -7);
         assert_eq!(optional_i64(&RnsOptionalField::Absent), 0);
+    }
+
+    #[test]
+    fn nested_fleet_peers_render_under_the_supervisor() {
+        let status = RnsInterfaceStatusReport {
+            name: String::from("Bluetooth Auto"),
+            short_name: RnsOptionalField::Absent,
+            interface_type: RnsOptionalField::Absent,
+            interface_hash: RnsOptionalField::Absent,
+            parent_name: RnsOptionalField::Absent,
+            parent_hash: RnsOptionalField::Absent,
+            online: true,
+            mode: personal_rns::interfaces::rns_management::RnsInterfaceMode::Full,
+            gravity: RnsOptionalField::Absent,
+            clients: RnsOptionalField::Absent,
+            receive_bytes: 100,
+            transmit_bytes: 50,
+            receive_speed_bps: 0.0,
+            transmit_speed_bps: 0.0,
+            bitrate_bps: RnsOptionalField::Absent,
+            peers: RnsOptionalField::Absent,
+            ifac_signature: RnsOptionalField::Absent,
+            ifac_size_bytes: RnsOptionalField::Absent,
+            ifac_network_name: RnsOptionalField::Absent,
+            autoconnect_source: RnsOptionalField::Absent,
+            announce_queue: RnsOptionalField::Absent,
+            held_announces: RnsOptionalField::Absent,
+            incoming_announce_frequency: RnsOptionalField::Absent,
+            outgoing_announce_frequency: RnsOptionalField::Absent,
+            incoming_path_request_frequency: RnsOptionalField::Absent,
+            outgoing_path_request_frequency: RnsOptionalField::Absent,
+            announce_rate_target_seconds: RnsOptionalField::Absent,
+            announce_rate_penalty_seconds: RnsOptionalField::Absent,
+            announce_rate_grace: RnsOptionalField::Absent,
+            burst_active: RnsOptionalField::Absent,
+            burst_activated_at: RnsOptionalField::Absent,
+            path_request_burst_active: RnsOptionalField::Absent,
+            path_request_burst_activated_at: RnsOptionalField::Absent,
+            i2p_connectable: RnsOptionalField::Absent,
+            i2p_b32: RnsOptionalField::Absent,
+            i2p_tunnel_state: RnsOptionalField::Absent,
+            airtime_short_percent: RnsOptionalField::Absent,
+            airtime_long_percent: RnsOptionalField::Absent,
+            channel_load_short_percent: RnsOptionalField::Absent,
+            channel_load_long_percent: RnsOptionalField::Absent,
+            noise_floor_dbm: RnsOptionalField::Absent,
+            interference_dbm: RnsOptionalField::Absent,
+            interference_last_at: RnsOptionalField::Absent,
+            interference_last_dbm: RnsOptionalField::Absent,
+            cpu_load_percent: RnsOptionalField::Absent,
+            cpu_temperature_celsius: RnsOptionalField::Absent,
+            memory_load_percent: RnsOptionalField::Absent,
+            battery_percent: RnsOptionalField::Absent,
+            battery_state: RnsOptionalField::Absent,
+            switch_id: RnsOptionalField::Absent,
+            endpoint_id: RnsOptionalField::Absent,
+            via_switch_id: RnsOptionalField::Absent,
+            blocked_ip_list: RnsOptionalField::Absent,
+            rssi: RnsOptionalField::Absent,
+            fleet_peers: vec![personal_rns::interfaces::rns_management::RnsFleetPeerReport {
+                name: String::from("ab12… @ AA:BB:CC:DD:EE:FF"),
+                online: true,
+                receive_bytes: 40,
+                transmit_bytes: 20,
+                receive_speed_bps: 0.0,
+                transmit_speed_bps: 0.0,
+                rssi: RnsOptionalField::Value(-61),
+            }],
+        };
+        let mut output = String::new();
+        render_fleet_peers(&mut output, &status);
+        assert!(output.contains("Peers     : 1 connected"));
+        assert!(output.contains("ab12… @ AA:BB:CC:DD:EE:FF  Up  rssi -61"));
+        assert!(output.contains("Traffic"));
     }
 }


### PR DESCRIPTION
## Summary
- Fix `Opens(E)` settle asymmetry: reject wrong GATT roles so the designated L2CAP opener can dial as central (Mac↔Android path).
- Harden macOS CoreBluetooth (scan watchdog, yield outbound dials while inbound is live, skip advertising bounce while linked) and Android reject teardown/redial.
- Keep Wi‑Fi Auto mDNS registrations across brief empty eligible-address windows so `_reticulum._udp` does not goodbye/re-register every second.

## Test plan
- [ ] Restart `prnsd` (macOS) + Android Hopspot with this build; confirm a peer appears and L2CAP fast lane comes up.
- [ ] Confirm Mac does not thrash outbound dials while an inbound Android session is live.
- [ ] Confirm Discovery no longer flaps ephemeral `_reticulum._udp` on brief IPv6 link-local empty windows.
- [ ] `cargo test -p prns-core --lib interfaces::bluetooth_auto`


Made with [Cursor](https://cursor.com)