### PR TITLE
Keep the Hopspot LoRa card when Tune retags the radio

### DIFF
--- a/personal-hopspot/embedded/esp32/src/s3/display.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/display.rs
@@ -58,12 +58,13 @@ fn classify_card(
     tcp_id: Option<InterfaceId>,
     tcp_client: Option<&HopspotTcpClientConfig>,
     wifi_kind: screen::CardKind,
-    lora_id: Option<InterfaceId>,
     espnow_id: Option<InterfaceId>,
 ) -> Option<(screen::CardKind, screen::CardLabel)> {
     if id == usb_id {
         Some((screen::CardKind::Usb, screen::card_label("USB")))
-    } else if Some(id) == lora_id {
+    } else if id.kind() == Some(InterfaceKind::LoRa) {
+        // LoRa retags its InterfaceId when frequency or modulation changes. Kind is the stable
+        // card identity; a boot-time id would mis-label the retagged radio as a Peer.
         Some((screen::CardKind::LoRa, screen::card_label("LoRa")))
     } else if Some(id) == wifi_id {
         Some((wifi_kind, screen::card_label("LAN")))
@@ -199,7 +200,6 @@ pub(super) fn build_cards(
     tcp_client: Option<&HopspotTcpClientConfig>,
     wifi: Option<&AutoWifiStatus<MEMBERS>>,
     wifi_config: &HopspotWifiConfig,
-    lora_id: Option<InterfaceId>,
     espnow_id: Option<InterfaceId>,
 ) -> HVec<screen::Card, 8> {
     let wifi_kind = if !wifi_config.has_station() {
@@ -211,7 +211,7 @@ pub(super) fn build_cards(
     };
     screen::snapshots_to_cards(snapshots, |id| {
         classify_card(
-            id, usb_id, wifi_id, tcp_id, tcp_client, wifi_kind, lora_id, espnow_id,
+            id, usb_id, wifi_id, tcp_id, tcp_client, wifi_kind, espnow_id,
         )
     })
 }

--- a/personal-hopspot/embedded/esp32/src/s3/firmware.rs
+++ b/personal-hopspot/embedded/esp32/src/s3/firmware.rs
@@ -153,15 +153,9 @@ pub(super) async fn run_core<B: Esp32S3Board>(
     // The Option shims mirror ESP-NOW's: boards without an SX1262 keep every downstream card,
     // toggle, and sleep path compiling against `None` instead of forking the render loop.
     #[cfg(feature = "lora")]
-    let (lora_card_id, lora_card_status): (
-        Option<InterfaceId>,
-        Option<&'static EmbassyInterfaceStatus>,
-    ) = (Some(lora_id), Some(lora_status));
+    let lora_card_status: Option<&'static EmbassyInterfaceStatus> = Some(lora_status);
     #[cfg(not(feature = "lora"))]
-    let (lora_card_id, lora_card_status): (
-        Option<InterfaceId>,
-        Option<&'static EmbassyInterfaceStatus>,
-    ) = (None, None);
+    let lora_card_status: Option<&'static EmbassyInterfaceStatus> = None;
     // Reclaim the private R8 probe allocation before placing the live LoRa queue in PSRAM.
     // This is a no-op on boards whose PSRAM belongs to the global heap.
     #[cfg(feature = "lora")]
@@ -514,7 +508,6 @@ pub(super) async fn run_core<B: Esp32S3Board>(
                 tcp_card_config,
                 wifi_status.as_ref(),
                 &wifi_config,
-                lora_card_id,
                 espnow_card_id,
             );
             let now_ms = embassy_time::Instant::now().as_millis();
@@ -824,11 +817,13 @@ pub(super) async fn run_core<B: Esp32S3Board>(
                                             usb_status.toggle_enabled();
                                             handled = true;
                                         }
-                                        if !handled && Some(card.id()) == lora_card_id {
+                                        if !handled {
                                             if let Some(status) = lora_card_status {
-                                                show_toggle_notice(status.is_enabled());
-                                                status.toggle_enabled();
-                                                handled = true;
+                                                if card.id() == status.id() {
+                                                    show_toggle_notice(status.is_enabled());
+                                                    status.toggle_enabled();
+                                                    handled = true;
+                                                }
                                             }
                                         }
                                         if !handled {


### PR DESCRIPTION
## Summary
- Classify the Hopspot LoRa card by `InterfaceKind::LoRa`, not the boot-time `InterfaceId`.
- Tune and Save retag LoRa's id from frequency and modulation; matching the old id turned a live LoRa radio into a generic Peer card.

## Test plan
- [x] `cargo test --locked -p personal-hopspot-core screen::tests` on Darwin arm64 (98 passed, before this was split onto trunk)
- [ ] Flash Heltec V4, Tune/Save a Montreal (or other) channel, confirm the LoRa card stays LoRa instead of becoming Peer
- [ ] Confirm a real Peer interface still renders as a Peer card


Made with [Cursor](https://cursor.com)