### PR TITLE
Fix ESP32 Hopspot storage capacity for RemoteControl

### DIFF
--- a/personal-hopspot/embedded/esp32/src/storage.rs
+++ b/personal-hopspot/embedded/esp32/src/storage.rs
@@ -15,15 +15,45 @@ use personal_rns::runtime::request_endpoints::RequestEndpointSet;
 use personal_rns::storage::Esp32S3;
 
 #[cfg(any(target_arch = "xtensa", target_arch = "riscv32"))]
+const REMOTE_CONTROL_REQUEST_HANDLER_ROWS: usize = 1;
+#[cfg(any(target_arch = "xtensa", target_arch = "riscv32"))]
 const NODE_REQUEST_HANDLER_CAPACITY: usize =
     <personal_hopspot_core::node_pages::NodePageRoutes as RequestEndpointSet<()>>::REGISTRATIONS
-        .len();
+        .len()
+        + REMOTE_CONTROL_REQUEST_HANDLER_ROWS;
 
 /// The engine's storage recipe: the small coordination shell stays inline in SRAM, while
 /// high-count or bulky columns (including links, routes, announces, history, app-data, and
 /// resource buffers) are placed in PSRAM through `PsramAlloc`.
 #[cfg(target_arch = "xtensa")]
 pub type EngineStorageType = Esp32S3<PsramAlloc, NODE_REQUEST_HANDLER_CAPACITY>;
+
+#[cfg(target_arch = "xtensa")]
+const _: () = {
+    use personal_rns::storage::{StorageCapacity, StorageLayout};
+    assert!(
+        matches!(
+            <EngineStorageType as StorageLayout>::LIMITS.held_identities,
+            StorageCapacity::Fixed(3)
+        ),
+        "Hopspot + RemoteControl requires three held-identity rows on ESP32-S3"
+    );
+    assert!(
+        matches!(
+            <EngineStorageType as StorageLayout>::LIMITS.upstream_app_destinations,
+            StorageCapacity::Fixed(3)
+        ),
+        "Hopspot + RemoteControl requires three upstream-app rows on ESP32-S3"
+    );
+};
+
+#[cfg(target_arch = "xtensa")]
+const _: () = assert!(
+    NODE_REQUEST_HANDLER_CAPACITY
+        >= REMOTE_CONTROL_REQUEST_HANDLER_ROWS
+            + <personal_hopspot_core::node_pages::NodePageRoutes as RequestEndpointSet<()>>::REGISTRATIONS
+                .len()
+);
 
 #[cfg(target_arch = "riscv32")]
 pub use riscv::C6Storage;
@@ -257,8 +287,10 @@ mod riscv {
         // Keep cheap relationships abundant while channels and resource continuations borrow
         // smaller shared tables. None of these counts constrain the eight-peer BLE controller.
         pub(crate) const TRACKED_DESTINATIONS: usize = 36;
-        const UPSTREAM_APP_DESTINATIONS: usize = 2;
-        const HELD_IDENTITIES: usize = REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY;
+        const UPSTREAM_APP_DESTINATIONS: usize =
+            REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY.saturating_add(1);
+        const HELD_IDENTITIES: usize =
+            REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY.saturating_add(1);
         pub const LINK_SESSIONS: usize = 12;
         const TRANSPORTED_LINKS: usize = 8;
         const CHANNELS: usize = 2;

--- a/prns-core/src/storage/impls/esp32s3.rs
+++ b/prns-core/src/storage/impls/esp32s3.rs
@@ -57,8 +57,13 @@ use crate::routing::warmth::FixedDepartedInterfaceTable;
 use crate::storage::{DisplayedStorageLimits, StorageCapacity, StorageLayout};
 
 const MAX_TRACKED_DESTINATIONS: usize = 512;
-const MAX_UPSTREAM_APP_DESTINATIONS: usize = 2;
-const MAX_HELD_IDENTITIES: usize = REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY;
+const MAX_UPSTREAM_APP_DESTINATIONS: usize =
+    REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY.saturating_add(1);
+const _: () = assert!(MAX_UPSTREAM_APP_DESTINATIONS >= 3);
+/// RemoteControl holds controller + target identities; Hopspot still holds one node identity for
+/// its delivery/node-page destinations and transport.
+const MAX_HELD_IDENTITIES: usize = REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY.saturating_add(1);
+const _: () = assert!(MAX_HELD_IDENTITIES >= 3);
 const MAX_LINK_SESSIONS: usize = 512;
 const MAX_TRANSPORTED_LINKS: usize = 32;
 const MAX_OUTSTANDING_RECEIPTS: usize = 8;

--- a/prns-runtime/core/src/runtime/node/assembly.rs
+++ b/prns-runtime/core/src/runtime/node/assembly.rs
@@ -423,7 +423,7 @@ fn configure_assembled_node<'a, D, St, R, F, S>(
 mod tests {
     use super::*;
     use crate::identity::vault::IdentitySecretKey;
-    use crate::identity::IdentityHash;
+    use crate::identity::{IdentityHash, Zeroizing, IDENTITY_SECRET_KEY_LEN};
     use crate::remote_control::{
         RemoteControlControllerGrant, RemoteControlControllerGrants,
         RemoteControlControllerIdentity, RemoteControlControllerIdentitySecret,
@@ -432,8 +432,11 @@ mod tests {
         REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY,
     };
     use crate::routing::request_handlers::RequestPathHash;
+    use crate::engine::RatchetPolicy;
+    use crate::routing::links::resources::ResourceStrategy;
+    use crate::routing::{LinkRequestPolicy, ProofStrategy};
     use crate::runtime::request_endpoints::{Decline, RequestContext, RequestEndpointPolicy};
-    use crate::runtime::{ManuallyAttached, NoPersistence};
+    use crate::runtime::{ManuallyAttached, NoPersistence, ServeMyRequestEndpoints};
     use crate::storage::TestFixedStorage;
 
     type Storage = TestFixedStorage<4, 4, 128, 4, 4, 4, 2, 2, 2, 2, 2, 2>;
@@ -636,6 +639,151 @@ mod tests {
             RevokeRemoteControlControllerOutcome::NotFound,
         );
         assert!(remote_control.access().is_empty());
+    }
+
+    #[test]
+    fn hopspot_style_recipe_needs_three_held_identity_rows_with_remote_control() {
+        let tight_storage = TestFixedStorage::<4, 4, 128, 4, 2, 2, 2, 2, 2, 2, 2, 2>;
+        let roomy_storage = TestFixedStorage::<4, 4, 128, 4, 3, 2, 2, 2, 2, 2, 2, 2>;
+        let node_secret = Zeroizing::new([0x55; IDENTITY_SECRET_KEY_LEN]);
+        let destinations = || {
+            [
+                PreConfiguredDestination::Single {
+                    app_name: "lxmf",
+                    aspects: &["delivery"],
+                    identity: node_secret.clone(),
+                    announce_app_data: b"delivery",
+                    proof: ProofStrategy::ProveAll,
+                    link_requests: LinkRequestPolicy::AcceptAll,
+                    ratchet: RatchetPolicy::Ratcheted,
+                    resource_strategy: ResourceStrategy::AcceptNone,
+                    maximum_request_bytes: Default::default(),
+                    request_endpoints: ServeMyRequestEndpoints::No,
+                },
+                PreConfiguredDestination::Single {
+                    app_name: "node",
+                    aspects: &["page"],
+                    identity: node_secret.clone(),
+                    announce_app_data: b"node",
+                    proof: ProofStrategy::ProveNone,
+                    link_requests: LinkRequestPolicy::AcceptAll,
+                    ratchet: RatchetPolicy::NoRatchets,
+                    resource_strategy: ResourceStrategy::AcceptNone,
+                    maximum_request_bytes: Default::default(),
+                    request_endpoints: ServeMyRequestEndpoints::Yes,
+                },
+            ]
+        };
+        let mut tight = MaybeUninit::uninit();
+        let tight_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            assemble_node_in_place(
+                &mut tight,
+                PrnsNodeRecipe {
+                    transport_identity: Some(node_secret.clone()),
+                    remote_control: remote_control_service(),
+                    pre_configured_destinations: destinations(),
+                    app_state: (),
+                    storage: tight_storage,
+                    request_endpoints: (),
+                    interfaces: ManuallyAttached,
+                    persistence: NoPersistence,
+                    on_event: |_, _| {},
+                },
+            );
+        }));
+        assert!(tight_result.is_err(), "two held rows cannot fit RC + Hopspot");
+
+        let mut roomy = MaybeUninit::uninit();
+        let (node, _, _) = assemble_node_in_place(
+            &mut roomy,
+            PrnsNodeRecipe {
+                transport_identity: Some(node_secret.clone()),
+                remote_control: remote_control_service(),
+                pre_configured_destinations: destinations(),
+                app_state: (),
+                storage: roomy_storage,
+                request_endpoints: (),
+                interfaces: ManuallyAttached,
+                persistence: NoPersistence,
+                on_event: |_, _| {},
+            },
+        );
+        assert_eq!(node.engine.held_identity_hashes().len(), 3);
+    }
+
+    #[test]
+    fn hopspot_style_recipe_needs_three_upstream_rows_with_remote_control_on_esp32s3() {
+        type Esp32LikeStorage = TestFixedStorage<4, 4, 128, 2, 3, 2, 2, 2, 2, 2, 2, 2>;
+        let node_secret = Zeroizing::new([0x55; IDENTITY_SECRET_KEY_LEN]);
+        let destinations = || {
+            [
+                PreConfiguredDestination::Single {
+                    app_name: "lxmf",
+                    aspects: &["delivery"],
+                    identity: node_secret.clone(),
+                    announce_app_data: b"delivery",
+                    proof: ProofStrategy::ProveAll,
+                    link_requests: LinkRequestPolicy::AcceptAll,
+                    ratchet: RatchetPolicy::Ratcheted,
+                    resource_strategy: ResourceStrategy::AcceptNone,
+                    maximum_request_bytes: Default::default(),
+                    request_endpoints: ServeMyRequestEndpoints::No,
+                },
+                PreConfiguredDestination::Single {
+                    app_name: "node",
+                    aspects: &["page"],
+                    identity: node_secret.clone(),
+                    announce_app_data: b"node",
+                    proof: ProofStrategy::ProveNone,
+                    link_requests: LinkRequestPolicy::AcceptAll,
+                    ratchet: RatchetPolicy::NoRatchets,
+                    resource_strategy: ResourceStrategy::AcceptNone,
+                    maximum_request_bytes: Default::default(),
+                    request_endpoints: ServeMyRequestEndpoints::Yes,
+                },
+            ]
+        };
+        let storage: Esp32LikeStorage = TestFixedStorage;
+        let mut slot = MaybeUninit::uninit();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            assemble_node_in_place(
+                &mut slot,
+                PrnsNodeRecipe {
+                    transport_identity: Some(node_secret.clone()),
+                    remote_control: remote_control_service(),
+                    pre_configured_destinations: destinations(),
+                    app_state: (),
+                    storage,
+                    request_endpoints: (),
+                    interfaces: ManuallyAttached,
+                    persistence: NoPersistence,
+                    on_event: |_, _| {},
+                },
+            );
+        }));
+        assert!(
+            result.is_err(),
+            "two upstream rows cannot fit RC target + delivery + node page"
+        );
+
+        type Esp32FixedStorage = TestFixedStorage<4, 4, 128, 3, 3, 2, 2, 2, 2, 2, 2, 2>;
+        let storage: Esp32FixedStorage = TestFixedStorage;
+        let mut slot = MaybeUninit::uninit();
+        let (node, _, _) = assemble_node_in_place(
+            &mut slot,
+            PrnsNodeRecipe {
+                transport_identity: Some(node_secret.clone()),
+                remote_control: remote_control_service(),
+                pre_configured_destinations: destinations(),
+                app_state: (),
+                storage,
+                request_endpoints: (),
+                interfaces: ManuallyAttached,
+                persistence: NoPersistence,
+                on_event: |_, _| {},
+            },
+        );
+        assert_eq!(node.engine.upstream_app_destinations().count(), 3);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Raise ESP32-S3 held-identity capacity from 2 to 3 so RemoteControl (controller + target) and the Hopspot node identity can coexist during recipe assembly.
- Raise upstream-app destination capacity from 2 to 3 for the RC target, lxmf/delivery, and node/page destinations.
- Reserve one extra request-handler row on embedded Hopspot builds for the RC endpoint in addition to node-page routes.
- Add host tests that reproduce the old limits and verify the Hopspot + RemoteControl recipe assembles cleanly at the new capacities.

## Root cause
Merging RemoteControl into the Hopspot ESP32 firmware left core 1 panicking inside `init_static_with_persistence` (`HoldIdentity(StoreFull)` / `Register(RegistryFull)` / request-handler table full). Core 0 kept running (WiFi associated, `network.ready`), but core 1 never reached the liveness task, producing the ~15s `watchdog: core1 heartbeat missing` reboot loop on Heltec V4 R8.

## Test plan
- [x] `cargo test hopspot_style_recipe` in `prns-runtime/core`
- [x] `cargo check -p hopspot-heltec-v4-r8 --target xtensa-esp32s3-none-elf` (ESP32-S3 compile-time asserts)
- [x] Hardware: Heltec V4 R8 flashed from integration branch — 90s stable, manifold events, zero watchdog warnings


Made with [Cursor](https://cursor.com)