### PR TITLE
Gate core tests and examples on the features they require

### DIFF
--- a/prns-core/Cargo.toml
+++ b/prns-core/Cargo.toml
@@ -25,6 +25,10 @@ include = [
 [lib]
 path = "src/lib.rs"
 
+[[example]]
+name = "subghz_turbo_evidence"
+required-features = ["std"]
+
 [features]
 default = ["std", "std-sync-host", "resource-work-offload"]
 # `zeroize/alloc` rides our own `alloc` gate so `Zeroize for Vec<u8>` is present by declaration rather than incidental dependency feature unification. The host identity vault's keyring backend zeroizes the secret bytes the OS store hands back.

--- a/prns-core/src/interfaces/subghz/regions/us915/turbo/tests.rs
+++ b/prns-core/src/interfaces/subghz/regions/us915/turbo/tests.rs
@@ -925,6 +925,7 @@ fn discontinuous_clock_update_reenters_quarantine() {
     );
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn deterministic_contention_simulation_executes_the_production_state_machines() {
     let result = simulate_contention(

--- a/prns-core/src/interfaces/subghz/regions/us915/turbo/tests.rs
+++ b/prns-core/src/interfaces/subghz/regions/us915/turbo/tests.rs
@@ -148,6 +148,7 @@ fn validated_acquired_schedule() -> ValidatedAcquiredSchedule {
     }
 }
 
+#[cfg(feature = "std")]
 fn acquisition_simulation(environment: AcquisitionEnvironment) -> AcquisitionSimulation {
     AcquisitionSimulation {
         seed: 0x5052_4e53_4143_5155,
@@ -945,6 +946,7 @@ fn deterministic_contention_simulation_executes_the_production_state_machines() 
     assert!(result.jain_fairness_millionths >= 800_000);
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn acquisition_simulation_graduates_only_through_the_production_tracker() {
     let input = acquisition_simulation(AcquisitionEnvironment::SingleSchedule);
@@ -955,6 +957,7 @@ fn acquisition_simulation_graduates_only_through_the_production_tracker() {
     assert_eq!(result.maximum_primary_phase_error_us, 0);
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn mixed_schedule_population_can_graduate_either_coherent_phase() {
     let input = acquisition_simulation(AcquisitionEnvironment::MixedSchedules {
@@ -967,6 +970,7 @@ fn mixed_schedule_population_can_graduate_either_coherent_phase() {
     assert!(result.maximum_primary_phase_error_us >= US915_TURBO_SPEC.cycle_us());
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn mixed_completion_timing_forces_contradiction_resets() {
     let input = acquisition_simulation(AcquisitionEnvironment::MixedCompletionTiming {
@@ -978,6 +982,7 @@ fn mixed_completion_timing_forces_contradiction_resets() {
     assert!(result.acquired_trials > 0);
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn acquisition_simulation_rejects_invalid_clock_and_environment_models_up_front() {
     let baseline = acquisition_simulation(AcquisitionEnvironment::SingleSchedule);

--- a/prns-core/src/routing/links/resources/receive/offload.rs
+++ b/prns-core/src/routing/links/resources/receive/offload.rs
@@ -365,6 +365,7 @@ mod tests {
         Settlement,
     };
     use crate::interfaces::{AttachedInterfaces, InboundPacket};
+    #[cfg(all(feature = "resource-work-offload", feature = "alloc"))]
     use crate::routing::links::resources::receive::conclude::ConcludeResourceOutcome;
     use crate::routing::links::resources::receive::tests_support::*;
     #[cfg(feature = "resource-work-offload")]
@@ -807,6 +808,7 @@ mod tests {
         ));
     }
 
+    #[cfg(all(feature = "resource-work-offload", feature = "alloc"))]
     #[test]
     fn a_completed_heap_transfer_moves_through_the_tail_worker() {
         let mut sender = active_engine::<crate::storage::GrowableHeap>();

--- a/prns-core/src/routing/links/resources/send.rs
+++ b/prns-core/src/routing/links/resources/send.rs
@@ -4142,6 +4142,7 @@ mod tests {
         live
     }
 
+    #[cfg(feature = "resource-work-offload")]
     fn serve_live_parts<S: StorageLayout>(
         engine: &mut EngineState<S>,
         live: &ResourceHash,
@@ -4237,6 +4238,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "resource-work-offload")]
     #[test]
     fn serving_the_last_live_part_seals_the_staged_continuation() {
         let mut engine = heap_sender_with_active_link();
@@ -4264,6 +4266,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "resource-work-offload")]
     #[test]
     fn the_live_proof_promotes_the_sealed_continuation_in_the_same_pass() {
         let mut engine = heap_sender_with_active_link();
@@ -4319,6 +4322,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "resource-work-offload")]
     #[test]
     fn a_request_or_proof_for_a_staged_hash_is_ignored() {
         let mut engine = heap_sender_with_active_link();


### PR DESCRIPTION
Some core tests and the Turbo example are selected in builds that do not enable the features they need, causing compilation failures.

Core changes needed by the Prns app must preserve support for builds without `std`. These failures blocked the alloc-only regression checks; correct feature guards make those checks usable again.

Require `std` for the Turbo contention and acquisition-simulation tests and the `subghz_turbo_evidence` example. Require the appropriate allocation/offload features for the affected resource tests. Production code and test assertions are unchanged.

## Tests

Passed:

- Alloc-only validation, including strict Clippy, unit tests, crypto tests, and doctests
- All four affected resource tests with offload enabled
- Turbo tests and evidence example with `std`
- All-target compilation checks for the affected feature combinations

## App integration

The earlier firmware-size issue is fixed in the app integration (#197). App commit `f3755a977` passes all 14 configured firmware profiles and the normal local publishing gate; T-Echo S140 v7 has 624 bytes of flash headroom, with limits and layouts unchanged. See the [September 10 validation](https://github.com/evelant/Prns/blob/f3755a9773cc7a305a8811ba679e0638f96ab52d/applications/checkpoints/2026-09-10-app-publication.md).

These results apply to the integrated app, not a fresh build or CI run of this PR. The branch-specific checks above remain separate.