### PR TITLE
Embassy Wi-Fi Auto: unicast keepalive for known peers

### DIFF
--- a/prns-interfaces/impls/embassy/src/wifi_auto/mod.rs
+++ b/prns-interfaces/impls/embassy/src/wifi_auto/mod.rs
@@ -958,6 +958,14 @@ impl<'a, const MEMBERS: usize> AutoWifi<'a, MEMBERS> {
                 self.status,
             )
             .await;
+            // Same cadence as tokio `send_periodic_peering`: mDNS targets are not the only
+            // peers we must keep alive, and IPv6 multicast beacons are blocked on many APs.
+            send_unicast_peer_refresh(
+                &self.primary.unicast_discovery,
+                &self.brain,
+                self.status,
+            )
+            .await;
         }
         BeaconMaintenanceOutcome::Completed
     }
@@ -1569,6 +1577,30 @@ async fn send_discovery_probes<const MEMBERS: usize>(
         Either::First(()) | Either::Second(Ok(())) => {}
         Either::Second(Err(_timeout)) => {
             crate::diagnostic_log::debug!("wifi-auto: discovery probe budget exhausted");
+        }
+    }
+}
+
+async fn send_unicast_peer_refresh<const MEMBERS: usize>(
+    unicast_discovery_socket: &UdpSocket<'_>,
+    brain: &contract::FixedAutoInterfaceProtocol<MEMBERS>,
+    status: AutoWifiStatus<MEMBERS>,
+) {
+    let token = brain.our_peering_token();
+    let send = with_timeout(SEND_TIMEOUT, async {
+        for address in brain.known_peer_addresses() {
+            let _send_result = unicast_discovery_socket
+                .send_to(
+                    token.as_bytes(),
+                    (IpAddress::Ipv6(address), contract::UNICAST_DISCOVERY_PORT),
+                )
+                .await;
+        }
+    });
+    match select(status.wait_until_disabled(), send).await {
+        Either::First(()) | Either::Second(Ok(())) => {}
+        Either::Second(Err(_timeout)) => {
+            crate::diagnostic_log::debug!("wifi-auto: unicast peer refresh budget exhausted");
         }
     }
 }


### PR DESCRIPTION
## Summary
- Refresh known Wi-Fi Auto peers with unicast peering tokens on embassy, every three beacon cycles (~4.8s), matching the tokio host cadence.
- Keeps LAN links alive on APs that block IPv6 link-local multicast peering beacons while mDNS discovery still works.

## Test plan
- [ ] Build an embassy Wi-Fi Auto board image (Heltec V4-R8 or T-Beam Supreme)
- [ ] Join a LAN with a Mac/Android tokio peer on the same discovery group
- [ ] Confirm peers stay connected past the 22s peering timeout without multicast beacons
- [ ] Confirm non-R8 S3 boards still build (`cargo heltec-v4`)


Made with [Cursor](https://cursor.com)