### PR TITLE
Use thin LTO on nRF52840 Hopspot so SX126x SPI stays intact

### DIFF
--- a/personal-hopspot/embedded/nrf52840/Cargo.toml
+++ b/personal-hopspot/embedded/nrf52840/Cargo.toml
@@ -94,7 +94,9 @@ codegen-units = 1
 debug = 2
 debug-assertions = false
 incremental = false
-lto = "fat"
+# fat LTO miscompiles the SX126x SPI command stream on thumbv7em (wrong
+# SetRfFrequency / SetTxParams, or a boot HardFault). thin is required.
+lto = "thin"
 opt-level = "z"
 overflow-checks = false
 


### PR DESCRIPTION
## Summary
- Switch the shared nRF52840 Hopspot profile from fat LTO to `lto = "thin"`.
- Fat LTO on thumbv7em can miscompile the SX126x command stream (`SetRfFrequency` / `SetTxParams`) or HardFault at boot. Every nRF Hopspot board shares this profile; `opt-level = "z"` is unchanged.

## Test plan
- [ ] Build MeshTower V2 UF2 with the thin-LTO profile
- [ ] Flash and confirm SX126x programs the requested frequency (Montreal 914.875 MHz should not land on channel-96 915.125 MHz)
- [ ] Confirm boot does not HardFault on MeshTower V2


Made with [Cursor](https://cursor.com)