### PR TITLE
Vendor casework in staged browser SDK

### DIFF
--- a/tools/build/stage-wasm-docs-browser-playground.sh
+++ b/tools/build/stage-wasm-docs-browser-playground.sh
@@ -34,6 +34,11 @@ else
     npm --prefix "$wasm_dir" run build:playground
 fi
 
+# The playground TypeScript project compiles prns-js from source so its SDK stays
+# coupled to the exact repository commit. Replace the resulting bare casework
+# package import with the same locked, self-contained module shipped by prns-js.
+node "$repo_root/prns-js/scripts/stage-code.mjs"
+
 if [[ -e "$public_dir/sdk" ]]; then
     rm -rf -- "$public_dir/sdk"
 fi
@@ -48,6 +53,7 @@ cp "$build_dir/prns-wasm/examples/browser-playground/presentation.js" "$public_d
 cp "$build_dir/prns-wasm/examples/browser-playground/state.js" "$public_dir/state.js"
 cp "$build_dir/prns-wasm/examples/browser-playground/view.js" "$public_dir/view.js"
 cp -R "$build_dir/prns-js/src/." "$public_dir/sdk/"
+cp "$repo_root/prns-js/dist/casework.js" "$public_dir/sdk/casework.js"
 cp "$example_dir/sdk/index.js" "$public_dir/sdk/index.js"
 cp "$example_dir/sdk/package.json" "$public_dir/sdk/package.json"
 cp "$build_dir/pkg/prns_wasm.js" "$public_dir/pkg/prns_wasm.js"

--- a/tools/tests/test_flasher_reproducibility.py
+++ b/tools/tests/test_flasher_reproducibility.py
@@ -397,6 +397,35 @@ class FlasherReproducibilityTests(unittest.TestCase):
             candidate_build.index(playground_stage),
         )
 
+    def test_staged_playground_vendors_its_locked_casework_runtime(self) -> None:
+        playground_stage = (
+            ROOT / "tools" / "build" / "stage-wasm-docs-browser-playground.sh"
+        ).read_text(encoding="utf-8")
+        vendor_casework = 'node "$repo_root/prns-js/scripts/stage-code.mjs"'
+        stage_sdk_sources = (
+            'cp -R "$build_dir/prns-js/src/." "$public_dir/sdk/"'
+        )
+        stage_vendored_casework = (
+            'cp "$repo_root/prns-js/dist/casework.js" '
+            '"$public_dir/sdk/casework.js"'
+        )
+        smoke_staged_sdk = "sdk_entry_native="
+        self.assertIn(vendor_casework, playground_stage)
+        self.assertIn(stage_sdk_sources, playground_stage)
+        self.assertIn(stage_vendored_casework, playground_stage)
+        self.assertLess(
+            playground_stage.index(vendor_casework),
+            playground_stage.index(stage_vendored_casework),
+        )
+        self.assertLess(
+            playground_stage.index(stage_sdk_sources),
+            playground_stage.index(stage_vendored_casework),
+        )
+        self.assertLess(
+            playground_stage.index(stage_vendored_casework),
+            playground_stage.index(smoke_staged_sdk),
+        )
+
     def test_candidate_rustdoc_is_deterministically_ordered_and_normalized(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- build the locked casework dependency through the canonical prns-js vendoring path during playground staging
- replace the source-compiled bare import with that self-contained ESM module
- enforce build/copy/smoke ordering in the release reproducibility contract

## Verification
- exact clean browser playground stage, including final staged SDK import
- 24 focused reproducibility tests
- 283 full release/custody contract tests
- complete local pre-push CI-parity gate