### PR TITLE
Ship 0.3.7-hotfix.5 ESP32-S3 entropy hotfix

### DIFF
--- a/about.toml
+++ b/about.toml
@@ -26,6 +26,9 @@ accepted = ["LicenseRef-Nordic-SoftDevice"]
 [serialport]
 accepted = ["MPL-2.0"]
 
+[option-ext]
+accepted = ["MPL-2.0"]
+
 [nrf-softdevice-s140.clarify]
 license = "LicenseRef-Nordic-SoftDevice"
 override-git-commit = "47d6121c6e823120e8b883a7ac75f44ce7daa3aa"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -3,6 +3,7 @@ name = "personal-reticulum-suite-benchmarks"
 version = "0.0.0"
 publish = false
 edition = "2021"
+license = "MIT OR Apache-2.0"
 autobins = false
 
 # Standalone, like `validation/fuzz/`: an empty `[workspace]` detaches this from the root so

--- a/deny.toml
+++ b/deny.toml
@@ -44,6 +44,9 @@ exceptions = [
     # tray-icon 0.24.1 reaches platform configuration through dirs 6.0.0 and this small
     # MPL-licensed option adapter. Keep the exception pinned instead of allowing MPL globally.
     { allow = ["MPL-2.0"], crate = "option-ext@0.2.0" },
+    # The non-shipping fuzz harness links LLVM's libFuzzer runtime. NCSA is permissive,
+    # but keep its acceptance pinned to the exact test-only package instead of widening products.
+    { allow = ["NCSA"], crate = "libfuzzer-sys@0.4.12" },
 ]
 
 # `unescaper` declares the malformed/deprecated SPDX expression "GPL-3.0/MIT". It is

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,7 @@
 # cargo-deny — turns three of our promises into CI-enforced guarantees instead of
 # review-time discipline:
-#   1. the permissive-by-default license claim — GPL/AGPL/LGPL fail, and the one required
-#      file-level MPL transport stays scoped to an exact package exception;
+#   1. the permissive-by-default license claim — GPL/AGPL/LGPL fail, and required
+#      file-level MPL dependencies stay scoped to exact package exceptions;
 #   2. no known-vulnerable dependencies (RUSTSEC advisory DB);
 #   3. no surprise dependency sources or yanked crates.
 #
@@ -41,6 +41,9 @@ exceptions = [
     # espflash 4.5.0's library serial engine requires serialport. Keep its file-level MPL
     # obligations quarantined to this exact transport crate instead of widening the policy.
     { allow = ["MPL-2.0"], crate = "serialport@4.9.0" },
+    # tray-icon 0.24.1 reaches platform configuration through dirs 6.0.0 and this small
+    # MPL-licensed option adapter. Keep the exception pinned instead of allowing MPL globally.
+    { allow = ["MPL-2.0"], crate = "option-ext@0.2.0" },
 ]
 
 # `unescaper` declares the malformed/deprecated SPDX expression "GPL-3.0/MIT". It is

--- a/docs/release-dependency-audit.md
+++ b/docs/release-dependency-audit.md
@@ -27,10 +27,10 @@ dependencies, and checks advisories, licenses, sources, and bans with cargo-deny
 
 - RUSTSEC-2026-0204 is resolved by `crossbeam-epoch 0.9.20`.
 - RUSTSEC-2026-0194 and RUSTSEC-2026-0195 are resolved by `plist 1.10.0` and `quick-xml 0.41.0`.
-- `dirs`/`option-ext`, `serialport`, and `tokio-serial` were removed from the engine/application
-  graphs. The standalone hardware flasher intentionally carries exact-scoped `directories` and
-  `serialport` dependencies for its user cache and direct USB operation; that separate graph is
-  audited on every published operating system target.
+- `serialport` and `tokio-serial` were removed from the engine/application graphs. The macOS and
+  Windows tray faces intentionally carry `dirs`/`option-ext` through `tray-icon`, while the
+  standalone hardware flasher carries exact-scoped `directories` and `serialport` dependencies
+  for its user cache and direct USB operation. Those platform graphs are audited independently.
 - Linux does not instantiate tray-icon's GTK3/GLib path for either `prnsd` or the Hopspot desktop
   face. Both use the blocking StatusNotifier backend in `ksni 0.3.6`; tray-icon remains
   target-scoped to macOS and Windows.
@@ -38,9 +38,9 @@ dependencies, and checks advisories, licenses, sources, and bans with cargo-deny
 The allowlist in `deny.toml` is a permissive-by-default policy: every unlisted expression fails.
 GPL, LGPL, AGPL, and unknown licenses are not accepted. Package-scoped additions are `ksni 0.3.6`
 under Unlicense, `nrf-softdevice-s140 0.1.2` under the hash-pinned Nordic terms, and the exact
-`serialport 4.9.0` transport required by the mandated `espflash 4.5.0` library under file-level
-MPL-2.0. That narrow hardware boundary is shipped with its source/license notice; MPL is not
-accepted generally. The SoftDevice source remains restricted to revision
+`serialport 4.9.0` and `option-ext 0.2.0` dependencies under file-level MPL-2.0. Those narrow
+transport and tray boundaries are shipped with their source/license notices; MPL is not accepted
+generally. The SoftDevice source remains restricted to revision
 `47d6121c6e823120e8b883a7ac75f44ce7daa3aa`.
 
 ## Unsafe enforcement

--- a/docs/runtime-entropy.md
+++ b/docs/runtime-entropy.md
@@ -84,7 +84,7 @@ source. A new platform must prove its initialization order by implementing
 `EntropySource`, constructing `RuntimeEntropy` before identity/bootstrap work,
 and passing only the resulting stream or handle into runtime consumers.
 
-## Personal Hopspot 0.4.0 remediation
+## Personal Hopspot 0.3.7-hotfix.5 remediation
 
 Personal Hopspot ESP32-S3 firmware versions 0.3.7 through 0.3.7-hotfix.4 could
 create a node identity and Auto-BLE identity before the documented primary
@@ -93,15 +93,16 @@ erase on Heltec LoRa 32 V4 variants and LilyGO T-Beam Supreme. Devices upgraded
 while retaining valid stored identities did not regenerate them and were not
 affected by that initialization path.
 
-The remediation for a potentially affected installation is a **0.4.0 full-erase
-reflash**. An ordinary sparse update deliberately preserves stored identity,
-routes, ratchets, radio configuration, and provisioning state, so it cannot
-replace an identity created on the affected path. Firmware will not silently
-rotate retained identities: identity replacement changes the node's public
-destinations and must remain an explicit operator action.
+The remediation for a potentially affected installation is a
+**0.3.7-hotfix.5 or later full-erase reflash**. An ordinary sparse update
+deliberately preserves stored identity, routes, ratchets, radio configuration,
+and provisioning state, so it cannot replace an identity created on the
+affected path. Firmware will not silently rotate retained identities: identity
+replacement changes the node's public destinations and must remain an explicit
+operator action.
 
 A full erase destroys the device's stored identities and other persistent
-state. Record anything needed for recovery, verify the exact board, and use the
-flasher's full-erase option when installing 0.4.0. Devices whose identities
-predate 0.3.7 do not need rotation solely because they later ran an affected
-release.
+state. Record anything needed for recovery, verify the exact board, and perform
+a full-chip erase before installing 0.3.7-hotfix.5 or later.
+Devices whose identities predate 0.3.7 do not need rotation solely because they
+later ran an affected release.

--- a/personal-hopspot/README.md
+++ b/personal-hopspot/README.md
@@ -118,8 +118,8 @@ signed release. Qualification receipts and their remaining limits live under
 ## Embedded flash-layout upgrade
 
 The [runtime entropy guide](../docs/runtime-entropy.md) documents board bring-up,
-reseed sources, and the 0.4.0 full-erase remediation for ESP32-S3 identities
-created on the affected 0.3.7 through 0.3.7-hotfix.4 first-boot path.
+reseed sources, and the 0.3.7-hotfix.5 full-erase remediation for ESP32-S3
+identities created on the affected 0.3.7 through 0.3.7-hotfix.4 first-boot path.
 
 LoRa-capable firmware persists the selected radio profile in a dedicated two-page store. Reset records a durable choice to follow the firmware default, while an explicitly saved profile remains fixed across updates. Sparse firmware updates preserve the profile store; a full-chip erase clears it.
 

--- a/release/acceptance/rosters/0.3.7.json
+++ b/release/acceptance/rosters/0.3.7.json
@@ -23,8 +23,8 @@
     {
       "board": "heltec-v4",
       "surface": "cli",
-      "os": "linux",
-      "architecture": "x86_64",
+      "os": "macos",
+      "architecture": "aarch64",
       "tester": "github:KenAKAFrosty",
       "cables_ready": true,
       "device_permissions_ready": true,

--- a/release/flash/hotfixes/0.3.7-hotfix.5.json
+++ b/release/flash/hotfixes/0.3.7-hotfix.5.json
@@ -1,0 +1,51 @@
+{
+  "changed_boards": [
+    "heltec-v4",
+    "heltec-v4-r8",
+    "t-beam-supreme"
+  ],
+  "qualification": {
+    "deferred_hardware": [
+      {
+        "basis": "The R8 target uses the same shared ESP32-S3 RNG/ADC TRNG bootstrap and identity-generation path exercised on the physical S3R2 V4, and its board-specific release build passes, but no physical R8 hardware is presently available for the signed candidate.",
+        "board": "heltec-v4-r8",
+        "follow_up": "Capture and review an S3R8 full-erase first boot, fresh node and Auto-BLE identity creation, identity retention after reboot, LoRa readiness, and stable-runtime observation after promotion."
+      },
+      {
+        "basis": "The T-Beam target uses the same shared ESP32-S3 RNG/ADC TRNG bootstrap and identity-generation path exercised on the physical S3R2 V4, and its board-specific release build passes, but no physical T-Beam hardware is presently available for the signed candidate.",
+        "board": "t-beam-supreme",
+        "follow_up": "Capture and review a T-Beam full-erase first boot, fresh node and Auto-BLE identity creation, identity retention after reboot, LoRa readiness, and stable-runtime observation after promotion."
+      }
+    ],
+    "physical_boards": [
+      "heltec-v4"
+    ],
+    "required_checks": [
+      "fresh-node-and-ble-identities-created",
+      "hardware-trng-enabled-before-identity-generation",
+      "identities-retained-after-reboot",
+      "lora-radio-ready",
+      "stable-post-boot-runtime"
+    ],
+    "required_scenarios": [
+      "correct-board",
+      "fresh-install",
+      "full-erase-first-boot",
+      "post-flash-boot",
+      "second-boot"
+    ],
+    "surfaces": [
+      "cli"
+    ]
+  },
+  "release": {
+    "base_manifest_sha256": "0143926b236c1d33c820fd4cb0f7c430f560c4f663c052eeb13b1c1a88b935f8",
+    "base_release_record_sha256": "5716909da55dc2da84ecae6969fb4e50b9b81d19acf266b549bb6ca34419a137",
+    "base_signed_candidate_sha256": "512f98becce21eae1de876995c0d98d5eafccde669085f2c8beced7c38407650",
+    "base_source_commit": "d9e33cdd877545821af4b9c5d769f064b2940c85",
+    "base_version": "0.3.7-hotfix.4",
+    "version": "0.3.7-hotfix.5"
+  },
+  "schema": 1,
+  "summary": "ESP32-S3 identity bootstrap now enables the hardware RNG/ADC TRNG source before generating node and Auto-BLE identities; potentially affected existing installations require an explicit full-erase reflash."
+}

--- a/validation/fuzz/Cargo.toml
+++ b/validation/fuzz/Cargo.toml
@@ -3,6 +3,7 @@ name = "personal-reticulum-suite-fuzz"
 version = "0.0.0"
 publish = false
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [package.metadata]
 cargo-fuzz = true


### PR DESCRIPTION
## Summary

- define 0.3.7-hotfix.5 directly on the complete current main source
- rebuild Heltec V4, Heltec V4 R8, and T-Beam Supreme with corrected ESP32-S3 TRNG ordering
- retain every unaffected hotfix.4 artifact byte-for-byte
- document full-chip erase as remediation for identities created by affected firmware
- close exhaustive pre-push license-policy gaps for standalone benchmark, tray, and fuzz graphs

## Validation

- complete repository pre-push CI-parity suite
- affected Xtensa release checks and two byte-identical local artifact builds
- core entropy and fixed-vector crypto tests
- Heltec V4 sparse flash and true reboot smoke
- Wi-Fi association and DHCP on both boots
- exactly one configured outbound TCP client connected after reboot
- LoRa GC1109, BLE, ESP-NOW, persistence, watchdog, and runtime entropy healthy
- no packet refusals, queue failures, panics, or resets observed

No selective backport is used. This branch starts at protected main f28ba636462f2255227e51cc19c7a9d6dd41343e and adds release metadata, documentation, and policy corrections only.