### PR TITLE
fix(hopspot): flash through the board's own partition table

### DIFF
--- a/personal-hopspot/embedded/esp32/.cargo/config.toml
+++ b/personal-hopspot/embedded/esp32/.cargo/config.toml
@@ -3,6 +3,12 @@
 #   cargo heltec-v4-r8     / -flash   the Heltec V4-R8 (S3R8 / Octal PSRAM)
 #   cargo tbeam-supreme    / -flash   the LilyGO T-Beam S3 Supreme
 #   cargo c6               / -flash   the headless XIAO ESP32-C6
+#
+# Each -flash alias passes the board's partition table explicitly. Without it espflash
+# falls back to its built-in default, whose `nvs` spans ble_id/hopcfg/node_id and whose
+# `factory` spans radio_cfg/prns_state, so flashing a provisioned board through these
+# aliases would take its identity with it. The tables are the same files the flash
+# manifest catalog names for each board, and paths resolve from this directory.
 
 [target.xtensa-esp32s3-none-elf]
 runner = "espflash flash --monitor --after watchdog-reset"
@@ -27,12 +33,12 @@ ESP_HAL_CONFIG_STACK_GUARD_OFFSET = "4096"
 
 [alias]
 heltec-v4 = "build --release -p hopspot-heltec-v4 --target xtensa-esp32s3-none-elf -Zbuild-std=core,alloc"
-heltec-v4-flash = "run --release -p hopspot-heltec-v4 --target xtensa-esp32s3-none-elf -Zbuild-std=core,alloc"
+heltec-v4-flash = "run --release -p hopspot-heltec-v4 --target xtensa-esp32s3-none-elf -Zbuild-std=core,alloc -- --partition-table partitions-hopspot-16mb.csv"
 heltec-v4-r8 = "build --release -p hopspot-heltec-v4-r8 --target xtensa-esp32s3-none-elf -Zbuild-std=core,alloc"
-heltec-v4-r8-flash = "run --release -p hopspot-heltec-v4-r8 --target xtensa-esp32s3-none-elf -Zbuild-std=core,alloc"
+heltec-v4-r8-flash = "run --release -p hopspot-heltec-v4-r8 --target xtensa-esp32s3-none-elf -Zbuild-std=core,alloc -- --partition-table partitions-hopspot-16mb.csv"
 tbeam-supreme = "build --release -p hopspot-t-beam-supreme --target xtensa-esp32s3-none-elf -Zbuild-std=core,alloc"
-tbeam-supreme-flash = "run --release -p hopspot-t-beam-supreme --target xtensa-esp32s3-none-elf -Zbuild-std=core,alloc"
+tbeam-supreme-flash = "run --release -p hopspot-t-beam-supreme --target xtensa-esp32s3-none-elf -Zbuild-std=core,alloc -- --partition-table partitions-hopspot-8mb.csv"
 # Seeed XIAO ESP32-C6 Hopspot: USB-auto + ESP-NOW + BLE on the headless board. ESP-NOW uses
 # Espressif's WiFi radio driver internally, but this build exposes no WiFi-LAN or SoftAP interface.
 c6 = "build --release -p hopspot-xiao-esp32-c6 --target riscv32imac-unknown-none-elf -Zbuild-std=core,alloc"
-c6-flash = "run --release -p hopspot-xiao-esp32-c6 --target riscv32imac-unknown-none-elf -Zbuild-std=core,alloc"
+c6-flash = "run --release -p hopspot-xiao-esp32-c6 --target riscv32imac-unknown-none-elf -Zbuild-std=core,alloc -- --partition-table partitions-hopspot-4mb.csv"

--- a/prns-flash-manifest/src/catalog.rs
+++ b/prns-flash-manifest/src/catalog.rs
@@ -1369,4 +1369,62 @@ mod tests {
         ));
         Ok(())
     }
+    /// Every `-flash` alias must hand espflash the same partition table the catalog
+    /// declares for that board. Without `--partition-table` espflash falls back to its
+    /// built-in default, whose `nvs` spans `ble_id`/`hopcfg`/`node_id` and whose
+    /// `factory` spans `radio_cfg`/`prns_state`, so flashing a provisioned board through
+    /// the alias would take its identity with it. Aliases are matched to boards on the
+    /// catalog's own `package`, so a new board cannot be added without its table.
+    #[test]
+    fn esp_flash_aliases_pass_the_partition_table_the_catalog_declares() -> Result<(), CatalogError>
+    {
+        const CARGO_CONFIG: &str =
+            include_str!("../../personal-hopspot/embedded/esp32/.cargo/config.toml");
+
+        let catalog = board_catalog()?;
+        let mut checked = 0;
+        for line in CARGO_CONFIG.lines() {
+            let line = line.trim();
+            let Some((name, invocation)) = line.split_once('=') else {
+                continue;
+            };
+            let name = name.trim();
+            if !name.ends_with("-flash") || name.starts_with('#') {
+                continue;
+            }
+            let package = invocation
+                .split_whitespace()
+                .skip_while(|word| *word != "-p")
+                .nth(1)
+                .unwrap_or_else(|| panic!("alias `{name}` names no -p package"));
+            let board = catalog
+                .boards
+                .iter()
+                .find(|board| match &board.build {
+                    BoardBuild::Esp(build) => build.package == package,
+                    _ => false,
+                })
+                .unwrap_or_else(|| panic!("alias `{name}` builds unregistered `{package}`"));
+            let BoardBuild::Esp(build) = &board.build else {
+                unreachable!("filtered to ESP builds above");
+            };
+            let expected = format!("--partition-table {}", build.partition_table);
+            assert!(
+                invocation.contains(&expected),
+                "alias `{name}` must pass `{expected}`; without it espflash falls back to \
+                 its built-in default and overwrites the identity partitions"
+            );
+            checked += 1;
+        }
+        assert_eq!(
+            checked,
+            catalog
+                .boards
+                .iter()
+                .filter(|board| matches!(board.build, BoardBuild::Esp(_)))
+                .count(),
+            "every ESP board in the catalog needs exactly one checked `-flash` alias"
+        );
+        Ok(())
+    }
 }


### PR DESCRIPTION
The four `-flash` aliases in `personal-hopspot/embedded/esp32/.cargo/config.toml` run espflash with no `--partition-table`, so espflash uses its built-in default. That is not the layout the firmware is built against.

I dumped both tables off the same ELF rather than reasoning about it, with `espflash save-image --chip esp32s3 --flash-size 16mb --merge` once with the flag and once without, then decoded the table at `0x8000` from each image:

```
built-in default                  partitions-hopspot-16mb.csv
nvs      0x009000 +0x006000       nvs        0x009000 +0x003000
                                  ble_id     0x00c000 +0x001000
                                  hopcfg     0x00d000 +0x001000
                                  node_id    0x00e000 +0x001000
phy_init 0x00f000 +0x001000       phy_init   0x00f000 +0x001000
factory  0x010000 +0xfa0000       factory    0x010000 +0xe6e000
                                  radio_cfg  0x0e7e000 +0x002000
                                  prns_state 0x0e80000 +0x180000
```

The default `nvs` covers `ble_id`, `hopcfg` and `node_id`. The default `factory` covers `radio_cfg` and `prns_state`. On a fresh board that costs nothing. On a board that already carries an identity, flashing through the documented alias takes `node_id` with it, and that one is not recoverable.

The fix is to give each alias its board's own table. The tables are the same files the flash manifest catalog already names per board, so the aliases now agree with the source of truth that `personal-hopspot/flasher`, the web flasher and `release.firmware.build` were already using. This was the one path that bypassed it. That is also why it is not a single `espflash.toml`: `heltec-v4-r8` and `t-beam-supreme` share the `xtensa-esp32s3-none-elf` runner but need different tables, so one file at that level would be wrong for one of them.

I added a check as well, because fixing the four aliases would have left the door open behind me. Two open pull requests add new `-flash` aliases and both are missing the flag the same way: #167 adds `heltec-e290-flash` and #95 adds `heltec-v3-flash`. Whichever of us lands second, the aliases that arrive would be unprotected.

The check reads the config, matches every `-flash` alias to a board on the catalog's own `package` field, and asserts the alias passes exactly the `partition_table` that board declares. Nothing is written down twice: add an ESP board to the catalog and the count assertion demands an alias for it, change a board's table and the alias has to follow. It sits next to `esp_partition_tables_match_the_firmware_layout_contract`, which already holds the CSVs to the firmware layout. This holds the aliases to the CSVs.

I checked that it fails on all three ways this goes wrong rather than assuming it would: a missing flag, a table belonging to a different board, and a catalog board with no alias at all. Each one fails with the offending alias named.

Two details on the fix itself. Paths resolve from `personal-hopspot/embedded/esp32`, which is where the aliases live and, since cargo discovers them by walking up from the working directory, the only place they can be run from. And if a path ever stops resolving, espflash exits non-zero and writes no image, so this fails loudly instead of quietly falling back to the default.

Gates on the branch: `FMT_DOC_CHECK_GATE_OK`, `VALIDATION_REGISTRY_OK`, `TOOLING_REGISTRY_OK`, `cargo clippy -- -D warnings` clean, and `cargo test` at 2064 passed / 0 failed across 26 suites against 2063 on the base commit, so this adds exactly the one test and drops nothing. I verified the aliases actually carry the flag by pointing `CARGO_TARGET_XTENSA_ESP32S3_NONE_ELF_RUNNER` at a script that echoes its arguments, so no board was flashed to check it:

```
RUNNER-ARGS: ...\hopspot-heltec-v4-r8 --partition-table partitions-hopspot-16mb.csv
```

This is the loose end from the last part of my comment on #46.
