### PR TITLE
release: prepare 0.3.7-hotfix.4 Heltec LoRa fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,8 +290,6 @@ jobs:
         working-directory: prnsd
 
   no-std-embedded:
-    # The forcing-function gate: the core stays no_std + alloc-free and cross-compiles
-    # to the ESP32-C6 (riscv32imac). Reuses the committed script verbatim.
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -303,26 +301,28 @@ jobs:
           components: llvm-tools-preview
           targets: riscv32imac-unknown-none-elf, thumbv7em-none-eabihf
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
-      - run: bash validation/platforms/no-std-esp-build.sh
-      - name: prns-interfaces-embassy — cross-build (ESP32-C6 / riscv32imac)
-        run: cargo build --locked --target riscv32imac-unknown-none-elf --features "tcp,wifi-auto,lora,esp-now,bluetooth-auto,usb"
-        working-directory: prns-interfaces/impls/embassy
-      - name: prns-interfaces-embassy — cross-build (nRF52840 / thumbv7em)
-        run: cargo build --locked --target thumbv7em-none-eabihf --features "lora,bluetooth-auto,usb"
-        working-directory: prns-interfaces/impls/embassy
-      - name: t-echo firmware — cross-build both S140 foundations (nRF52840 / thumbv7em)
-        run: |
-          cargo build --release --locked --no-default-features \
-            --features board-t-echo,softdevice-s140-v6 \
-            --target-dir target/s140-v6
-          cargo build --release --locked --no-default-features \
-            --features board-t-echo,softdevice-s140-v7 \
-            --target-dir target/s140-v7
-        working-directory: personal-hopspot/embedded/nrf52840
-      - name: heltec t114 firmware — build recovery-compatible developer UF2
-        run: ./tools/prns build hopspot t114
-      - name: heltec meshtower v2 firmware — build recovery-compatible developer UF2
-        run: ./tools/prns build hopspot mesh-tower-v2
+      - name: complete no_std and nRF52840 firmware matrix
+        run: python3 validation/run.py run --suite embedded-builds --expected-sha "$GITHUB_SHA"
+
+  esp32-firmware:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          submodules: false
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: 1.96.0
+      - name: Install checksum-pinned ESP compiler and tools
+        run: ./tools/prns release toolchain esp install -- "${RUNNER_TEMP}/prns-esp-tools"
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
+        with:
+          workspaces: personal-hopspot/embedded/esp32
+          shared-key: esp32-firmware-check
+      - name: compile every ESP32 shipping face on its real architecture
+        run: python3 validation/run.py run --suite esp32-firmware-check --expected-sha "$GITHUB_SHA"
 
   android-service:
     # Android is now more than a foreground Activity shell: the Hopspot app packages a foreground
@@ -545,6 +545,7 @@ jobs:
       - release-workflow-contracts
       - msrv
       - no-std-embedded
+      - esp32-firmware
       - android-service
       - macos-ble
       - windows-desktop
@@ -561,6 +562,7 @@ jobs:
       WORKFLOWS_RESULT: ${{ needs.release-workflow-contracts.result }}
       MSRV_RESULT: ${{ needs.msrv.result }}
       EMBEDDED_RESULT: ${{ needs.no-std-embedded.result }}
+      ESP32_RESULT: ${{ needs.esp32-firmware.result }}
       ANDROID_RESULT: ${{ needs.android-service.result }}
       APPLE_RESULT: ${{ needs.macos-ble.result }}
       WINDOWS_RESULT: ${{ needs.windows-desktop.result }}
@@ -578,6 +580,7 @@ jobs:
             "$WORKFLOWS_RESULT" \
             "$MSRV_RESULT" \
             "$EMBEDDED_RESULT" \
+            "$ESP32_RESULT" \
             "$ANDROID_RESULT" \
             "$APPLE_RESULT" \
             "$WINDOWS_RESULT" \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 16
       matrix:
         include:
           - language: actions

--- a/.github/workflows/deep-validation.yml
+++ b/.github/workflows/deep-validation.yml
@@ -52,7 +52,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 16
       matrix: ${{ fromJSON(needs.inventory.outputs.kani) }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
@@ -76,7 +76,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 16
       matrix: ${{ fromJSON(needs.inventory.outputs.fuzz) }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
@@ -106,7 +106,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 16
       matrix: ${{ fromJSON(needs.inventory.outputs.oracles) }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
@@ -128,7 +128,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 16
       matrix: ${{ fromJSON(needs.inventory.outputs.interop) }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
@@ -150,7 +150,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 16
       matrix: ${{ fromJSON(needs.inventory.outputs.hardening) }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262

--- a/.github/workflows/flasher-candidate.yml
+++ b/.github/workflows/flasher-candidate.yml
@@ -241,7 +241,7 @@ jobs:
     name: CLI ${{ matrix.build_pass }} ${{ matrix.platform.target }}
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 16
       matrix:
         build_pass: [primary, reproduction]
         platform:
@@ -336,7 +336,7 @@ jobs:
     name: Sparse firmware and hosted site ${{ matrix.build_pass }}
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 16
       matrix:
         build_pass: [primary, reproduction]
     runs-on: ubuntu-24.04
@@ -430,7 +430,7 @@ jobs:
     name: Release dependency and notice evidence ${{ matrix.build_pass }}
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 16
       matrix:
         build_pass: [primary, reproduction]
     runs-on: ubuntu-24.04
@@ -477,7 +477,7 @@ jobs:
     needs: [cli, core-candidate, dependency-audit]
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 16
       matrix:
         build_pass: [primary, reproduction]
     runs-on: ubuntu-24.04

--- a/.github/workflows/flasher-installation-qualification.yml
+++ b/.github/workflows/flasher-installation-qualification.yml
@@ -213,7 +213,7 @@ jobs:
     needs: inventory
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 16
       matrix:
         include:
           - runner: macos-15

--- a/.github/workflows/hardening.yml
+++ b/.github/workflows/hardening.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 16
       matrix:
         sanitizer: [address, leak, thread]
     steps:

--- a/.github/workflows/host-sdks.yml
+++ b/.github/workflows/host-sdks.yml
@@ -155,7 +155,7 @@ jobs:
     needs: contract
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 16
       matrix:
         settings:
           - host: ubuntu-latest
@@ -366,7 +366,7 @@ jobs:
     needs: contract
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 16
       matrix:
         settings:
           - ndk: arm64-v8a
@@ -522,7 +522,7 @@ jobs:
     needs: managed
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 16
       matrix:
         host:
           - ubuntu-latest

--- a/.github/workflows/mutation-audit.yml
+++ b/.github/workflows/mutation-audit.yml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 240
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 16
       matrix: ${{ fromJSON(needs.inventory.outputs.mutation) }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -122,7 +122,7 @@ jobs:
   napi-build:
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 16
       matrix:
         settings:
           - host: windows-latest
@@ -213,7 +213,7 @@ jobs:
     needs: napi-build
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 16
       matrix:
         settings:
           - host: windows-latest
@@ -273,7 +273,7 @@ jobs:
     needs: napi-build
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 16
       matrix:
         settings:
           - host: ubuntu-latest

--- a/.github/workflows/prnsd-candidate.yml
+++ b/.github/workflows/prnsd-candidate.yml
@@ -20,7 +20,7 @@ jobs:
     name: ${{ matrix.pass }} ${{ matrix.platform.target }}
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 16
       matrix:
         pass: [primary, reproduction]
         platform:

--- a/.github/workflows/prnsd-image-candidate.yml
+++ b/.github/workflows/prnsd-image-candidate.yml
@@ -20,7 +20,7 @@ jobs:
     name: ${{ matrix.pass }} ${{ matrix.image.platform }}
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 16
       matrix:
         pass: [primary, reproduction]
         image:

--- a/personal-hopspot/embedded/esp32/src/s3/boards/heltec_frontend.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/boards/heltec_frontend.rs
@@ -1,0 +1,136 @@
+use core::cell::RefCell;
+
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::blocking_mutex::Mutex;
+use esp_hal::gpio::{Flex, InputConfig, Level, Output, OutputConfig, OutputPin, Pin};
+use esp_hal::time::Duration;
+use personal_rns::radios::sx126x::FrontendControl;
+
+/// Heltec's front-end family discriminator needs one bounded settling interval after its rail is
+/// enabled. GPIO2 is sampled exactly once after this interval; it is not a readiness signal and
+/// there is no polling state machine behind it.
+const FRONTEND_FAMILY_DETECTION_SETTLE: Duration = Duration::from_millis(5);
+
+// Both front-end variants amplify the receive path before the SX1262. These typical gains are
+// removed from RSSI reports so channel access and diagnostics remain antenna-referred.
+const GC1109_RX_GAIN_DB: u8 = 17;
+const KCT8103L_RX_GAIN_DB: u8 = 23;
+
+#[derive(Debug, Clone, Copy)]
+pub(super) enum HeltecFrontendKind {
+    Gc1109,
+    Kct8103l,
+}
+
+impl HeltecFrontendKind {
+    pub(super) const fn rx_gain_db(self) -> u8 {
+        match self {
+            Self::Gc1109 => GC1109_RX_GAIN_DB,
+            Self::Kct8103l => KCT8103L_RX_GAIN_DB,
+        }
+    }
+
+    pub(super) const fn control(self) -> FrontendControl {
+        match self {
+            Self::Gc1109 => FrontendControl::NoDynamicControl,
+            Self::Kct8103l => FrontendControl::TxRx {
+                enter_transmit,
+                enter_receive,
+            },
+        }
+    }
+}
+
+enum ModeControl {
+    /// GC1109 CPS is board-driven and remains high; CTX is driven by SX1262 DIO2.
+    Gc1109 { _cps: Output<'static> },
+    /// KCT8103L CTX is low for RX and high for TX; CPS is driven by SX1262 DIO2.
+    Kct8103l { ctx: Output<'static> },
+}
+
+/// Retain the GPIO owners for as long as callbacks can switch the front-end. Keeping this state
+/// outside the board future also avoids carrying it across unrelated async suspension points.
+struct HeldFrontend {
+    _power: Output<'static>,
+    _chip_enable: Flex<'static>,
+    mode: ModeControl,
+}
+
+static HELD_FRONTEND: Mutex<CriticalSectionRawMutex, RefCell<Option<HeldFrontend>>> =
+    Mutex::new(RefCell::new(None));
+
+pub(super) fn initialize(
+    power_pin: impl OutputPin + 'static,
+    chip_enable_pin: impl Pin + 'static,
+    gc1109_cps_pin: impl OutputPin + 'static,
+    kct8103l_ctx_pin: impl OutputPin + 'static,
+) -> HeltecFrontendKind {
+    // Match the reference detection sequence: configure CSD as an input, power the front-end,
+    // allow its family strap to settle, then sample once before repurposing CSD as chip enable.
+    let mut chip_enable = Flex::new(chip_enable_pin);
+    chip_enable.apply_input_config(&InputConfig::default());
+    chip_enable.set_input_enable(true);
+    let power = Output::new(power_pin, Level::High, OutputConfig::default());
+    esp_hal::delay::Delay::new().delay(FRONTEND_FAMILY_DETECTION_SETTLE);
+
+    let kind = if chip_enable.is_high() {
+        HeltecFrontendKind::Kct8103l
+    } else {
+        HeltecFrontendKind::Gc1109
+    };
+
+    // Set the latch before enabling the output driver so CSD cannot glitch low during the input →
+    // output transition.
+    chip_enable.set_high();
+    chip_enable.set_input_enable(false);
+    chip_enable.set_output_enable(true);
+
+    let mode = match kind {
+        HeltecFrontendKind::Gc1109 => {
+            log::info!("LoRa FEM detected: GC1109 (GPIO46 CPS held high)");
+            ModeControl::Gc1109 {
+                _cps: Output::new(gc1109_cps_pin, Level::High, OutputConfig::default()),
+            }
+        }
+        HeltecFrontendKind::Kct8103l => {
+            log::info!("LoRa FEM detected: KCT8103L (GPIO5 CTX TX/RX switching enabled)");
+            ModeControl::Kct8103l {
+                ctx: Output::new(kct8103l_ctx_pin, Level::Low, OutputConfig::default()),
+            }
+        }
+    };
+
+    HELD_FRONTEND.lock(|held| {
+        *held.borrow_mut() = Some(HeldFrontend {
+            _power: power,
+            _chip_enable: chip_enable,
+            mode,
+        });
+    });
+
+    kind
+}
+
+fn enter_transmit() {
+    HELD_FRONTEND.lock(|held| {
+        if let Some(HeldFrontend {
+            mode: ModeControl::Kct8103l { ctx },
+            ..
+        }) = held.borrow_mut().as_mut()
+        {
+            ctx.set_high();
+        }
+    });
+}
+
+fn enter_receive() {
+    HELD_FRONTEND.lock(|held| {
+        if let Some(HeldFrontend {
+            mode: ModeControl::Kct8103l { ctx },
+            ..
+        }) = held.borrow_mut().as_mut()
+        {
+            ctx.set_low();
+        }
+    });
+}

--- a/personal-hopspot/embedded/esp32/src/s3/boards/heltec_v4.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/boards/heltec_v4.rs
@@ -1,5 +1,5 @@
 use esp_hal::analog::adc::{Adc, AdcCalCurve, AdcConfig, AdcPin, Attenuation};
-use esp_hal::gpio::{Flex, Input, InputConfig, Level, Output, OutputConfig};
+use esp_hal::gpio::{Input, InputConfig, Level, Output, OutputConfig};
 use esp_hal::i2c::master::{Config as I2cConfig, I2c};
 use esp_hal::spi::master::{Config as SpiConfig, Spi};
 use esp_hal::time::Rate;
@@ -19,7 +19,7 @@ use personal_rns::radios::sx126x::{BoardConfig, Sx126x, TcxoVoltage};
 
 use personal_hopspot_core as screen;
 
-use super::{HELTEC_GC1109_RX_GAIN_DB, HELTEC_KCT8103L_RX_GAIN_DB};
+use super::heltec_frontend;
 use crate::s3::{
     self, BoardDisplay, BoardFace, Esp32S3Board, GnssProvider, GnssShared, S3BoardHardware,
     S3InterfaceHardware, S3ManifoldHardware,
@@ -314,23 +314,7 @@ impl Esp32S3Board for HeltecBoard {
             let lora_reset = Output::new(p.GPIO12, Level::High, OutputConfig::default());
             let lora_busy = Input::new(p.GPIO13, InputConfig::default());
             let lora_dio1 = Input::new(p.GPIO14, InputConfig::default());
-            let _lora_pa_pwr = Output::new(p.GPIO7, Level::High, OutputConfig::default());
-            let mut lora_csd = Flex::new(p.GPIO2);
-            lora_csd.apply_input_config(&InputConfig::default());
-            lora_csd.set_input_enable(true);
-            let lora_is_kct8103l = lora_csd.is_high();
-            let lora_rx_gain_db = if lora_is_kct8103l {
-                HELTEC_KCT8103L_RX_GAIN_DB
-            } else {
-                HELTEC_GC1109_RX_GAIN_DB
-            };
-            lora_csd.set_output_enable(true);
-            lora_csd.set_high();
-            let _lora_fem_switch = if lora_is_kct8103l {
-                Output::new(p.GPIO5, Level::High, OutputConfig::default())
-            } else {
-                Output::new(p.GPIO46, Level::High, OutputConfig::default())
-            };
+            let lora_frontend = heltec_frontend::initialize(p.GPIO7, p.GPIO2, p.GPIO46, p.GPIO5);
             Sx126x::new(
                 lora_spi_device,
                 lora_busy,
@@ -342,10 +326,9 @@ impl Esp32S3Board for HeltecBoard {
                     use_dcdc: true,
                     rx_boost: true,
                     dio2_as_rf_switch: true,
-                    external_rx_gain_db: lora_rx_gain_db,
+                    external_rx_gain_db: lora_frontend.rx_gain_db(),
                     external_power_amplifier: None,
-                    enter_transmit: None,
-                    enter_receive: None,
+                    frontend_control: lora_frontend.control(),
                 },
             )
         };

--- a/personal-hopspot/embedded/esp32/src/s3/boards/heltec_v4_r8.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/boards/heltec_v4_r8.rs
@@ -1,5 +1,5 @@
 use esp_hal::analog::adc::{Adc, AdcCalCurve, AdcConfig, AdcPin, Attenuation};
-use esp_hal::gpio::{Flex, Input, InputConfig, Level, Output, OutputConfig};
+use esp_hal::gpio::{Input, InputConfig, Level, Output, OutputConfig};
 use esp_hal::i2c::master::{Config as I2cConfig, I2c};
 use esp_hal::spi::master::{Config as SpiConfig, Spi};
 use esp_hal::time::Rate;
@@ -16,7 +16,7 @@ use personal_rns::radios::sx126x::{BoardConfig, Sx126x, TcxoVoltage};
 
 use personal_hopspot_core as screen;
 
-use super::{HELTEC_GC1109_RX_GAIN_DB, HELTEC_KCT8103L_RX_GAIN_DB};
+use super::heltec_frontend;
 use crate::s3::{
     self, BoardDisplay, BoardFace, Esp32S3Board, NoGnss, S3BoardHardware, S3InterfaceHardware,
     S3ManifoldHardware,
@@ -195,23 +195,7 @@ impl Esp32S3Board for HeltecV4R8Board {
             let lora_reset = Output::new(p.GPIO12, Level::High, OutputConfig::default());
             let lora_busy = Input::new(p.GPIO13, InputConfig::default());
             let lora_dio1 = Input::new(p.GPIO14, InputConfig::default());
-            let _lora_pa_pwr = Output::new(p.GPIO7, Level::High, OutputConfig::default());
-            let mut lora_csd = Flex::new(p.GPIO2);
-            lora_csd.apply_input_config(&InputConfig::default());
-            lora_csd.set_input_enable(true);
-            let lora_is_kct8103l = lora_csd.is_high();
-            let lora_rx_gain_db = if lora_is_kct8103l {
-                HELTEC_KCT8103L_RX_GAIN_DB
-            } else {
-                HELTEC_GC1109_RX_GAIN_DB
-            };
-            lora_csd.set_output_enable(true);
-            lora_csd.set_high();
-            let _lora_fem_switch = if lora_is_kct8103l {
-                Output::new(p.GPIO5, Level::High, OutputConfig::default())
-            } else {
-                Output::new(p.GPIO46, Level::High, OutputConfig::default())
-            };
+            let lora_frontend = heltec_frontend::initialize(p.GPIO7, p.GPIO2, p.GPIO46, p.GPIO5);
             Sx126x::new(
                 lora_spi_device,
                 lora_busy,
@@ -223,10 +207,9 @@ impl Esp32S3Board for HeltecV4R8Board {
                     use_dcdc: true,
                     rx_boost: true,
                     dio2_as_rf_switch: true,
-                    external_rx_gain_db: lora_rx_gain_db,
+                    external_rx_gain_db: lora_frontend.rx_gain_db(),
                     external_power_amplifier: None,
-                    enter_transmit: None,
-                    enter_receive: None,
+                    frontend_control: lora_frontend.control(),
                 },
             )
         };

--- a/personal-hopspot/embedded/esp32/src/s3/boards/mod.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/boards/mod.rs
@@ -7,9 +7,5 @@ pub mod heltec_v4_r8;
 #[cfg(feature = "lora")]
 pub mod t_beam_supreme;
 
-// Both Heltec V4 front-end variants amplify the receive path before the SX1262. These typical
-// gains are removed from its RSSI reports so channel access and diagnostics remain antenna-referred.
 #[cfg(feature = "lora")]
-pub(super) const HELTEC_GC1109_RX_GAIN_DB: u8 = 17;
-#[cfg(feature = "lora")]
-pub(super) const HELTEC_KCT8103L_RX_GAIN_DB: u8 = 23;
+mod heltec_frontend;

--- a/personal-hopspot/embedded/esp32/src/s3/boards/t_beam_supreme/mod.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/boards/t_beam_supreme/mod.rs
@@ -18,7 +18,7 @@ use embedded_graphics::Pixel;
 use embedded_hal_bus::spi::ExclusiveDevice;
 
 use personal_rns::interfaces::InterfaceId;
-use personal_rns::radios::sx126x::{BoardConfig, Sx126x, TcxoVoltage};
+use personal_rns::radios::sx126x::{BoardConfig, FrontendControl, Sx126x, TcxoVoltage};
 
 use personal_hopspot_core as screen;
 use static_cell::StaticCell;
@@ -413,8 +413,7 @@ impl Esp32S3Board for TBeamSupremeBoard {
                     dio2_as_rf_switch: true,
                     external_rx_gain_db: 0,
                     external_power_amplifier: None,
-                    enter_transmit: None,
-                    enter_receive: None,
+                    frontend_control: FrontendControl::NoDynamicControl,
                 },
             )
         };

--- a/personal-hopspot/embedded/nrf52840/src/boards/mesh_tower_v2/hardware.rs
+++ b/personal-hopspot/embedded/nrf52840/src/boards/mesh_tower_v2/hardware.rs
@@ -15,7 +15,7 @@ use embassy_sync::blocking_mutex::Mutex;
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use personal_rns::lora::LoRaInterface;
-use personal_rns::radios::sx126x::{BoardConfig, Sx126x, TcxoVoltage};
+use personal_rns::radios::sx126x::{BoardConfig, FrontendControl, Sx126x, TcxoVoltage};
 use static_cell::StaticCell;
 
 use crate::boards::status_led::StatusLed;
@@ -144,8 +144,10 @@ impl MeshTowerV2Board {
                 dio2_as_rf_switch: true,
                 external_rx_gain_db: 0,
                 external_power_amplifier: None,
-                enter_transmit: Some(enter_transmit),
-                enter_receive: Some(enter_receive),
+                frontend_control: FrontendControl::TxRx {
+                    enter_transmit,
+                    enter_receive,
+                },
             },
         );
 

--- a/personal-hopspot/embedded/nrf52840/src/boards/t096/hardware.rs
+++ b/personal-hopspot/embedded/nrf52840/src/boards/t096/hardware.rs
@@ -17,7 +17,9 @@ use embassy_sync::blocking_mutex::Mutex;
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use personal_rns::lora::LoRaInterface;
-use personal_rns::radios::sx126x::{BoardConfig, ExternalPowerAmplifier, Sx126x, TcxoVoltage};
+use personal_rns::radios::sx126x::{
+    BoardConfig, ExternalPowerAmplifier, FrontendControl, Sx126x, TcxoVoltage,
+};
 use static_cell::StaticCell;
 
 use crate::boards::status_led::StatusLed;
@@ -226,8 +228,10 @@ impl T096Board {
                     maximum_output_power_dbm: 22,
                     chip_power_dbm: t096_chip_power_dbm,
                 }),
-                enter_transmit: Some(enter_transmit),
-                enter_receive: Some(enter_receive),
+                frontend_control: FrontendControl::TxRx {
+                    enter_transmit,
+                    enter_receive,
+                },
             },
         );
 

--- a/personal-hopspot/embedded/nrf52840/src/boards/t114/hardware.rs
+++ b/personal-hopspot/embedded/nrf52840/src/boards/t114/hardware.rs
@@ -12,7 +12,7 @@ use embassy_nrf::{bind_interrupts, config, peripherals, usb};
 use embassy_time::{Delay, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use personal_rns::lora::LoRaInterface;
-use personal_rns::radios::sx126x::{BoardConfig, Sx126x, TcxoVoltage};
+use personal_rns::radios::sx126x::{BoardConfig, FrontendControl, Sx126x, TcxoVoltage};
 use static_cell::StaticCell;
 
 use crate::boards::status_led::StatusLed;
@@ -167,8 +167,7 @@ impl T114Board {
                 dio2_as_rf_switch: true,
                 external_rx_gain_db: 0,
                 external_power_amplifier: None,
-                enter_transmit: None,
-                enter_receive: None,
+                frontend_control: FrontendControl::NoDynamicControl,
             },
         );
 

--- a/personal-hopspot/embedded/nrf52840/src/boards/t_echo/hardware.rs
+++ b/personal-hopspot/embedded/nrf52840/src/boards/t_echo/hardware.rs
@@ -11,7 +11,7 @@ use embassy_nrf::{bind_interrupts, config, peripherals, usb, Peri};
 use embassy_time::{Delay, Duration, Timer};
 use embedded_hal_bus::spi::ExclusiveDevice;
 use epd_waveshare::epd1in54_v2::Display1in54;
-use personal_rns::radios::sx126x::{BoardConfig, Sx126x, TcxoVoltage};
+use personal_rns::radios::sx126x::{BoardConfig, FrontendControl, Sx126x, TcxoVoltage};
 use static_cell::StaticCell;
 
 bind_interrupts!(struct Irqs {
@@ -199,8 +199,7 @@ impl TechoDeferredHardware {
                 dio2_as_rf_switch: true,
                 external_rx_gain_db: 0,
                 external_power_amplifier: None,
-                enter_transmit: None,
-                enter_receive: None,
+                frontend_control: FrontendControl::NoDynamicControl,
             },
         );
 

--- a/personal-rns/src/interface_families/radios.rs
+++ b/personal-rns/src/interface_families/radios.rs
@@ -11,7 +11,8 @@ pub mod lr1110 {
 
 pub mod sx126x {
     pub use prns_interfaces_embassy::radios::sx126x::{
-        Bandwidth, BoardConfig, CodingRate, Error, ExternalPowerAmplifier, LoraPacket, Modulation,
-        RadioConfig, ReceivedAirFrame, SpreadingFactor, Sx126x, TcxoVoltage,
+        Bandwidth, BoardConfig, CodingRate, Error, ExternalPowerAmplifier, FrontendControl,
+        LoraPacket, Modulation, RadioConfig, ReceivedAirFrame, SpreadingFactor, Sx126x,
+        TcxoVoltage,
     };
 }

--- a/prns-interfaces/impls/embassy/src/radios/sx126x.rs
+++ b/prns-interfaces/impls/embassy/src/radios/sx126x.rs
@@ -198,6 +198,34 @@ pub struct ExternalPowerAmplifier {
     pub chip_power_dbm: fn(i8) -> i8,
 }
 
+/// Board-owned front-end switching that must surround every SX126x TX/RX transition.
+///
+/// The callbacks are one unit because a front-end that can enter transmit must also have a
+/// defined path back to receive. Boards with no software-driven transition use
+/// [`Self::NoDynamicControl`].
+#[derive(Debug, Clone, Copy)]
+pub enum FrontendControl {
+    NoDynamicControl,
+    TxRx {
+        enter_transmit: fn(),
+        enter_receive: fn(),
+    },
+}
+
+impl FrontendControl {
+    fn enter_transmit(self) {
+        if let Self::TxRx { enter_transmit, .. } = self {
+            enter_transmit();
+        }
+    }
+
+    fn enter_receive(self) {
+        if let Self::TxRx { enter_receive, .. } = self {
+            enter_receive();
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct BoardConfig {
     /// `Some(v)` if a TCXO is fed from DIO3 at voltage `v`; `None` for a bare XTAL.
@@ -211,10 +239,7 @@ pub struct BoardConfig {
     /// External transmit PA behavior. When present, profiles remain antenna-referred while the
     /// driver programs the lower chip power required to produce that output through the PA.
     pub external_power_amplifier: Option<ExternalPowerAmplifier>,
-    /// Optional external PA/LNA switch into transmit. Invoked immediately before `SetTx`.
-    pub enter_transmit: Option<fn()>,
-    /// Optional external PA/LNA switch into receive. Invoked immediately before `SetRx`.
-    pub enter_receive: Option<fn()>,
+    pub frontend_control: FrontendControl,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -483,7 +508,7 @@ where
             .await?;
         self.configure().await?;
         self.route_irqs_and_tune_rx().await?;
-        invoke_frontend(self.config.enter_receive);
+        self.config.frontend_control.enter_receive();
         Ok(())
     }
 
@@ -528,7 +553,7 @@ where
         // EasyDMA (and most SPI DMA) can only source from RAM; the caller's payload may be flash-resident (`&'static`), so stage it through the RAM `tx_staging` field.
         self.tx_staging[..len].copy_from_slice(payload);
 
-        invoke_frontend(self.config.enter_transmit);
+        self.config.frontend_control.enter_transmit();
         self.standby().await?;
         self.set_packet_params(len as u8).await?;
         self.write_tx_payload(len).await?;
@@ -557,7 +582,7 @@ where
 
     /// Arm continuous RX: restamp the RX-side max payload length, clear stale IRQs, enter SetRx continuous. [`read_frame`](Self::read_frame) waits WITHOUT re-arming, so a host-side select that cancels the read mid-listen leaves the radio receiving (the RxDone IRQ latches) rather than guillotining an in-flight multi-hundred-ms LoRa frame.
     pub async fn arm_rx(&mut self) -> Result<(), Error> {
-        invoke_frontend(self.config.enter_receive);
+        self.config.frontend_control.enter_receive();
         self.standby().await?;
         self.set_packet_params(0xFF).await?;
         self.clear_irq(irq::ALL).await?;
@@ -885,12 +910,6 @@ fn decode_rssi_dbm(encoded: u8) -> i16 {
     -i16::from(encoded) / 2
 }
 
-fn invoke_frontend(hook: Option<fn()>) {
-    if let Some(enter) = hook {
-        enter();
-    }
-}
-
 fn antenna_referred_rssi_dbm(encoded: u8, external_rx_gain_db: u8) -> i16 {
     decode_rssi_dbm(encoded).saturating_sub(i16::from(external_rx_gain_db))
 }
@@ -920,6 +939,7 @@ fn pa_config(power_dbm: i8) -> PaConfig {
 mod tests {
     use super::*;
     use core::future::Future;
+    use core::sync::atomic::{AtomicU8, Ordering};
     use core::task::{Context, Poll, Waker};
     use std::cell::RefCell;
     use std::rc::Rc;
@@ -1152,8 +1172,7 @@ mod tests {
             dio2_as_rf_switch: true,
             external_rx_gain_db: 0,
             external_power_amplifier: None,
-            enter_transmit: None,
-            enter_receive: None,
+            frontend_control: FrontendControl::NoDynamicControl,
         }
     }
 
@@ -1193,6 +1212,31 @@ mod tests {
             sync_word_for_network(LoRaNetwork::Reticulum),
             RNODE_LORA_SYNC_WORD
         );
+    }
+
+    #[test]
+    fn external_frontend_control_keeps_tx_and_rx_transitions_together() {
+        static FRONTEND_STATE: AtomicU8 = AtomicU8::new(0);
+
+        fn enter_transmit() {
+            FRONTEND_STATE.store(1, Ordering::Relaxed);
+        }
+
+        fn enter_receive() {
+            FRONTEND_STATE.store(2, Ordering::Relaxed);
+        }
+
+        let control = FrontendControl::TxRx {
+            enter_transmit,
+            enter_receive,
+        };
+        control.enter_transmit();
+        assert_eq!(FRONTEND_STATE.load(Ordering::Relaxed), 1);
+        control.enter_receive();
+        assert_eq!(FRONTEND_STATE.load(Ordering::Relaxed), 2);
+
+        FrontendControl::NoDynamicControl.enter_transmit();
+        assert_eq!(FRONTEND_STATE.load(Ordering::Relaxed), 2);
     }
 
     #[test]
@@ -1284,8 +1328,7 @@ mod tests {
             dio2_as_rf_switch: true,
             external_rx_gain_db: 0,
             external_power_amplifier: None,
-            enter_transmit: None,
-            enter_receive: None,
+            frontend_control: FrontendControl::NoDynamicControl,
         };
         let mut radio = Sx126x::new(
             MockSpi { log: log.clone() },

--- a/release/flash/hotfixes/0.3.7-hotfix.4.json
+++ b/release/flash/hotfixes/0.3.7-hotfix.4.json
@@ -1,0 +1,42 @@
+{
+  "changed_boards": [
+    "heltec-v4",
+    "heltec-v4-r8"
+  ],
+  "qualification": {
+    "deferred_hardware": [
+      {
+        "basis": "The R8 target uses the same shared vendor-reference KCT8103L detection and TX/RX control path as the S3R2 target, and its release build passes, but no physical R8 hardware is presently available for the signed candidate.",
+        "board": "heltec-v4-r8",
+        "follow_up": "Capture and review an R8 or other KCT8103L post-flash boot, front-end detection, LoRa operation, and stable-runtime observation after promotion."
+      }
+    ],
+    "physical_boards": [
+      "heltec-v4"
+    ],
+    "required_checks": [
+      "gc1109-front-end-detected",
+      "lora-radio-ready",
+      "stable-post-boot-runtime"
+    ],
+    "required_scenarios": [
+      "correct-board",
+      "fresh-install",
+      "post-flash-boot",
+      "sparse-write"
+    ],
+    "surfaces": [
+      "web"
+    ]
+  },
+  "release": {
+    "base_manifest_sha256": "d9ee2162d76bb326e71ba949b303cf47e5d10e7fb6fd04419db1d972b909f9ca",
+    "base_release_record_sha256": "4f223c42ee305195a540c0336c57d5d437cc8b29a602c50e9cf49d846059af38",
+    "base_signed_candidate_sha256": "2a3190bd56824791ec95baaa7761cbe2c97018c0e0f1a3d08914b8d97ef50bc0",
+    "base_source_commit": "f13a6d0db253f4f37e473e0663ea379a6565d391",
+    "base_version": "0.3.7-hotfix.3",
+    "version": "0.3.7-hotfix.4"
+  },
+  "schema": 1,
+  "summary": "Heltec V4 and V4-R8 dynamic GC1109/KCT8103L LoRa front-end detection and TX/RX control."
+}

--- a/validation/manifest.toml
+++ b/validation/manifest.toml
@@ -653,6 +653,24 @@ inputs = ["validation/platforms/embedded.sh", "validation/platforms/no-std-esp-b
 artifacts = "validation-artifacts/results/embedded-builds"
 
 [[suite]]
+id = "esp32-firmware-check"
+domain = "platform"
+group = "esp"
+tiers = ["pr"]
+platform = "linux"
+toolchain = "esp"
+timeout_seconds = 5400
+command = ["bash", "validation/platforms/esp32-firmware-check.sh"]
+inputs = [
+  "validation/platforms/esp32-firmware-check.sh",
+  "personal-hopspot/embedded/esp32",
+  "tools/release/install-release-esp-toolchain.sh",
+  "tools/release/release-esp-toolchain-identity.sh",
+  "tools/release/verify-release-esp-toolchain.sh",
+]
+artifacts = "validation-artifacts/results/esp32-firmware-check"
+
+[[suite]]
 id = "shipping-firmware"
 domain = "platform"
 group = "esp"

--- a/validation/platforms/esp32-firmware-check.sh
+++ b/validation/platforms/esp32-firmware-check.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Compile every ESP shipping face on its real architecture without paying the
+# release lane's artifact assembly and reproducibility cost. This is the PR
+# forcing function for target-gated S3/C6 code that a host build cannot see.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$root"
+
+./tools/prns release toolchain esp verify
+
+(
+    cd personal-hopspot/embedded/esp32
+
+    cargo +esp check --release --locked \
+        -p hopspot-heltec-v4 \
+        -p hopspot-heltec-v4-r8 \
+        -p hopspot-t-beam-supreme \
+        --target xtensa-esp32s3-none-elf \
+        -Zbuild-std=core,alloc
+
+    cargo +esp check --release --locked \
+        -p hopspot-xiao-esp32-c6 \
+        --target riscv32imac-unknown-none-elf \
+        -Zbuild-std=core,alloc
+)
+
+echo "ESP32_FIRMWARE_CHECK_GATE_OK"

--- a/validation/release/workflow-contracts.py
+++ b/validation/release/workflow-contracts.py
@@ -24,8 +24,8 @@ AUTOMATIC_WORKFLOWS = frozenset(
         "napi.yml",
     }
 )
-STANDARD_MATRIX_PARALLELISM_LIMIT = 4
-MATRIX_PARALLELISM_LIMITS = {"release-readiness.yml": 20}
+STANDARD_MATRIX_PARALLELISM = 16
+MATRIX_PARALLELISM_OVERRIDES = {"release-readiness.yml": 20}
 MAIN_RELEASE_AUTHORITY_WORKFLOWS = (
     "host-sdk-promote.yml",
     "host-sdk-public-qualification.yml",
@@ -73,8 +73,8 @@ def validate_resource_bounds(workflow: Path, text: str) -> list[str]:
     errors: list[str] = []
     relative = workflow.relative_to(ROOT)
     artifact_limit = 7 if workflow.name in AUTOMATIC_WORKFLOWS else 30
-    parallelism_limit = MATRIX_PARALLELISM_LIMITS.get(
-        workflow.name, STANDARD_MATRIX_PARALLELISM_LIMIT
+    parallelism = MATRIX_PARALLELISM_OVERRIDES.get(
+        workflow.name, STANDARD_MATRIX_PARALLELISM
     )
     for job_name, block in workflow_jobs(text):
         if re.search(r"(?m)^    runs-on:", block):
@@ -93,16 +93,9 @@ def validate_resource_bounds(workflow: Path, text: str) -> list[str]:
             )
             if parallel is None:
                 errors.append(f"{relative}: {job_name} has an unbounded matrix")
-            elif not 1 <= int(parallel.group(1)) <= parallelism_limit:
+            elif int(parallel.group(1)) != parallelism:
                 errors.append(
-                    f"{relative}: {job_name} exceeds {parallelism_limit} parallel matrix jobs"
-                )
-            elif (
-                workflow.name in MATRIX_PARALLELISM_LIMITS
-                and int(parallel.group(1)) != parallelism_limit
-            ):
-                errors.append(
-                    f"{relative}: {job_name} must use all {parallelism_limit} "
+                    f"{relative}: {job_name} must use {parallelism} "
                     "parallel matrix jobs"
                 )
 
@@ -496,6 +489,16 @@ def validate() -> list[str]:
             errors.append(f"ESP toolchain verifier does not check {field}")
     if "RUSTUP_TOOLCHAIN: 1.90.0" not in ci or "toolchain: 1.90.0" not in ci:
         errors.append("ci.yml does not explicitly force and install the Rust 1.90.0 MSRV")
+    for product_matrix_gate in (
+        "run --suite embedded-builds",
+        "run --suite esp32-firmware-check",
+        'release toolchain esp install -- "${RUNNER_TEMP}/prns-esp-tools"',
+        "ESP32_RESULT: ${{ needs.esp32-firmware.result }}",
+    ):
+        if product_matrix_gate not in ci:
+            errors.append(
+                f"ci.yml is missing required product-matrix gate {product_matrix_gate!r}"
+            )
     if 'node-version: "24.18.0"' not in ci:
         errors.append("ci.yml does not test the release web graph with Node 24.18.0")
     for browser_gate in (


### PR DESCRIPTION
Prepares the target-scoped 0.3.7-hotfix.4 release for issue #150. Applies dynamic GC1109/KCT8103L detection and paired TX/RX control to Heltec V4 and V4-R8, retains all other hotfix.3 artifacts, and carries the validated CI parallelism/product-matrix update. Local validation: LoRa suite 71/71; Heltec V4 and V4-R8 release builds; hotfix tests 7/7; workflow contracts; public hotfix.3 base hashes independently verified. The physical Heltec V4 GC1109 web run is required after prerelease publication; V4-R8 hardware is explicitly deferred with a concrete follow-up.