### PR TITLE
Size embedded storage for RemoteControl

### DIFF
--- a/personal-hopspot/embedded/esp32/src/storage.rs
+++ b/personal-hopspot/embedded/esp32/src/storage.rs
@@ -10,6 +10,8 @@ use core::alloc::Layout;
 use core::ptr::NonNull;
 
 #[cfg(any(target_arch = "xtensa", target_arch = "riscv32"))]
+use personal_rns::remote_control::REMOTE_CONTROL_REQUIRED_REQUEST_HANDLER_CAPACITY;
+#[cfg(any(target_arch = "xtensa", target_arch = "riscv32"))]
 use personal_rns::runtime::request_endpoints::RequestEndpointSet;
 #[cfg(target_arch = "xtensa")]
 use personal_rns::storage::Esp32S3;
@@ -17,7 +19,8 @@ use personal_rns::storage::Esp32S3;
 #[cfg(any(target_arch = "xtensa", target_arch = "riscv32"))]
 const NODE_REQUEST_HANDLER_CAPACITY: usize =
     <personal_hopspot_core::node_pages::NodePageRoutes as RequestEndpointSet<()>>::REGISTRATIONS
-        .len();
+        .len()
+        .saturating_add(REMOTE_CONTROL_REQUIRED_REQUEST_HANDLER_CAPACITY);
 
 /// The engine's storage recipe: the small coordination shell stays inline in SRAM, while
 /// high-count or bulky columns (including links, routes, announces, history, app-data, and
@@ -208,7 +211,10 @@ mod riscv {
     use personal_rns::identity::held::FixedHeldIdentityTable;
     use personal_rns::manifold::interface_seam::EMBEDDED_MAX_LINK_MTU;
     use personal_rns::prelude::*;
-    use personal_rns::remote_control::REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY;
+    use personal_rns::remote_control::{
+        REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY,
+        REMOTE_CONTROL_REQUIRED_UPSTREAM_APP_DESTINATION_CAPACITY,
+    };
     use personal_rns::routing::announce::destination_announce_limit::FixedDestinationAnnounceLimitTable;
     use personal_rns::routing::announce::held::FixedHeldAnnounceTable;
     use personal_rns::routing::announce::interface_announce_limit::FixedInterfaceAnnounceLimitTable;
@@ -257,8 +263,10 @@ mod riscv {
         // Keep cheap relationships abundant while channels and resource continuations borrow
         // smaller shared tables. None of these counts constrain the eight-peer BLE controller.
         pub(crate) const TRACKED_DESTINATIONS: usize = 36;
-        const UPSTREAM_APP_DESTINATIONS: usize = 2;
-        const HELD_IDENTITIES: usize = REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY;
+        const UPSTREAM_APP_DESTINATIONS: usize =
+            2usize.saturating_add(REMOTE_CONTROL_REQUIRED_UPSTREAM_APP_DESTINATION_CAPACITY);
+        const HELD_IDENTITIES: usize =
+            1usize.saturating_add(REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY);
         pub const LINK_SESSIONS: usize = 12;
         const TRANSPORTED_LINKS: usize = 8;
         const CHANNELS: usize = 2;

--- a/personal-hopspot/embedded/nrf52840/src/storage.rs
+++ b/personal-hopspot/embedded/nrf52840/src/storage.rs
@@ -3,7 +3,11 @@ use personal_rns::identity::destination_identity::{
     NoDestinationIdentityAppData, NoDestinationIdentityTable,
 };
 use personal_rns::identity::held::FixedHeldIdentityTable;
-use personal_rns::remote_control::REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY;
+use personal_rns::remote_control::{
+    REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY,
+    REMOTE_CONTROL_REQUIRED_REQUEST_HANDLER_CAPACITY,
+    REMOTE_CONTROL_REQUIRED_UPSTREAM_APP_DESTINATION_CAPACITY,
+};
 use personal_rns::routing::announce::destination_announce_limit::FixedDestinationAnnounceLimitTable;
 use personal_rns::routing::announce::held::FixedHeldAnnounceTable;
 use personal_rns::routing::announce::interface_announce_limit::FixedInterfaceAnnounceLimitTable;
@@ -51,15 +55,18 @@ impl Nrf52840Storage {
     // Relationship tables are intentionally independent from transfer workspaces. An idle link is
     // cheap; channels and resources borrow the smaller shared pools only while doing payload work.
     pub(crate) const TRACKED_DESTINATIONS: usize = 8;
-    pub(crate) const UPSTREAM_APP_DESTINATIONS: usize = 2;
+    pub(crate) const UPSTREAM_APP_DESTINATIONS: usize =
+        2usize.saturating_add(REMOTE_CONTROL_REQUIRED_UPSTREAM_APP_DESTINATION_CAPACITY);
     const REQUEST_HANDLERS: usize =
         <personal_hopspot_core::node_pages::NodePageRoutes as RequestEndpointSet<()>>::REGISTRATIONS
-            .len();
+            .len()
+            .saturating_add(REMOTE_CONTROL_REQUIRED_REQUEST_HANDLER_CAPACITY);
     pub const LINK_SESSIONS: usize = 32;
     const TRANSPORTED_LINKS: usize = 4;
     const CHANNELS: usize = 1;
     const RESOURCE_ASSEMBLIES: usize = 1;
-    const HELD_IDENTITIES: usize = REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY;
+    const HELD_IDENTITIES: usize =
+        1usize.saturating_add(REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY);
     const BLACKHOLED_IDENTITIES: usize = 0;
     const BLACKHOLE_REASON_BYTES: usize = 0;
     const HELD_ANNOUNCES: usize = 4;

--- a/prns-core/src/remote_control/core.rs
+++ b/prns-core/src/remote_control/core.rs
@@ -5,7 +5,12 @@ use crate::storage::TablePushError;
 
 use super::{RemoteControlRequestKind, RemoteControlRequestSet};
 
+/// Held-identity rows consumed by an available RemoteControl service.
 pub const REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY: usize = 2;
+/// Upstream application-destination rows consumed by an available RemoteControl service.
+pub const REMOTE_CONTROL_REQUIRED_UPSTREAM_APP_DESTINATION_CAPACITY: usize = 1;
+/// Request-handler rows consumed by an available RemoteControl service.
+pub const REMOTE_CONTROL_REQUIRED_REQUEST_HANDLER_CAPACITY: usize = 1;
 
 pub struct RemoteControlControllerIdentitySecret {
     parts: IdentityParts,

--- a/prns-core/src/storage/impls/esp32s3.rs
+++ b/prns-core/src/storage/impls/esp32s3.rs
@@ -12,7 +12,10 @@ use crate::interfaces::EMBEDDED_MAX_LINK_MTU;
 use crate::persistence::{
     flash_journal_record_storage_len, maximum_route_upsert_payload_len, self_ratchets_snapshot_len,
 };
-use crate::remote_control::REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY;
+use crate::remote_control::{
+    REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY,
+    REMOTE_CONTROL_REQUIRED_UPSTREAM_APP_DESTINATION_CAPACITY,
+};
 use crate::routing::announce::defaults::MAX_ANNOUNCE_IDS_PER_DESTINATION;
 use crate::routing::announce::destination_announce_limit::{
     destination_announce_limit_index_buckets, FixedHeapDestinationAnnounceLimitTable,
@@ -57,8 +60,12 @@ use crate::routing::warmth::FixedDepartedInterfaceTable;
 use crate::storage::{DisplayedStorageLimits, StorageCapacity, StorageLayout};
 
 const MAX_TRACKED_DESTINATIONS: usize = 512;
-const MAX_UPSTREAM_APP_DESTINATIONS: usize = 2;
-const MAX_HELD_IDENTITIES: usize = REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY;
+// Two Hopspot destinations share one node identity. RemoteControl owns an independent target
+// destination plus its controller/target identity pair.
+const MAX_UPSTREAM_APP_DESTINATIONS: usize =
+    2usize.saturating_add(REMOTE_CONTROL_REQUIRED_UPSTREAM_APP_DESTINATION_CAPACITY);
+const MAX_HELD_IDENTITIES: usize =
+    1usize.saturating_add(REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY);
 const MAX_LINK_SESSIONS: usize = 512;
 const MAX_TRANSPORTED_LINKS: usize = 32;
 const MAX_OUTSTANDING_RECEIPTS: usize = 8;
@@ -97,8 +104,8 @@ const CHANNEL_MESSAGE_BYTES: usize = channel_mdu(EMBEDDED_MAX_LINK_MTU);
 ///
 /// `MAX_REQUEST_HANDLERS` is independent from the upstream-application destination capacity:
 /// applications commonly register several request paths on one destination. It defaults to the
-/// historical two rows, while application recipes with more routes should supply their exact
-/// registration count.
+/// fixed profile's destination count, while application recipes with more routes should supply
+/// their exact registration count.
 pub struct Esp32S3<
     A: Allocator = Global,
     const MAX_REQUEST_HANDLERS: usize = MAX_UPSTREAM_APP_DESTINATIONS,

--- a/prns-runtime/core/src/runtime/node/assembly.rs
+++ b/prns-runtime/core/src/runtime/node/assembly.rs
@@ -495,6 +495,8 @@ mod tests {
         RemoteControlInitialAccess, RemoteControlNodeIdentitySecrets, RemoteControlPublicAppData,
         RemoteControlRequestKind, RemoteControlRequestSet, RemoteControlTargetIdentitySecret,
         REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY,
+        REMOTE_CONTROL_REQUIRED_REQUEST_HANDLER_CAPACITY,
+        REMOTE_CONTROL_REQUIRED_UPSTREAM_APP_DESTINATION_CAPACITY,
     };
     use crate::routing::request_handlers::RequestPathHash;
     use crate::runtime::request_endpoints::{Decline, RequestContext, RequestEndpointPolicy};
@@ -502,6 +504,20 @@ mod tests {
     use crate::storage::TestFixedStorage;
 
     type Storage = TestFixedStorage<4, 4, 128, 4, 4, 4, 2, 2, 2, 2, 2, 2>;
+    type RemoteControlOnlyStorage = TestFixedStorage<
+        4,
+        4,
+        128,
+        REMOTE_CONTROL_REQUIRED_UPSTREAM_APP_DESTINATION_CAPACITY,
+        REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY,
+        4,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+    >;
 
     struct Routes;
 
@@ -665,6 +681,24 @@ mod tests {
                 },
             ),
         );
+    }
+
+    #[test]
+    fn remote_control_capacity_constants_fit_exact_fixed_storage() {
+        let mut engine = EngineState::<RemoteControlOnlyStorage>::default();
+        let configured = configure_remote_control_service(&mut engine, remote_control_service())
+            .expect("the advertised RemoteControl capacities fit the service");
+
+        assert!(configured.is_available());
+        assert_eq!(
+            engine.held_identity_hashes().len(),
+            REMOTE_CONTROL_REQUIRED_HELD_IDENTITY_CAPACITY,
+        );
+        assert_eq!(
+            engine.upstream_app_destinations().count(),
+            REMOTE_CONTROL_REQUIRED_UPSTREAM_APP_DESTINATION_CAPACITY,
+        );
+        assert_eq!(REMOTE_CONTROL_REQUIRED_REQUEST_HANDLER_CAPACITY, 1);
     }
 
     #[test]


### PR DESCRIPTION
RemoteControl consumes two held identities, one upstream application destination, and one request handler. The fixed embedded Hopspot profiles did not reserve all of that capacity, causing E290 startup to panic with HoldIdentity(StoreFull).

This change adds explicit RemoteControl capacity requirements, applies them to the ESP32-S3, ESP32-C6, and nRF52840 storage profiles, and adds an exact-capacity regression test.

Validated with the affected test suites, cross-target release builds, and an E290 hardware boot smoke.