### PR TITLE
Fix clean flasher candidate playground build

### DIFF
--- a/prns-wasm/examples/browser-playground/bluetooth.ts
+++ b/prns-wasm/examples/browser-playground/bluetooth.ts
@@ -154,6 +154,15 @@ export class PlaygroundBluetoothController {
           describeInterfaceCloseFailure(failure),
         );
       },
+      RuntimeRejected: (data) => {
+        const failure = Tag("RuntimeRejected", data);
+        this.#transition(Tag("CloseFailed", { session, failure }));
+        this.#view.record(
+          "Failure",
+          "Bluetooth close failed",
+          describeInterfaceCloseFailure(failure),
+        );
+      },
     });
   }
 

--- a/prns-wasm/examples/browser-playground/main.ts
+++ b/prns-wasm/examples/browser-playground/main.ts
@@ -400,6 +400,15 @@ class BrowserPlayground {
           describeInterfaceCloseFailure(failure),
         );
       },
+      RuntimeRejected: (data) => {
+        const failure = Tag("RuntimeRejected", data);
+        this.#webSocket = Tag("CloseFailed", { session, failure });
+        this.#view.record(
+          "Failure",
+          "WebSocket close failed",
+          describeInterfaceCloseFailure(failure),
+        );
+      },
     });
     this.#view.renderWebSocket(this.#webSocket);
     this.#syncControls();
@@ -510,6 +519,15 @@ class BrowserPlayground {
       },
       CloseFailed: (data) => {
         const failure = Tag("CloseFailed", data);
+        this.#usb = Tag("CloseFailed", { session, failure });
+        this.#view.record(
+          "Failure",
+          "USB Auto close failed",
+          describeInterfaceCloseFailure(failure),
+        );
+      },
+      RuntimeRejected: (data) => {
+        const failure = Tag("RuntimeRejected", data);
         this.#usb = Tag("CloseFailed", { session, failure });
         this.#view.record(
           "Failure",

--- a/prns-wasm/examples/browser-playground/outcomes.ts
+++ b/prns-wasm/examples/browser-playground/outcomes.ts
@@ -151,6 +151,7 @@ export function describeInterfaceCloseFailure(
     HostOperationFailed: ({ operation, detail }) => `${operation}: ${detail}`,
     CloseFailed: ({ causes }) =>
       causes.map(describeCleanupFailure).join("; "),
+    RuntimeRejected: ({ operation, detail }) => `${operation}: ${detail}`,
   });
 }
 

--- a/tools/release/build-flasher-candidate.sh
+++ b/tools/release/build-flasher-candidate.sh
@@ -46,6 +46,8 @@ fi
 for release_input in \
     "$root/Cargo.lock" \
     "$root/docs/website/package-lock.json" \
+    "$root/prns-js/package-lock.json" \
+    "$root/prns-wasm/package-lock.json" \
     "$root/LICENSE-APACHE" \
     "$root/LICENSE-MIT" \
     "$root/THIRD_PARTY_NOTICES.md" \
@@ -230,6 +232,7 @@ PRNS_API_DOCS_STAGED=1 \
 cargo run --locked --bin finalize_ssg -- "$hosted_dist"
 mkdir -p "$candidate/website/assets/flasher"
 cp -R "$hosted_dist/." "$candidate/website/"
+npm --prefix "$root/prns-js" ci --ignore-scripts --no-audit --no-fund
 npm --prefix "$root/prns-wasm" ci --ignore-scripts --no-audit --no-fund
 bash "$root/tools/build/stage-wasm-docs-browser-playground.sh" \
     "$candidate/website/browser-node-playground-console"

--- a/tools/tests/test_flasher_reproducibility.py
+++ b/tools/tests/test_flasher_reproducibility.py
@@ -369,6 +369,34 @@ class FlasherReproducibilityTests(unittest.TestCase):
             candidate_build.index('cp -R "$hosted_dist/." "$candidate/website/"'),
         )
 
+    def test_candidate_installs_locked_playground_dependency_graphs(self) -> None:
+        candidate_build = (SCRIPTS / "build-flasher-candidate.sh").read_text(
+            encoding="utf-8"
+        )
+        js_lock = '"$root/prns-js/package-lock.json"'
+        wasm_lock = '"$root/prns-wasm/package-lock.json"'
+        js_install = (
+            'npm --prefix "$root/prns-js" ci '
+            "--ignore-scripts --no-audit --no-fund"
+        )
+        wasm_install = (
+            'npm --prefix "$root/prns-wasm" ci '
+            "--ignore-scripts --no-audit --no-fund"
+        )
+        playground_stage = "stage-wasm-docs-browser-playground.sh"
+        self.assertIn(js_lock, candidate_build)
+        self.assertIn(wasm_lock, candidate_build)
+        self.assertIn(js_install, candidate_build)
+        self.assertIn(wasm_install, candidate_build)
+        self.assertLess(
+            candidate_build.index(js_install),
+            candidate_build.index(playground_stage),
+        )
+        self.assertLess(
+            candidate_build.index(wasm_install),
+            candidate_build.index(playground_stage),
+        )
+
     def test_candidate_rustdoc_is_deterministically_ordered_and_normalized(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- install both locked JavaScript dependency graphs before staging the release playground
- require both package locks as explicit candidate inputs
- handle the typed RuntimeRejected close outcome exhaustively in the browser playground
- add a release-contract regression test for dependency-install ordering

## Validation
- npm test (106 passed)
- npm run build:playground:ts
- bash validation/release/contracts.sh
- complete local pre-push CI parity gate, including 22 host workspaces, embedded matrices, Clippy, browser/WASM, JVM, Swift, license and dependency policy