### PR TITLE
Surface nested Auto fleet peers in prnsd status

### DIFF
--- a/prns-core/src/interfaces/bluetooth_auto/policy.rs
+++ b/prns-core/src/interfaces/bluetooth_auto/policy.rs
@@ -62,6 +62,7 @@ pub enum PolicyAction {
         slot: usize,
         address: BleAddress,
         lane: L2capPlan,
+        peer_rssi: Option<i8>,
     },
     Evict {
         identity: BleIdentity,
@@ -293,6 +294,7 @@ impl<const MAX_PEERS: usize, const DIAL_TRACK: usize> ConnectionPolicy<MAX_PEERS
             slot,
             address,
             lane,
+            peer_rssi: established.peer_rssi,
         });
         self.reconcile(emit);
     }
@@ -610,6 +612,7 @@ mod tests {
                     slot: 0,
                     address: addr(2),
                     lane: L2capPlan::None,
+                    peer_rssi: None,
                 },
                 PolicyAction::SetAdvertising(AdvertisingMode::Off),
                 PolicyAction::SetScanning(ScanningMode::Off),

--- a/prns-core/src/interfaces/rns_management/interface_stats.rs
+++ b/prns-core/src/interfaces/rns_management/interface_stats.rs
@@ -35,6 +35,8 @@ pub struct RnsInterfaceStatsEntry {
     name: Option<String>,
     snapshot: InterfaceSnapshot,
     access_code: Option<RnsInterfaceAccessCode>,
+    rssi: Option<i8>,
+    fleet_peers: Vec<RnsInterfaceStatsEntry>,
 }
 
 impl RnsInterfaceStatsEntry {
@@ -47,7 +49,19 @@ impl RnsInterfaceStatsEntry {
             name,
             snapshot,
             access_code,
+            rssi: None,
+            fleet_peers: Vec::new(),
         }
+    }
+
+    pub fn with_rssi(mut self, rssi: Option<i8>) -> Self {
+        self.rssi = rssi;
+        self
+    }
+
+    pub fn with_fleet_peers(mut self, fleet_peers: Vec<RnsInterfaceStatsEntry>) -> Self {
+        self.fleet_peers = fleet_peers;
+        self
     }
 }
 
@@ -170,7 +184,14 @@ fn encode_interface_entry(
         rx_bps: 0,
         tx_bps: 0,
     });
-    encoder.map(14)?;
+    let mut fields = 14usize;
+    if entry.rssi.is_some() {
+        fields = fields.saturating_add(1);
+    }
+    if !entry.fleet_peers.is_empty() {
+        fields = fields.saturating_add(1);
+    }
+    encoder.map(fields)?;
     encoder.string_field(interface::NAME, &name)?;
     encoder.string_field(interface::SHORT_NAME, &name)?;
     encoder.string_field(interface::TYPE, &interface_type(entry.snapshot.id))?;
@@ -206,6 +227,45 @@ fn encode_interface_entry(
     {
         Some(network_name) => encoder.string(network_name)?,
         None => encoder.nil(),
+    }
+    if let Some(rssi) = entry.rssi {
+        encoder.field(interface::RSSI)?;
+        encoder.signed(i64::from(rssi));
+    }
+    if !entry.fleet_peers.is_empty() {
+        encoder.field(interface::FLEET_PEERS)?;
+        encoder.array(entry.fleet_peers.len())?;
+        for peer in &entry.fleet_peers {
+            encode_fleet_peer_entry(encoder, peer)?;
+        }
+    }
+    Ok(())
+}
+
+fn encode_fleet_peer_entry(
+    encoder: &mut MessagePackEncoder,
+    entry: &RnsInterfaceStatsEntry,
+) -> Result<(), RnsManagementEncodeError> {
+    let name = entry
+        .name
+        .clone()
+        .unwrap_or_else(|| interface_name(entry.snapshot.id));
+    let rates = entry.snapshot.transfer_rates.unwrap_or(TransferRates {
+        rx_bps: 0,
+        tx_bps: 0,
+    });
+    let fields = if entry.rssi.is_some() { 7usize } else { 6usize };
+    encoder.map(fields)?;
+    encoder.string_field(interface::NAME, &name)?;
+    encoder.field(interface::STATUS)?;
+    encoder.boolean(is_online(entry.snapshot.connection));
+    encoder.unsigned_field(interface::RECEIVE_BYTES, entry.snapshot.rx_bytes)?;
+    encoder.unsigned_field(interface::TRANSMIT_BYTES, entry.snapshot.tx_bytes)?;
+    encoder.unsigned_field(interface::RECEIVE_SPEED, u64::from(rates.rx_bps))?;
+    encoder.unsigned_field(interface::TRANSMIT_SPEED, u64::from(rates.tx_bps))?;
+    if let Some(rssi) = entry.rssi {
+        encoder.field(interface::RSSI)?;
+        encoder.signed(i64::from(rssi));
     }
     Ok(())
 }

--- a/prns-core/src/interfaces/rns_management/mod.rs
+++ b/prns-core/src/interfaces/rns_management/mod.rs
@@ -31,7 +31,7 @@ pub use remote_request::{
     RnsRemoteStatusRequest,
 };
 pub use status_report::{
-    RnsInterfaceMode, RnsInterfaceStatsDecodeError, RnsInterfaceStatsReport,
+    RnsFleetPeerReport, RnsInterfaceMode, RnsInterfaceStatsDecodeError, RnsInterfaceStatsReport,
     RnsInterfaceStatusReport, RnsOptionalField, RnsRemoteInterfaceStatsReport, RnsStatsFieldPath,
     RnsStatsFieldScope,
 };

--- a/prns-core/src/interfaces/rns_management/status_report/decode.rs
+++ b/prns-core/src/interfaces/rns_management/status_report/decode.rs
@@ -1,4 +1,5 @@
 use alloc::collections::BTreeSet;
+use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::fmt;
@@ -11,8 +12,8 @@ use crate::interfaces::rns_management::wire_names::{interface, transport};
 use crate::wire::DestinationHash;
 
 use super::{
-    RnsInterfaceMode, RnsInterfaceStatsReport, RnsInterfaceStatusReport, RnsOptionalField,
-    RnsRemoteInterfaceStatsReport,
+    RnsFleetPeerReport, RnsInterfaceMode, RnsInterfaceStatsReport, RnsInterfaceStatusReport,
+    RnsOptionalField, RnsRemoteInterfaceStatsReport,
 };
 
 const MAXIMUM_DEPTH: usize = 8;
@@ -237,6 +238,8 @@ struct InterfaceBuilder {
     endpoint_id: RnsOptionalField<String>,
     via_switch_id: RnsOptionalField<String>,
     blocked_ip_list: RnsOptionalField<Vec<String>>,
+    rssi: RnsOptionalField<i64>,
+    fleet_peers: Vec<RnsFleetPeerReport>,
 }
 
 impl InterfaceBuilder {
@@ -299,6 +302,8 @@ impl InterfaceBuilder {
             endpoint_id: self.endpoint_id,
             via_switch_id: self.via_switch_id,
             blocked_ip_list: self.blocked_ip_list,
+            rssi: self.rssi,
+            fleet_peers: self.fleet_peers,
         })
     }
 }
@@ -571,10 +576,91 @@ fn read_interface(
             interface::BLOCKED_IP_LIST => {
                 interface_report.blocked_ip_list = read_optional_string_array(reader, path)?
             }
+            interface::RSSI => interface_report.rssi = read_optional_i64(reader, path)?,
+            interface::FLEET_PEERS => {
+                interface_report.fleet_peers = read_fleet_peers(reader, index)?
+            }
             _ => skip(reader)?,
         }
     }
     interface_report.finish(index)
+}
+
+fn read_fleet_peers(
+    reader: &mut MessagePackReader<'_>,
+    parent_index: usize,
+) -> Result<Vec<RnsFleetPeerReport>, RnsInterfaceStatsDecodeError> {
+    let marker = marker(reader)?;
+    let length = reader
+        .array_length(marker)
+        .map_err(|_| RnsInterfaceStatsDecodeError::InvalidMessagePack)?
+        .ok_or(RnsInterfaceStatsDecodeError::ExpectedInterfacesArray)?;
+    let mut peers = Vec::new();
+    peers
+        .try_reserve_exact(length)
+        .map_err(|_| RnsInterfaceStatsDecodeError::AllocationFailed { entries: length })?;
+    for peer_index in 0..length {
+        peers.push(read_fleet_peer(reader, parent_index, peer_index)?);
+    }
+    Ok(peers)
+}
+
+fn read_fleet_peer(
+    reader: &mut MessagePackReader<'_>,
+    parent_index: usize,
+    peer_index: usize,
+) -> Result<RnsFleetPeerReport, RnsInterfaceStatsDecodeError> {
+    let marker = marker(reader)?;
+    let length = reader
+        .map_length(marker)
+        .map_err(|_| RnsInterfaceStatsDecodeError::InvalidMessagePack)?
+        .ok_or(RnsInterfaceStatsDecodeError::ExpectedInterfaceMap {
+            index: parent_index,
+        })?;
+    let mut fields = BTreeSet::new();
+    let mut name = None;
+    let mut online = None;
+    let mut receive_bytes = None;
+    let mut transmit_bytes = None;
+    let mut receive_speed_bps = None;
+    let mut transmit_speed_bps = None;
+    let mut rssi = RnsOptionalField::Absent;
+    for _ in 0..length {
+        let key = read_key(reader, RnsStatsFieldScope::Interface(parent_index))?;
+        let path = RnsStatsFieldPath::interface(parent_index, &format!("fleet_peers[{peer_index}].{key}"));
+        ensure_unique(&mut fields, path.clone())?;
+        match key.as_str() {
+            interface::NAME => name = Some(read_string(reader, path)?),
+            interface::STATUS => online = Some(read_bool(reader, path)?),
+            interface::RECEIVE_BYTES => receive_bytes = Some(read_u64(reader, path)?),
+            interface::TRANSMIT_BYTES => transmit_bytes = Some(read_u64(reader, path)?),
+            interface::RECEIVE_SPEED => receive_speed_bps = Some(read_number(reader, path)?),
+            interface::TRANSMIT_SPEED => transmit_speed_bps = Some(read_number(reader, path)?),
+            interface::RSSI => rssi = read_optional_i64(reader, path)?,
+            _ => skip(reader)?,
+        }
+    }
+    Ok(RnsFleetPeerReport {
+        name: required(name, RnsStatsFieldPath::interface(parent_index, interface::NAME))?,
+        online: required(online, RnsStatsFieldPath::interface(parent_index, interface::STATUS))?,
+        receive_bytes: required(
+            receive_bytes,
+            RnsStatsFieldPath::interface(parent_index, interface::RECEIVE_BYTES),
+        )?,
+        transmit_bytes: required(
+            transmit_bytes,
+            RnsStatsFieldPath::interface(parent_index, interface::TRANSMIT_BYTES),
+        )?,
+        receive_speed_bps: required(
+            receive_speed_bps,
+            RnsStatsFieldPath::interface(parent_index, interface::RECEIVE_SPEED),
+        )?,
+        transmit_speed_bps: required(
+            transmit_speed_bps,
+            RnsStatsFieldPath::interface(parent_index, interface::TRANSMIT_SPEED),
+        )?,
+        rssi,
+    })
 }
 
 fn required<T>(

--- a/prns-core/src/interfaces/rns_management/status_report/mod.rs
+++ b/prns-core/src/interfaces/rns_management/status_report/mod.rs
@@ -136,6 +136,19 @@ pub struct RnsInterfaceStatusReport {
     pub endpoint_id: RnsOptionalField<String>,
     pub via_switch_id: RnsOptionalField<String>,
     pub blocked_ip_list: RnsOptionalField<Vec<String>>,
+    pub rssi: RnsOptionalField<i64>,
+    pub fleet_peers: Vec<RnsFleetPeerReport>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RnsFleetPeerReport {
+    pub name: String,
+    pub online: bool,
+    pub receive_bytes: u64,
+    pub transmit_bytes: u64,
+    pub receive_speed_bps: f64,
+    pub transmit_speed_bps: f64,
+    pub rssi: RnsOptionalField<i64>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/prns-core/src/interfaces/rns_management/tests.rs
+++ b/prns-core/src/interfaces/rns_management/tests.rs
@@ -91,6 +91,70 @@ fn interface_stats_preserve_live_counters_and_access_code_fields() {
 }
 
 #[test]
+fn interface_stats_encode_nested_fleet_peers_with_rssi() {
+    let supervisor = InterfaceId::from_channel_tag(InterfaceKind::BluetoothAuto, b"ble");
+    let peer = InterfaceId::from_channel_tag(InterfaceKind::BluetoothPeer, b"peer");
+    let stats = RnsInterfaceStats::new(vec![RnsInterfaceStatsEntry::new(
+        Some(String::from("Bluetooth Auto")),
+        InterfaceSnapshot {
+            id: supervisor,
+            mode: crate::interfaces::InterfaceMode::Full,
+            gravity: crate::interfaces::InterfaceGravity::ZERO,
+            connection: ConnectionState::Connected,
+            failure_reason: None,
+            rx_bytes: 100,
+            tx_bytes: 50,
+            transfer_rates: Some(TransferRates {
+                rx_bps: 10,
+                tx_bps: 5,
+            }),
+            destinations: 0,
+            links: 0,
+            transported_links: 0,
+            membership: Membership::Independent,
+        },
+        None,
+    )
+    .with_fleet_peers(vec![RnsInterfaceStatsEntry::new(
+        Some(String::from("ab12… @ AA:BB:CC:DD:EE:FF")),
+        InterfaceSnapshot {
+            id: peer,
+            mode: crate::interfaces::InterfaceMode::Full,
+            gravity: crate::interfaces::InterfaceGravity::ZERO,
+            connection: ConnectionState::Connected,
+            failure_reason: None,
+            rx_bytes: 40,
+            tx_bytes: 20,
+            transfer_rates: Some(TransferRates {
+                rx_bps: 4,
+                tx_bps: 2,
+            }),
+            destinations: 0,
+            links: 0,
+            transported_links: 0,
+            membership: Membership::FleetMember {
+                supervisor_id: supervisor,
+            },
+        },
+        None,
+    )
+    .with_rssi(Some(-61))])]);
+    let Ok(encoded) = stats.encode_message_pack() else {
+        panic!("interface stats must encode");
+    };
+    let report = RnsInterfaceStatsReport::decode_message_pack(&encoded)
+        .expect("encoded fleet peers must decode");
+    assert_eq!(report.interfaces.len(), 1);
+    assert_eq!(report.interfaces[0].fleet_peers.len(), 1);
+    let nested = &report.interfaces[0].fleet_peers[0];
+    assert_eq!(nested.name, "ab12… @ AA:BB:CC:DD:EE:FF");
+    assert!(nested.online);
+    assert_eq!(nested.receive_bytes, 40);
+    assert_eq!(nested.transmit_bytes, 20);
+    assert_eq!(nested.rssi, RnsOptionalField::Value(-61));
+}
+
+#[test]
 fn local_interface_fallback_names_match_stock_rnstatus_categories() {
     let server = InterfaceId::from_channel_tag(InterfaceKind::LocalServer, b"server");
     let client = InterfaceId::from_channel_tag(InterfaceKind::LocalClient, b"client");

--- a/prns-core/src/interfaces/rns_management/wire_names.rs
+++ b/prns-core/src/interfaces/rns_management/wire_names.rs
@@ -41,6 +41,8 @@ pub mod interface {
     pub const PARENT_HASH: &str = "parent_interface_hash";
     pub const BITRATE: &str = "bitrate";
     pub const PEERS: &str = "peers";
+    pub const FLEET_PEERS: &str = "fleet_peers";
+    pub const RSSI: &str = "rssi";
     pub const AUTOCONNECT_SOURCE: &str = "autoconnect_source";
     pub const ANNOUNCE_QUEUE: &str = "announce_queue";
     pub const HELD_ANNOUNCES: &str = "held_announces";

--- a/prns-interfaces/impls/embassy/src/bluetooth_auto/runtime.rs
+++ b/prns-interfaces/impls/embassy/src/bluetooth_auto/runtime.rs
@@ -1414,6 +1414,7 @@ async fn apply_settled<
                 slot,
                 address,
                 lane,
+                ..
             } => {
                 if let Some(mut link) = held.take() {
                     if !matches!(lane, L2capPlan::None) {

--- a/prns-interfaces/impls/tokio/src/bluetooth_auto/runtime.rs
+++ b/prns-interfaces/impls/tokio/src/bluetooth_auto/runtime.rs
@@ -719,6 +719,7 @@ async fn apply_settle<B, const MAX_PEERS: usize>(
                 identity,
                 address,
                 lane,
+                peer_rssi,
                 ..
             } => {
                 if let Some(mut held) = link.take() {
@@ -727,7 +728,8 @@ async fn apply_settle<B, const MAX_PEERS: usize>(
                     let member = BluetoothPeer::with_policy(identity, source, sink, policy)
                         .report_close_to(address, closed.clone());
                     let status = member.status();
-                    let attached = fleet.add(member);
+                    let name = format_ble_peer_name(identity, address);
+                    let attached = fleet.add_named(member, name, peer_rssi);
                     members.insert(
                         identity,
                         TokioMember {
@@ -817,6 +819,15 @@ async fn drive_handshake<L: BleLink>(
         Ok(result) => result,
         Err(_) => Err(HandshakeFailure::Timeout),
     }
+}
+
+fn format_ble_peer_name(identity: BleIdentity, address: BleAddress) -> String {
+    let id = identity.as_bytes();
+    let addr = address.octets();
+    format!(
+        "{:02x}{:02x}{:02x}{:02x}… @ {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
+        id[0], id[1], id[2], id[3], addr[0], addr[1], addr[2], addr[3], addr[4], addr[5]
+    )
 }
 
 async fn arm_fast_lane<L: BleLink>(link: &mut L, lane: &L2capPlan) {

--- a/prns-interfaces/impls/tokio/src/weave/supervision/mod.rs
+++ b/prns-interfaces/impls/tokio/src/weave/supervision/mod.rs
@@ -338,7 +338,8 @@ fn ensure_peer(
         outbound.clone(),
     );
     let peer_status = peer.status();
-    let attached = fleet.add(peer);
+    let endpoint_name = format_weave_peer_name(endpoint);
+    let attached = fleet.add_named(peer, endpoint_name, None);
     peers.insert(
         endpoint,
         ManagedPeer {
@@ -381,6 +382,14 @@ fn teardown_peers(peers: &mut HashMap<EndpointId, ManagedPeer>, status: &WeaveIn
 
 fn publish_members(peers: &HashMap<EndpointId, ManagedPeer>, status: &WeaveInterfaceStatus) {
     status.set_members(peers.values().map(|peer| peer.status.clone()).collect());
+}
+
+fn format_weave_peer_name(endpoint: EndpointId) -> String {
+    let bytes = endpoint.as_bytes();
+    format!(
+        "endpoint {:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7]
+    )
 }
 
 fn encoding_error(error: weave::EncodeError) -> io::Error {

--- a/prns-interfaces/impls/tokio/src/wifi_auto/mod.rs
+++ b/prns-interfaces/impls/tokio/src/wifi_auto/mod.rs
@@ -1017,7 +1017,8 @@ impl DiscoveredTcpDials {
                 RENDEZVOUS_RECONNECT,
             );
             let client_status = tcp_client.status();
-            let attached_client = fleet.add(tcp_client);
+            let attached_client =
+                fleet.add_named(tcp_client, desired_endpoint.to_string(), None);
             self.members.insert(
                 desired_endpoint,
                 AttachedStatus {
@@ -1279,7 +1280,8 @@ impl Supervisor {
                         self.policy,
                     );
                     let connection_status = tcp_connection.status();
-                    let attached_connection = self.fleet.add(tcp_connection);
+                    let attached_connection =
+                        self.fleet.add_named(tcp_connection, peer_address.to_string(), None);
                     self.accepted.push(AttachedStatus {
                         attached: attached_connection,
                         status: connection_status,
@@ -1559,7 +1561,8 @@ impl Supervisor {
             &self.settings.instance_tag,
         );
         let status = member.status();
-        let attached = self.fleet.add(member);
+        let peer_name = format!("{}%{}", peer_address.ip_address, peer_address.scope_id);
+        let attached = self.fleet.add_named(member, peer_name, None);
         crate::diagnostic_log::debug!(
             "wifi-auto: peer {}%{} discovered",
             peer_address.ip_address,
@@ -1693,9 +1696,9 @@ impl Supervisor {
             return;
         }
         let target = std::format!("127.0.0.1:{}", contract::TCP_RENDEZVOUS_PORT);
-        let client = TcpClientInterface::with_policy(target, self.policy, RENDEZVOUS_RECONNECT);
+        let client = TcpClientInterface::with_policy(target.clone(), self.policy, RENDEZVOUS_RECONNECT);
         let status = client.status();
-        let attached = self.fleet.add(client);
+        let attached = self.fleet.add_named(client, target, None);
         self.loopback = Some(AttachedStatus { attached, status });
         self.publish_status();
     }
@@ -1801,9 +1804,10 @@ impl Supervisor {
             crate::diagnostic_log::debug!(
                 "wifi-auto: dialing gateway rendezvous {target} on ifindex {index}"
             );
-            let client = TcpClientInterface::with_policy(target, self.policy, RENDEZVOUS_RECONNECT);
+            let client =
+                TcpClientInterface::with_policy(target.clone(), self.policy, RENDEZVOUS_RECONNECT);
             let status = client.status();
-            let attached = self.fleet.add(client);
+            let attached = self.fleet.add_named(client, target, None);
             self.gateways.insert(
                 index,
                 GatewayDial {

--- a/prns-runtime/core/src/runtime/node_introspection/core.rs
+++ b/prns-runtime/core/src/runtime/node_introspection/core.rs
@@ -4,6 +4,9 @@ use prns_core::interfaces::{
     InterfaceSnapshot, Membership, TransferRates,
 };
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InterfaceIfacSnapshot<Label> {
     pub signature: [u8; 64],
@@ -17,6 +20,11 @@ pub struct InterfaceInventoryEntry<Label> {
     pub origin: InterfaceOriginKind,
     pub snapshot: InterfaceSnapshot,
     pub ifac: Option<InterfaceIfacSnapshot<Label>>,
+    /// Link-up RSSI in dBm when the interface recorded one (Bluetooth Auto peers).
+    pub rssi: Option<i8>,
+    /// Fleet members nested under a folded supervisor. Always empty on leaf entries.
+    #[cfg(feature = "alloc")]
+    pub members: Vec<InterfaceInventoryEntry<Label>>,
 }
 
 struct FoldedInterface<Label> {
@@ -25,6 +33,9 @@ struct FoldedInterface<Label> {
     origin: InterfaceOriginKind,
     root: Option<InterfaceSnapshot>,
     ifac: Option<InterfaceIfacSnapshot<Label>>,
+    rssi: Option<i8>,
+    #[cfg(feature = "alloc")]
+    members: Vec<InterfaceInventoryEntry<Label>>,
     member_connection: ConnectionState,
     member_mode: Option<InterfaceMode>,
     member_gravity: Option<InterfaceGravity>,
@@ -46,6 +57,9 @@ impl<Label> FoldedInterface<Label> {
             origin,
             root: None,
             ifac: None,
+            rssi: None,
+            #[cfg(feature = "alloc")]
+            members: Vec::new(),
             member_connection: ConnectionState::Unknown,
             member_mode: None,
             member_gravity: None,
@@ -60,7 +74,10 @@ impl<Label> FoldedInterface<Label> {
         }
     }
 
-    fn add(&mut self, entry: &mut InterfaceInventoryEntry<Label>) {
+    fn add(&mut self, entry: &mut InterfaceInventoryEntry<Label>)
+    where
+        Label: Clone,
+    {
         let snapshot = entry.snapshot;
         self.destinations = self.destinations.saturating_add(snapshot.destinations);
         self.links = self.links.saturating_add(snapshot.links);
@@ -77,6 +94,7 @@ impl<Label> FoldedInterface<Label> {
                 if entry.ifac.is_some() {
                     self.ifac = entry.ifac.take();
                 }
+                self.rssi = entry.rssi.or(self.rssi);
             }
             Membership::FleetMember { .. } => {
                 if self.root.is_none() && entry.origin == InterfaceOriginKind::Discovered {
@@ -98,11 +116,28 @@ impl<Label> FoldedInterface<Label> {
                     aggregate.rx_bps = aggregate.rx_bps.saturating_add(rates.rx_bps);
                     aggregate.tx_bps = aggregate.tx_bps.saturating_add(rates.tx_bps);
                 }
-                if self.name.is_none() {
-                    self.name = entry.name.take();
+                #[cfg(feature = "alloc")]
+                {
+                    if self.ifac.is_none() {
+                        self.ifac = entry.ifac.clone();
+                    }
+                    self.members.push(InterfaceInventoryEntry {
+                        name: entry.name.take(),
+                        origin: entry.origin,
+                        snapshot,
+                        ifac: entry.ifac.take(),
+                        rssi: entry.rssi,
+                        members: Vec::new(),
+                    });
                 }
-                if self.ifac.is_none() {
-                    self.ifac = entry.ifac.take();
+                #[cfg(not(feature = "alloc"))]
+                {
+                    if self.name.is_none() {
+                        self.name = entry.name.take();
+                    }
+                    if self.ifac.is_none() {
+                        self.ifac = entry.ifac.take();
+                    }
                 }
             }
         }
@@ -153,12 +188,15 @@ impl<Label> FoldedInterface<Label> {
                 membership: Membership::Independent,
             },
             ifac: self.ifac,
+            rssi: self.rssi,
+            #[cfg(feature = "alloc")]
+            members: self.members,
         }
     }
 }
 
 #[must_use]
-pub fn fold_logical_interface_inventory<Label: Ord>(
+pub fn fold_logical_interface_inventory<Label: Clone + Ord>(
     inventory: &mut [InterfaceInventoryEntry<Label>],
 ) -> &mut [InterfaceInventoryEntry<Label>] {
     inventory.sort_unstable_by(|left, right| {
@@ -263,6 +301,9 @@ mod tests {
                 membership,
             },
             ifac: None,
+            rssi: None,
+            #[cfg(feature = "alloc")]
+            members: Vec::new(),
         }
     }
 
@@ -275,7 +316,7 @@ mod tests {
             supervisor_id: supervisor,
         };
         let mut snapshots = [
-            snapshot(second, membership, 60, 3, 2, None),
+            snapshot(second, membership, 60, 3, 2, Some("second-peer")),
             snapshot(
                 supervisor,
                 Membership::Independent,
@@ -284,7 +325,11 @@ mod tests {
                 0,
                 Some("Public server"),
             ),
-            snapshot(first, membership, 40, 2, 1, None),
+            {
+                let mut peer = snapshot(first, membership, 40, 2, 1, Some("first-peer"));
+                peer.rssi = Some(-61);
+                peer
+            },
         ];
 
         let logical = fold_logical_interface_inventory(&mut snapshots);
@@ -297,6 +342,27 @@ mod tests {
         assert_eq!(logical[0].snapshot.destinations, 5);
         assert_eq!(logical[0].snapshot.links, 3);
         assert_eq!(logical[0].snapshot.membership, Membership::Independent);
+        #[cfg(feature = "alloc")]
+        {
+            assert_eq!(logical[0].members.len(), 2);
+            let member_names: alloc::vec::Vec<_> =
+                logical[0].members.iter().map(|peer| peer.name).collect();
+            assert!(member_names.contains(&Some("first-peer")));
+            assert!(member_names.contains(&Some("second-peer")));
+            let first_peer = logical[0]
+                .members
+                .iter()
+                .find(|peer| peer.snapshot.id == first)
+                .expect("first peer retained");
+            assert_eq!(first_peer.snapshot.rx_bytes, 40);
+            assert_eq!(first_peer.rssi, Some(-61));
+            let second_peer = logical[0]
+                .members
+                .iter()
+                .find(|peer| peer.snapshot.id == second)
+                .expect("second peer retained");
+            assert_eq!(second_peer.snapshot.rx_bytes, 60);
+        }
     }
 
     #[test]

--- a/prns-runtime/core/src/runtime/node_introspection/impls/heap.rs
+++ b/prns-runtime/core/src/runtime/node_introspection/impls/heap.rs
@@ -92,7 +92,7 @@ pub trait NodeIntrospection {
 }
 
 #[must_use]
-pub fn logical_interface_inventory<Label: Ord>(
+pub fn logical_interface_inventory<Label: Clone + Ord>(
     mut inventory: Vec<InterfaceInventoryEntry<Label>>,
 ) -> Vec<InterfaceInventoryEntry<Label>> {
     let logical_len = fold_logical_interface_inventory(&mut inventory).len();

--- a/prns-runtime/core/src/runtime/rns_management.rs
+++ b/prns-runtime/core/src/runtime/rns_management.rs
@@ -14,18 +14,29 @@ pub fn interface_stats(inventory: Vec<InterfaceInventoryEntry<String>>) -> RnsIn
     RnsInterfaceStats::new(
         logical_interface_inventory(inventory)
             .into_iter()
-            .map(|entry| {
-                let access_code = entry.ifac.map(|access_code| {
-                    RnsInterfaceAccessCode::new(
-                        access_code.signature,
-                        access_code.size,
-                        access_code.network_name,
-                    )
-                });
-                RnsInterfaceStatsEntry::new(entry.name, entry.snapshot, access_code)
-            })
+            .map(stats_entry_from_inventory)
             .collect(),
     )
+}
+
+fn stats_entry_from_inventory(entry: InterfaceInventoryEntry<String>) -> RnsInterfaceStatsEntry {
+    let access_code = entry.ifac.map(|access_code| {
+        RnsInterfaceAccessCode::new(
+            access_code.signature,
+            access_code.size,
+            access_code.network_name,
+        )
+    });
+    let fleet_peers = entry
+        .members
+        .into_iter()
+        .map(|member| {
+            RnsInterfaceStatsEntry::new(member.name, member.snapshot, None).with_rssi(member.rssi)
+        })
+        .collect();
+    RnsInterfaceStatsEntry::new(entry.name, entry.snapshot, access_code)
+        .with_rssi(entry.rssi)
+        .with_fleet_peers(fleet_peers)
 }
 
 pub fn announce_rate_table(entries: Vec<AnnounceRateSnapshot>) -> RnsAnnounceRateTable {

--- a/prns-runtime/core/src/runtime/rns_rpc/tests/routes.rs
+++ b/prns-runtime/core/src/runtime/rns_rpc/tests/routes.rs
@@ -113,6 +113,8 @@ async fn interface_stats_renders_each_held_interface_with_its_live_counters() {
                     size: prns_core::interfaces::IfacSize::WIDE,
                     network_name: Some("private-net".into()),
                 }),
+                rssi: None,
+                members: std::vec::Vec::new(),
             },
             InterfaceInventoryEntry {
                 name: Some("Remote bridge".into()),
@@ -135,6 +137,8 @@ async fn interface_stats_renders_each_held_interface_with_its_live_counters() {
                     membership: prns_core::interfaces::Membership::Independent,
                 },
                 ifac: None,
+                rssi: None,
+                members: std::vec::Vec::new(),
             },
         ],
     };

--- a/prns-runtime/impls/tokio/src/runtime/node_facade/interface_lifecycle/mod.rs
+++ b/prns-runtime/impls/tokio/src/runtime/node_facade/interface_lifecycle/mod.rs
@@ -173,6 +173,7 @@ impl PrnsNodeHandle {
                 gravity: descriptor.gravity,
                 ifac: ifac.as_ref().map(RuntimeIfac::snapshot),
                 name,
+                rssi: None,
                 byte_accounting: ByteAccounting::OwnTraffic,
                 retired_member_bytes: RetiredMemberBytes::default(),
             }),
@@ -220,6 +221,8 @@ impl PrnsNodeHandle {
                             membership: placement.membership,
                         },
                         ifac: ifac.clone(),
+                        rssi: registered.rssi,
+                        members: std::vec::Vec::new(),
                     }
                 })
             })
@@ -318,6 +321,7 @@ impl PrnsNodeHandle {
                 gravity: policy.gravity,
                 ifac: ifac_status,
                 name: None,
+                rssi: None,
                 byte_accounting: ByteAccounting::FleetAggregate,
                 retired_member_bytes: RetiredMemberBytes::default(),
             }),
@@ -513,6 +517,31 @@ impl Fleet {
     where
         I: Interface + ReportsStatus + Send + 'static,
     {
+        self.add_with_peer_status(interface, None, None)
+    }
+
+    /// Stand up a named fleet member, optionally recording link-up RSSI for status nesting.
+    pub fn add_named<I>(
+        &self,
+        interface: I,
+        name: impl Into<String>,
+        rssi: Option<i8>,
+    ) -> AttachedInterface
+    where
+        I: Interface + ReportsStatus + Send + 'static,
+    {
+        self.add_with_peer_status(interface, Some(name.into()), rssi)
+    }
+
+    fn add_with_peer_status<I>(
+        &self,
+        interface: I,
+        name: Option<String>,
+        rssi: Option<i8>,
+    ) -> AttachedInterface
+    where
+        I: Interface + ReportsStatus + Send + 'static,
+    {
         let view = interface.status_view();
         let connection = interface.connection_view();
         let descriptor = interface.descriptor();
@@ -543,7 +572,8 @@ impl Fleet {
                 mode: descriptor.mode,
                 gravity: descriptor.gravity,
                 ifac: self.ifac.as_ref().map(RuntimeIfac::snapshot),
-                name: None,
+                name,
+                rssi,
                 byte_accounting: ByteAccounting::OwnTraffic,
                 retired_member_bytes: RetiredMemberBytes::default(),
             }),
@@ -705,6 +735,7 @@ pub(super) struct RegisteredInterface {
     gravity: crate::interfaces::InterfaceGravity,
     ifac: Option<InterfaceIfacSnapshot>,
     name: Option<String>,
+    rssi: Option<i8>,
     byte_accounting: ByteAccounting,
     retired_member_bytes: RetiredMemberBytes,
 }

--- a/prns-runtime/impls/tokio/src/runtime/node_facade/interface_lifecycle/tests.rs
+++ b/prns-runtime/impls/tokio/src/runtime/node_facade/interface_lifecycle/tests.rs
@@ -155,6 +155,8 @@ async fn runtime_attachment_carries_ifac_wire_and_status_metadata() {
                 size: IfacSize::WIDE,
                 network_name: Some("private-net".into()),
             }),
+            rssi: None,
+            members: std::vec::Vec::new(),
         }]
     );
 }
@@ -201,6 +203,7 @@ fn registered_status(view: StatusView, membership: Membership) -> RegisteredInte
         gravity: crate::interfaces::InterfaceGravity::new(-27),
         ifac: None,
         name: None,
+        rssi: None,
         byte_accounting: ByteAccounting::OwnTraffic,
         retired_member_bytes: RetiredMemberBytes::default(),
     }

--- a/prnsd/src/utilities/rnstatus/json.rs
+++ b/prnsd/src/utilities/rnstatus/json.rs
@@ -1,6 +1,6 @@
 use personal_rns::interfaces::rns_management::wire_names::{interface, transport};
 use personal_rns::interfaces::rns_management::{
-    RnsInterfaceStatsReport, RnsInterfaceStatusReport, RnsOptionalField,
+    RnsFleetPeerReport, RnsInterfaceStatsReport, RnsInterfaceStatusReport, RnsOptionalField,
 };
 use serde_json::{Map, Value};
 
@@ -260,6 +260,37 @@ fn interface_value(status: &RnsInterfaceStatusReport) -> Value {
         &status.blocked_ip_list,
         |values| Value::Array(values.iter().cloned().map(Value::String).collect()),
     );
+    insert_optional_i64(&mut fields, interface::RSSI, &status.rssi);
+    if !status.fleet_peers.is_empty() {
+        fields.insert(
+            String::from(interface::FLEET_PEERS),
+            Value::Array(status.fleet_peers.iter().map(fleet_peer_value).collect()),
+        );
+    }
+    Value::Object(fields)
+}
+
+fn fleet_peer_value(peer: &RnsFleetPeerReport) -> Value {
+    let mut fields = Map::new();
+    fields.insert(String::from(interface::NAME), Value::String(peer.name.clone()));
+    fields.insert(String::from(interface::STATUS), peer.online.into());
+    fields.insert(
+        String::from(interface::RECEIVE_BYTES),
+        peer.receive_bytes.into(),
+    );
+    fields.insert(
+        String::from(interface::TRANSMIT_BYTES),
+        peer.transmit_bytes.into(),
+    );
+    fields.insert(
+        String::from(interface::RECEIVE_SPEED),
+        number(peer.receive_speed_bps),
+    );
+    fields.insert(
+        String::from(interface::TRANSMIT_SPEED),
+        number(peer.transmit_speed_bps),
+    );
+    insert_optional_i64(&mut fields, interface::RSSI, &peer.rssi);
     Value::Object(fields)
 }
 
@@ -393,6 +424,8 @@ mod tests {
                 String::from("192.0.2.10"),
                 String::from("2001:db8::1"),
             ]),
+            rssi: RnsOptionalField::Absent,
+            fleet_peers: vec![],
         };
         let Value::Object(fields) = interface_value(&status) else {
             unreachable!();

--- a/prnsd/src/utilities/rnstatus/render.rs
+++ b/prnsd/src/utilities/rnstatus/render.rs
@@ -154,6 +154,34 @@ fn render_interface(
     render_access(output, status);
     render_announce_state(output, status, args, now);
     render_traffic(output, status);
+    render_fleet_peers(output, status);
+}
+
+fn render_fleet_peers(output: &mut String, status: &RnsInterfaceStatusReport) {
+    if status.fleet_peers.is_empty() {
+        return;
+    }
+    let count = status.fleet_peers.len();
+    let _ = writeln!(output, "    Peers     : {count} connected");
+    for peer in &status.fleet_peers {
+        let state = if peer.online { "Up" } else { "Down" };
+        let mut line = format!("      {}  {state}", peer.name);
+        if let Some(rssi) = peer.rssi.value() {
+            line.push_str(&format!("  rssi {rssi}"));
+        }
+        let _ = writeln!(output, "{line}");
+        let tx = format!(
+            "↑{}  {}",
+            pretty_size(peer.transmit_bytes as f64, "B"),
+            pretty_speed(peer.transmit_speed_bps)
+        );
+        let rx = format!(
+            "↓{}  {}",
+            pretty_size(peer.receive_bytes as f64, "B"),
+            pretty_speed(peer.receive_speed_bps)
+        );
+        let _ = writeln!(output, "        Traffic   : {tx}\n                    {rx}");
+    }
 }
 
 fn render_clients(output: &mut String, status: &RnsInterfaceStatusReport, clients: u64) {
@@ -720,5 +748,79 @@ mod tests {
         assert_eq!(output, "    Gravity   : -7\n");
         assert_eq!(optional_i64(&RnsOptionalField::Value(-7)), -7);
         assert_eq!(optional_i64(&RnsOptionalField::Absent), 0);
+    }
+
+    #[test]
+    fn nested_fleet_peers_render_under_the_supervisor() {
+        let status = RnsInterfaceStatusReport {
+            name: String::from("Bluetooth Auto"),
+            short_name: RnsOptionalField::Absent,
+            interface_type: RnsOptionalField::Absent,
+            interface_hash: RnsOptionalField::Absent,
+            parent_name: RnsOptionalField::Absent,
+            parent_hash: RnsOptionalField::Absent,
+            online: true,
+            mode: personal_rns::interfaces::rns_management::RnsInterfaceMode::Full,
+            gravity: RnsOptionalField::Absent,
+            clients: RnsOptionalField::Absent,
+            receive_bytes: 100,
+            transmit_bytes: 50,
+            receive_speed_bps: 0.0,
+            transmit_speed_bps: 0.0,
+            bitrate_bps: RnsOptionalField::Absent,
+            peers: RnsOptionalField::Absent,
+            ifac_signature: RnsOptionalField::Absent,
+            ifac_size_bytes: RnsOptionalField::Absent,
+            ifac_network_name: RnsOptionalField::Absent,
+            autoconnect_source: RnsOptionalField::Absent,
+            announce_queue: RnsOptionalField::Absent,
+            held_announces: RnsOptionalField::Absent,
+            incoming_announce_frequency: RnsOptionalField::Absent,
+            outgoing_announce_frequency: RnsOptionalField::Absent,
+            incoming_path_request_frequency: RnsOptionalField::Absent,
+            outgoing_path_request_frequency: RnsOptionalField::Absent,
+            announce_rate_target_seconds: RnsOptionalField::Absent,
+            announce_rate_penalty_seconds: RnsOptionalField::Absent,
+            announce_rate_grace: RnsOptionalField::Absent,
+            burst_active: RnsOptionalField::Absent,
+            burst_activated_at: RnsOptionalField::Absent,
+            path_request_burst_active: RnsOptionalField::Absent,
+            path_request_burst_activated_at: RnsOptionalField::Absent,
+            i2p_connectable: RnsOptionalField::Absent,
+            i2p_b32: RnsOptionalField::Absent,
+            i2p_tunnel_state: RnsOptionalField::Absent,
+            airtime_short_percent: RnsOptionalField::Absent,
+            airtime_long_percent: RnsOptionalField::Absent,
+            channel_load_short_percent: RnsOptionalField::Absent,
+            channel_load_long_percent: RnsOptionalField::Absent,
+            noise_floor_dbm: RnsOptionalField::Absent,
+            interference_dbm: RnsOptionalField::Absent,
+            interference_last_at: RnsOptionalField::Absent,
+            interference_last_dbm: RnsOptionalField::Absent,
+            cpu_load_percent: RnsOptionalField::Absent,
+            cpu_temperature_celsius: RnsOptionalField::Absent,
+            memory_load_percent: RnsOptionalField::Absent,
+            battery_percent: RnsOptionalField::Absent,
+            battery_state: RnsOptionalField::Absent,
+            switch_id: RnsOptionalField::Absent,
+            endpoint_id: RnsOptionalField::Absent,
+            via_switch_id: RnsOptionalField::Absent,
+            blocked_ip_list: RnsOptionalField::Absent,
+            rssi: RnsOptionalField::Absent,
+            fleet_peers: vec![personal_rns::interfaces::rns_management::RnsFleetPeerReport {
+                name: String::from("ab12… @ AA:BB:CC:DD:EE:FF"),
+                online: true,
+                receive_bytes: 40,
+                transmit_bytes: 20,
+                receive_speed_bps: 0.0,
+                transmit_speed_bps: 0.0,
+                rssi: RnsOptionalField::Value(-61),
+            }],
+        };
+        let mut output = String::new();
+        render_fleet_peers(&mut output, &status);
+        assert!(output.contains("Peers     : 1 connected"));
+        assert!(output.contains("ab12… @ AA:BB:CC:DD:EE:FF  Up  rssi -61"));
+        assert!(output.contains("Traffic"));
     }
 }


### PR DESCRIPTION
## Summary
- Preserve Auto fleet members (Bluetooth, Wi-Fi, Weave) through inventory fold instead of dropping them when aggregating supervisors
- Name peers at fleet admission and carry optional link-up RSSI for Bluetooth peers
- Encode nested `fleet_peers` on interface status and render them under each Auto supervisor in `prnsd status` human and JSON output

## Test plan
- [x] Fold inventory unit tests (members retained with names/bytes/RSSI)
- [x] MessagePack encode/decode round-trip for `fleet_peers`
- [x] rnstatus human/JSON render tests
- [ ] `prnsd status` with a connected Bluetooth Auto peer shows nested peer name, Up/Down, RSSI, and traffic
- [ ] `prnsd status -j` includes `fleet_peers` under each Auto supervisor


Made with [Cursor](https://cursor.com)