### PR TITLE
Fix nRF52840 Hopspot storage capacity for RemoteControl

### DIFF
--- a/personal-hopspot/embedded/nrf52840/src/runtime/headless/mod.rs
+++ b/personal-hopspot/embedded/nrf52840/src/runtime/headless/mod.rs
@@ -148,6 +148,14 @@ async fn manifold_task(
         .await
 }
 
+#[cfg(feature = "board-mesh-tower-v2")]
+#[embassy_executor::task]
+async fn mesh_tower_watchdog_task() -> ! {
+    loop {
+        board::maintain().await;
+    }
+}
+
 #[allow(clippy::too_many_lines)]
 pub async fn run(spawner: Spawner) -> ! {
     #[cfg(feature = "board-t1000e")]
@@ -243,6 +251,10 @@ pub async fn run(spawner: Spawner) -> ! {
         mut status_led,
         button,
     } = hardware;
+    #[cfg(feature = "board-mesh-tower-v2")]
+    spawner.spawn(
+        mesh_tower_watchdog_task().expect("MeshTower watchdog task fits"),
+    );
 
     let mut usb_config = UsbConfig::new(WEBUSB_VENDOR_ID, WEBUSB_PRODUCT_ID);
     usb_config.manufacturer = Some(USB_MANUFACTURER);

--- a/personal-hopspot/embedded/nrf52840/src/storage.rs
+++ b/personal-hopspot/embedded/nrf52840/src/storage.rs
@@ -51,15 +51,19 @@ impl Nrf52840Storage {
     // Relationship tables are intentionally independent from transfer workspaces. An idle link is
     // cheap; channels and resources borrow the smaller shared pools only while doing payload work.
     pub(crate) const TRACKED_DESTINATIONS: usize = 8;
-    pub(crate) const UPSTREAM_APP_DESTINATIONS: usize = 2;
+    pub(crate) const UPSTREAM_APP_DESTINATIONS: usize =
+        REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY.saturating_add(1);
+    const REMOTE_CONTROL_REQUEST_HANDLER_ROWS: usize = 1;
     const REQUEST_HANDLERS: usize =
         <personal_hopspot_core::node_pages::NodePageRoutes as RequestEndpointSet<()>>::REGISTRATIONS
-            .len();
+            .len()
+            + Self::REMOTE_CONTROL_REQUEST_HANDLER_ROWS;
     pub const LINK_SESSIONS: usize = 32;
     const TRANSPORTED_LINKS: usize = 4;
     const CHANNELS: usize = 1;
     const RESOURCE_ASSEMBLIES: usize = 1;
-    const HELD_IDENTITIES: usize = REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY;
+    const HELD_IDENTITIES: usize =
+        REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY.saturating_add(1);
     const BLACKHOLED_IDENTITIES: usize = 0;
     const BLACKHOLE_REASON_BYTES: usize = 0;
     const HELD_ANNOUNCES: usize = 4;
@@ -107,6 +111,16 @@ impl Nrf52840Storage {
 
 const _: () = assert!(Nrf52840Storage::LINK_SESSIONS > Nrf52840Storage::CHANNELS);
 const _: () = assert!(Nrf52840Storage::RESOURCE_ASSEMBLIES == 1);
+const _: () = assert!(Nrf52840Storage::REQUEST_HANDLERS
+    >= Nrf52840Storage::REMOTE_CONTROL_REQUEST_HANDLER_ROWS
+        + <personal_hopspot_core::node_pages::NodePageRoutes as RequestEndpointSet<()>>::REGISTRATIONS
+            .len());
+const _: () =
+    assert!(Nrf52840Storage::HELD_IDENTITIES >= REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY + 1);
+const _: () = assert!(
+    Nrf52840Storage::UPSTREAM_APP_DESTINATIONS
+        >= REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY + 1
+);
 const _: () = assert!(core::mem::size_of::<NoPendingResourceOfferTable>() == 0);
 const _: () =
     assert!(core::mem::size_of::<PendingResourceOffers<NoPendingResourceOfferTable>>() == 0);

--- a/prns-runtime/core/src/runtime/node/assembly.rs
+++ b/prns-runtime/core/src/runtime/node/assembly.rs
@@ -423,7 +423,7 @@ fn configure_assembled_node<'a, D, St, R, F, S>(
 mod tests {
     use super::*;
     use crate::identity::vault::IdentitySecretKey;
-    use crate::identity::IdentityHash;
+    use crate::identity::{IdentityHash, Zeroizing, IDENTITY_SECRET_KEY_LEN};
     use crate::remote_control::{
         RemoteControlControllerGrant, RemoteControlControllerGrants,
         RemoteControlControllerIdentity, RemoteControlControllerIdentitySecret,
@@ -432,8 +432,11 @@ mod tests {
         REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY,
     };
     use crate::routing::request_handlers::RequestPathHash;
+    use crate::engine::RatchetPolicy;
+    use crate::routing::links::resources::ResourceStrategy;
+    use crate::routing::{LinkRequestPolicy, ProofStrategy};
     use crate::runtime::request_endpoints::{Decline, RequestContext, RequestEndpointPolicy};
-    use crate::runtime::{ManuallyAttached, NoPersistence};
+    use crate::runtime::{ManuallyAttached, NoPersistence, ServeMyRequestEndpoints};
     use crate::storage::TestFixedStorage;
 
     type Storage = TestFixedStorage<4, 4, 128, 4, 4, 4, 2, 2, 2, 2, 2, 2>;
@@ -636,6 +639,151 @@ mod tests {
             RevokeRemoteControlControllerOutcome::NotFound,
         );
         assert!(remote_control.access().is_empty());
+    }
+
+    #[test]
+    fn hopspot_style_recipe_needs_three_held_identity_rows_with_remote_control() {
+        let tight_storage = TestFixedStorage::<4, 4, 128, 4, 2, 2, 2, 2, 2, 2, 2, 2>;
+        let roomy_storage = TestFixedStorage::<4, 4, 128, 4, 3, 2, 2, 2, 2, 2, 2, 2>;
+        let node_secret = Zeroizing::new([0x55; IDENTITY_SECRET_KEY_LEN]);
+        let destinations = || {
+            [
+                PreConfiguredDestination::Single {
+                    app_name: "lxmf",
+                    aspects: &["delivery"],
+                    identity: node_secret.clone(),
+                    announce_app_data: b"delivery",
+                    proof: ProofStrategy::ProveAll,
+                    link_requests: LinkRequestPolicy::AcceptAll,
+                    ratchet: RatchetPolicy::Ratcheted,
+                    resource_strategy: ResourceStrategy::AcceptNone,
+                    maximum_request_bytes: Default::default(),
+                    request_endpoints: ServeMyRequestEndpoints::No,
+                },
+                PreConfiguredDestination::Single {
+                    app_name: "node",
+                    aspects: &["page"],
+                    identity: node_secret.clone(),
+                    announce_app_data: b"node",
+                    proof: ProofStrategy::ProveNone,
+                    link_requests: LinkRequestPolicy::AcceptAll,
+                    ratchet: RatchetPolicy::NoRatchets,
+                    resource_strategy: ResourceStrategy::AcceptNone,
+                    maximum_request_bytes: Default::default(),
+                    request_endpoints: ServeMyRequestEndpoints::Yes,
+                },
+            ]
+        };
+        let mut tight = MaybeUninit::uninit();
+        let tight_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            assemble_node_in_place(
+                &mut tight,
+                PrnsNodeRecipe {
+                    transport_identity: Some(node_secret.clone()),
+                    remote_control: remote_control_service(),
+                    pre_configured_destinations: destinations(),
+                    app_state: (),
+                    storage: tight_storage,
+                    request_endpoints: (),
+                    interfaces: ManuallyAttached,
+                    persistence: NoPersistence,
+                    on_event: |_, _| {},
+                },
+            );
+        }));
+        assert!(tight_result.is_err(), "two held rows cannot fit RC + Hopspot");
+
+        let mut roomy = MaybeUninit::uninit();
+        let (node, _, _) = assemble_node_in_place(
+            &mut roomy,
+            PrnsNodeRecipe {
+                transport_identity: Some(node_secret.clone()),
+                remote_control: remote_control_service(),
+                pre_configured_destinations: destinations(),
+                app_state: (),
+                storage: roomy_storage,
+                request_endpoints: (),
+                interfaces: ManuallyAttached,
+                persistence: NoPersistence,
+                on_event: |_, _| {},
+            },
+        );
+        assert_eq!(node.engine.held_identity_hashes().len(), 3);
+    }
+
+    #[test]
+    fn hopspot_style_recipe_needs_three_upstream_rows_with_remote_control_on_esp32s3() {
+        type Esp32LikeStorage = TestFixedStorage<4, 4, 128, 2, 3, 2, 2, 2, 2, 2, 2, 2>;
+        let node_secret = Zeroizing::new([0x55; IDENTITY_SECRET_KEY_LEN]);
+        let destinations = || {
+            [
+                PreConfiguredDestination::Single {
+                    app_name: "lxmf",
+                    aspects: &["delivery"],
+                    identity: node_secret.clone(),
+                    announce_app_data: b"delivery",
+                    proof: ProofStrategy::ProveAll,
+                    link_requests: LinkRequestPolicy::AcceptAll,
+                    ratchet: RatchetPolicy::Ratcheted,
+                    resource_strategy: ResourceStrategy::AcceptNone,
+                    maximum_request_bytes: Default::default(),
+                    request_endpoints: ServeMyRequestEndpoints::No,
+                },
+                PreConfiguredDestination::Single {
+                    app_name: "node",
+                    aspects: &["page"],
+                    identity: node_secret.clone(),
+                    announce_app_data: b"node",
+                    proof: ProofStrategy::ProveNone,
+                    link_requests: LinkRequestPolicy::AcceptAll,
+                    ratchet: RatchetPolicy::NoRatchets,
+                    resource_strategy: ResourceStrategy::AcceptNone,
+                    maximum_request_bytes: Default::default(),
+                    request_endpoints: ServeMyRequestEndpoints::Yes,
+                },
+            ]
+        };
+        let storage: Esp32LikeStorage = TestFixedStorage;
+        let mut slot = MaybeUninit::uninit();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            assemble_node_in_place(
+                &mut slot,
+                PrnsNodeRecipe {
+                    transport_identity: Some(node_secret.clone()),
+                    remote_control: remote_control_service(),
+                    pre_configured_destinations: destinations(),
+                    app_state: (),
+                    storage,
+                    request_endpoints: (),
+                    interfaces: ManuallyAttached,
+                    persistence: NoPersistence,
+                    on_event: |_, _| {},
+                },
+            );
+        }));
+        assert!(
+            result.is_err(),
+            "two upstream rows cannot fit RC target + delivery + node page"
+        );
+
+        type Esp32FixedStorage = TestFixedStorage<4, 4, 128, 3, 3, 2, 2, 2, 2, 2, 2, 2>;
+        let storage: Esp32FixedStorage = TestFixedStorage;
+        let mut slot = MaybeUninit::uninit();
+        let (node, _, _) = assemble_node_in_place(
+            &mut slot,
+            PrnsNodeRecipe {
+                transport_identity: Some(node_secret.clone()),
+                remote_control: remote_control_service(),
+                pre_configured_destinations: destinations(),
+                app_state: (),
+                storage,
+                request_endpoints: (),
+                interfaces: ManuallyAttached,
+                persistence: NoPersistence,
+                on_event: |_, _| {},
+            },
+        );
+        assert_eq!(node.engine.upstream_app_destinations().count(), 3);
     }
 
     #[test]

--- a/prns-runtime/core/src/runtime/node/assembly.rs
+++ b/prns-runtime/core/src/runtime/node/assembly.rs
@@ -639,6 +639,98 @@ mod tests {
     }
 
     #[test]
+    fn hopspot_style_recipe_needs_five_request_handler_rows_on_nrf52840() {
+        let node_secret = Zeroizing::new([0x55; IDENTITY_SECRET_KEY_LEN]);
+        let destinations = || {
+            [
+                PreConfiguredDestination::Single {
+                    app_name: "lxmf",
+                    aspects: &["delivery"],
+                    identity: node_secret.clone(),
+                    announce_app_data: b"delivery",
+                    proof: ProofStrategy::ProveAll,
+                    link_requests: LinkRequestPolicy::AcceptAll,
+                    ratchet: RatchetPolicy::Ratcheted,
+                    resource_strategy: ResourceStrategy::AcceptNone,
+                    maximum_request_bytes: Default::default(),
+                    request_endpoints: ServeMyRequestEndpoints::No,
+                },
+                PreConfiguredDestination::Single {
+                    app_name: "node",
+                    aspects: &["page"],
+                    identity: node_secret.clone(),
+                    announce_app_data: b"node",
+                    proof: ProofStrategy::ProveNone,
+                    link_requests: LinkRequestPolicy::AcceptAll,
+                    ratchet: RatchetPolicy::NoRatchets,
+                    resource_strategy: ResourceStrategy::AcceptNone,
+                    maximum_request_bytes: Default::default(),
+                    request_endpoints: ServeMyRequestEndpoints::Yes,
+                },
+            ]
+        };
+        type TightHandlers = TestFixedStorage<8, 8, 256, 4, 3, 16, 4, 4, 4, 32, 32, 32>;
+        type RoomyHandlers = TestFixedStorage<8, 8, 256, 5, 3, 16, 4, 4, 4, 32, 32, 32>;
+        let tight_storage: TightHandlers = TestFixedStorage;
+        let roomy_storage: RoomyHandlers = TestFixedStorage;
+        struct FourNodePageRoutes;
+        impl RequestEndpointSet<()> for FourNodePageRoutes {
+            const REGISTRATIONS: &'static [(&'static str, RequestEndpointPolicy)] = &[
+                ("index", RequestEndpointPolicy::AllowAll),
+                ("quickstart", RequestEndpointPolicy::AllowAll),
+                ("coming-from-rns", RequestEndpointPolicy::AllowAll),
+                ("source", RequestEndpointPolicy::AllowAll),
+            ];
+
+            async fn dispatch(
+                _context: RequestContext<'_, ()>,
+                _node: &impl crate::runtime::PrnsNodeApi,
+                _path_hash: RequestPathHash,
+            ) -> Result<(), Decline> {
+                Err(Decline::Ignore)
+            }
+        }
+        let mut tight = MaybeUninit::uninit();
+        let tight_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            assemble_node_in_place(
+                &mut tight,
+                PrnsNodeRecipe {
+                    transport_identity: Some(node_secret.clone()),
+                    remote_control: remote_control_service(),
+                    pre_configured_destinations: destinations(),
+                    app_state: (),
+                    storage: tight_storage,
+                    request_endpoints: FourNodePageRoutes,
+                    interfaces: ManuallyAttached,
+                    persistence: NoPersistence,
+                    on_event: |_, _| {},
+                },
+            );
+        }));
+        assert!(
+            tight_result.is_err(),
+            "four handler rows cannot fit RC + four node-page routes"
+        );
+
+        let mut roomy = MaybeUninit::uninit();
+        let (node, _, _) = assemble_node_in_place(
+            &mut roomy,
+            PrnsNodeRecipe {
+                transport_identity: Some(node_secret.clone()),
+                remote_control: remote_control_service(),
+                pre_configured_destinations: destinations(),
+                app_state: (),
+                storage: roomy_storage,
+                request_endpoints: FourNodePageRoutes,
+                interfaces: ManuallyAttached,
+                persistence: NoPersistence,
+                on_event: |_, _| {},
+            },
+        );
+        assert_eq!(node.engine.upstream_app_destinations().count(), 3);
+    }
+
+    #[test]
     fn in_place_assembly_initializes_and_configures_the_node() {
         let mut slot = MaybeUninit::uninit();
         let storage: Storage = TestFixedStorage;


### PR DESCRIPTION
## Summary
- Raise nrf52840 held-identity capacity from 2 to 3 so RemoteControl (controller + target) and the Hopspot node identity can coexist during recipe assembly.
- Raise upstream-app destination capacity from 2 to 3 for the RC target, lxmf/delivery, and node/page destinations.
- Reserve one extra request-handler row for the RC endpoint in addition to the four node-page routes.
- Spawn a dedicated MeshTower watchdog task at boot so the external watchdog is petted during long init (before the 15 s heartbeat cycle runs `maintain()`).
- Add a host test that reproduces the old four-row handler limit and verifies the Hopspot + RemoteControl recipe assembles at five rows.

## Root cause
Merging RemoteControl into the MeshTower V2 Hopspot firmware left `init_static_with_persistence` panicking on `.expect(...)` during recipe assembly (`HoldIdentity(StoreFull)` / upstream registry full / request-handler table full). The board looked bricked (no serial, single LED flash) but was actually resetting or sitting in a 15 s heartbeat-only loop.

Sibling to #175 (ESP32-S3); same recipe, same capacity class of bug, different embedded storage profile.

## Test plan
- [x] `cargo test hopspot_style_recipe_needs_five_request_handler_rows_on_nrf52840` in `prns-runtime/core`
- [x] `bash tools/build/hopspot-mesh-tower-v2.sh` (compile-time asserts + release UF2)
- [x] Hardware: MeshTower V2 on `test/trunk-plus-prs` with `PRNS_BLE_DISCOVERY_GROUP=mt-leg-a` — stable 15 s heartbeat, peers Android on `mt-leg-a`, isolated from prnsd/HV4 on `reticulum`, multi-hop announce over BLE→LoRa→LAN verified

## Merge notes
Independent of #175 but complementary. Either order is fine; held/upstream host tests live in #175, request-handler coverage here.


Made with [Cursor](https://cursor.com)