### PR TITLE
Let iOS apps configure CoreBluetooth state restoration

### DIFF
--- a/personal-rns/src/interface_families/bluetooth_auto.rs
+++ b/personal-rns/src/interface_families/bluetooth_auto.rs
@@ -4,6 +4,11 @@ pub use prns_interfaces_tokio::bluetooth_auto::{
     BluetoothPeer, ConfiguredAutoBle, ConfiguredAutoBluetoothLe,
 };
 
+#[cfg(all(feature = "tokio-host", target_os = "ios"))]
+pub use prns_interfaces_tokio::bluetooth_auto::{
+    CoreBluetoothRestorationIdentifiers, CoreBluetoothRestorationIdentifiersError,
+};
+
 #[cfg(all(feature = "embassy-host", not(feature = "tokio-host")))]
 pub use prns_interfaces_embassy::bluetooth_auto::{
     connection_slots, BluetoothAuto, BluetoothAutoShared, BluetoothAutoStatus,

--- a/prns-ffi/src/bluetooth_auto/macos/backend.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/backend.rs
@@ -275,7 +275,7 @@ enum ManagerPreparation {
     RestorationAware(CoreBluetoothRestorationIdentifiers),
     #[cfg(not(target_os = "ios"))]
     PlatformDefault,
-    ForegroundOnly,
+    WithoutRestoration,
 }
 
 impl ManagerPreparation {
@@ -283,7 +283,7 @@ impl ManagerPreparation {
     fn restoration_identifiers(&self) -> Option<&CoreBluetoothRestorationIdentifiers> {
         match self {
             Self::RestorationAware(identifiers) => Some(identifiers),
-            Self::ForegroundOnly => None,
+            Self::WithoutRestoration => None,
         }
     }
 }
@@ -297,8 +297,8 @@ impl MacosBleBackend {
     /// Creates CoreBluetooth managers with the existing iOS restoration identifiers.
     ///
     /// Applications using this path are responsible for the matching background modes and
-    /// restoration lifecycle. Use [`Self::prepare_foreground`] when the owner intentionally has no
-    /// CoreBluetooth state-restoration contract.
+    /// restoration lifecycle. Use [`Self::prepare_without_restoration`] when the owner
+    /// intentionally has no CoreBluetooth state-restoration contract.
     pub async fn prepare(identity: BleIdentity) -> Result<PreparedMacosBleBackend, MacosBleError> {
         #[cfg(target_os = "ios")]
         let manager_preparation =
@@ -325,10 +325,10 @@ impl MacosBleBackend {
     ///
     /// Central and peripheral operation remain available while the application is running, but
     /// CoreBluetooth will not preserve or restore these managers after process termination.
-    pub async fn prepare_foreground(
+    pub async fn prepare_without_restoration(
         identity: BleIdentity,
     ) -> Result<PreparedMacosBleBackend, MacosBleError> {
-        Self::prepare_with(identity, ManagerPreparation::ForegroundOnly).await
+        Self::prepare_with(identity, ManagerPreparation::WithoutRestoration).await
     }
 
     async fn prepare_with(
@@ -739,9 +739,9 @@ mod native_thread_tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn foreground_preparation_is_distinct_from_the_platform_default() {
+    fn preparation_without_restoration_is_distinct_from_the_platform_default() {
         assert_ne!(
-            ManagerPreparation::ForegroundOnly,
+            ManagerPreparation::WithoutRestoration,
             ManagerPreparation::PlatformDefault
         );
     }

--- a/prns-ffi/src/bluetooth_auto/macos/backend.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/backend.rs
@@ -27,7 +27,10 @@ use super::central::{
 use super::gatt_link::{gatt_inbound_channel, ControlPlane, GattLink};
 use super::peripheral::PeripheralDelegate;
 #[cfg(target_os = "ios")]
-use super::{central_manager_options, peripheral_manager_options};
+use super::{
+    central_manager_options, legacy_restoration_identifiers, peripheral_manager_options,
+    CoreBluetoothRestorationIdentifiers,
+};
 use super::{
     start_scan, Event, MacosBleError, PeripheralTable, RestoredPeripherals, SendCentralDelegate,
     SendCentralManager, SendPeripheral, SendPeripheralDelegate,
@@ -266,15 +269,22 @@ pub struct PreparedMacosBleBackend {
     handles: Handles,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 enum ManagerPreparation {
-    RestorationAware,
+    #[cfg(target_os = "ios")]
+    RestorationAware(CoreBluetoothRestorationIdentifiers),
+    #[cfg(not(target_os = "ios"))]
+    PlatformDefault,
     ForegroundOnly,
 }
 
 impl ManagerPreparation {
-    const fn uses_state_restoration(self) -> bool {
-        matches!(self, Self::RestorationAware)
+    #[cfg(target_os = "ios")]
+    fn restoration_identifiers(&self) -> Option<&CoreBluetoothRestorationIdentifiers> {
+        match self {
+            Self::RestorationAware(identifiers) => Some(identifiers),
+            Self::ForegroundOnly => None,
+        }
     }
 }
 
@@ -290,7 +300,25 @@ impl MacosBleBackend {
     /// restoration lifecycle. Use [`Self::prepare_foreground`] when the owner intentionally has no
     /// CoreBluetooth state-restoration contract.
     pub async fn prepare(identity: BleIdentity) -> Result<PreparedMacosBleBackend, MacosBleError> {
-        Self::prepare_with(identity, ManagerPreparation::RestorationAware).await
+        #[cfg(target_os = "ios")]
+        let manager_preparation =
+            ManagerPreparation::RestorationAware(legacy_restoration_identifiers());
+        #[cfg(not(target_os = "ios"))]
+        let manager_preparation = ManagerPreparation::PlatformDefault;
+        Self::prepare_with(identity, manager_preparation).await
+    }
+
+    /// Creates CoreBluetooth managers with stable restoration identifiers supplied by the
+    /// application that owns their lifecycle.
+    ///
+    /// The containing application must declare both matching CoreBluetooth background modes and
+    /// recreate the managers with these exact identifiers during an iOS restoration launch.
+    #[cfg(target_os = "ios")]
+    pub async fn prepare_with_restoration(
+        identity: BleIdentity,
+        identifiers: CoreBluetoothRestorationIdentifiers,
+    ) -> Result<PreparedMacosBleBackend, MacosBleError> {
+        Self::prepare_with(identity, ManagerPreparation::RestorationAware(identifiers)).await
     }
 
     /// Creates CoreBluetooth managers without opting into iOS state restoration.
@@ -307,9 +335,10 @@ impl MacosBleBackend {
         identity: BleIdentity,
         manager_preparation: ManagerPreparation,
     ) -> Result<PreparedMacosBleBackend, MacosBleError> {
-        let uses_state_restoration = manager_preparation.uses_state_restoration();
+        #[cfg(target_os = "ios")]
+        let restoration_identifiers = manager_preparation.restoration_identifiers().cloned();
         #[cfg(not(target_os = "ios"))]
-        let _ = uses_state_restoration;
+        let _ = manager_preparation;
         let (events_tx, events_rx) = tokio_mpsc::unbounded_channel::<Event>();
         let (keepalive, shutdown_rx) = sync_mpsc::channel::<()>();
         let (handles_tx, handles_rx) = oneshot::channel::<Handles>();
@@ -334,7 +363,9 @@ impl MacosBleBackend {
                 );
                 let central_proto = ProtocolObject::from_ref(&*central_delegate);
                 #[cfg(target_os = "ios")]
-                let central_options = uses_state_restoration.then(central_manager_options);
+                let central_options = restoration_identifiers
+                    .as_ref()
+                    .map(|identifiers| central_manager_options(identifiers.central()));
                 #[cfg(not(target_os = "ios"))]
                 let central_options: Option<
                     Retained<NSDictionary<NSString, AnyObject>>,
@@ -354,7 +385,9 @@ impl MacosBleBackend {
                     PeripheralDelegate::new(events_tx, queue.clone(), identity);
                 let peripheral_proto = ProtocolObject::from_ref(&*peripheral_delegate);
                 #[cfg(target_os = "ios")]
-                let peripheral_options = uses_state_restoration.then(peripheral_manager_options);
+                let peripheral_options = restoration_identifiers
+                    .as_ref()
+                    .map(|identifiers| peripheral_manager_options(identifiers.peripheral()));
                 #[cfg(not(target_os = "ios"))]
                 let peripheral_options: Option<
                     Retained<NSDictionary<NSString, AnyObject>>,
@@ -705,9 +738,11 @@ mod native_thread_tests {
     use std::sync::atomic::{AtomicBool, Ordering};
 
     #[test]
-    fn foreground_preparation_does_not_request_state_restoration() {
-        assert!(!ManagerPreparation::ForegroundOnly.uses_state_restoration());
-        assert!(ManagerPreparation::RestorationAware.uses_state_restoration());
+    fn foreground_preparation_is_distinct_from_the_platform_default() {
+        assert_ne!(
+            ManagerPreparation::ForegroundOnly,
+            ManagerPreparation::PlatformDefault
+        );
     }
 
     #[test]

--- a/prns-ffi/src/bluetooth_auto/macos/backend.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/backend.rs
@@ -255,8 +255,8 @@ impl Drop for NativeThread {
     }
 }
 
-/// Restoration-aware CoreBluetooth managers whose delegates and serial queue already exist, while
-/// radio authorization, service publication, and L2CAP readiness remain asynchronous.
+/// Prepared CoreBluetooth managers whose delegates and serial queue already exist, while radio
+/// authorization, service publication, and L2CAP readiness remain asynchronous.
 pub struct PreparedMacosBleBackend {
     native_thread: NativeThread,
     events: tokio_mpsc::UnboundedReceiver<Event>,
@@ -266,13 +266,50 @@ pub struct PreparedMacosBleBackend {
     handles: Handles,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ManagerPreparation {
+    RestorationAware,
+    ForegroundOnly,
+}
+
+impl ManagerPreparation {
+    const fn uses_state_restoration(self) -> bool {
+        matches!(self, Self::RestorationAware)
+    }
+}
+
 impl MacosBleBackend {
     #[cfg(target_os = "ios")]
     pub const MAX_PEERS: usize = 7;
     #[cfg(target_os = "macos")]
     pub const MAX_PEERS: usize = 8;
 
+    /// Creates CoreBluetooth managers with the existing iOS restoration identifiers.
+    ///
+    /// Applications using this path are responsible for the matching background modes and
+    /// restoration lifecycle. Use [`Self::prepare_foreground`] when the owner intentionally has no
+    /// CoreBluetooth state-restoration contract.
     pub async fn prepare(identity: BleIdentity) -> Result<PreparedMacosBleBackend, MacosBleError> {
+        Self::prepare_with(identity, ManagerPreparation::RestorationAware).await
+    }
+
+    /// Creates CoreBluetooth managers without opting into iOS state restoration.
+    ///
+    /// Central and peripheral operation remain available while the application is running, but
+    /// CoreBluetooth will not preserve or restore these managers after process termination.
+    pub async fn prepare_foreground(
+        identity: BleIdentity,
+    ) -> Result<PreparedMacosBleBackend, MacosBleError> {
+        Self::prepare_with(identity, ManagerPreparation::ForegroundOnly).await
+    }
+
+    async fn prepare_with(
+        identity: BleIdentity,
+        manager_preparation: ManagerPreparation,
+    ) -> Result<PreparedMacosBleBackend, MacosBleError> {
+        let uses_state_restoration = manager_preparation.uses_state_restoration();
+        #[cfg(not(target_os = "ios"))]
+        let _ = uses_state_restoration;
         let (events_tx, events_rx) = tokio_mpsc::unbounded_channel::<Event>();
         let (keepalive, shutdown_rx) = sync_mpsc::channel::<()>();
         let (handles_tx, handles_rx) = oneshot::channel::<Handles>();
@@ -297,7 +334,7 @@ impl MacosBleBackend {
                 );
                 let central_proto = ProtocolObject::from_ref(&*central_delegate);
                 #[cfg(target_os = "ios")]
-                let central_options = Some(central_manager_options());
+                let central_options = uses_state_restoration.then(central_manager_options);
                 #[cfg(not(target_os = "ios"))]
                 let central_options: Option<
                     Retained<NSDictionary<NSString, AnyObject>>,
@@ -317,7 +354,7 @@ impl MacosBleBackend {
                     PeripheralDelegate::new(events_tx, queue.clone(), identity);
                 let peripheral_proto = ProtocolObject::from_ref(&*peripheral_delegate);
                 #[cfg(target_os = "ios")]
-                let peripheral_options = Some(peripheral_manager_options());
+                let peripheral_options = uses_state_restoration.then(peripheral_manager_options);
                 #[cfg(not(target_os = "ios"))]
                 let peripheral_options: Option<
                     Retained<NSDictionary<NSString, AnyObject>>,
@@ -666,6 +703,12 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
 mod native_thread_tests {
     use super::*;
     use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[test]
+    fn foreground_preparation_does_not_request_state_restoration() {
+        assert!(!ManagerPreparation::ForegroundOnly.uses_state_restoration());
+        assert!(ManagerPreparation::RestorationAware.uses_state_restoration());
+    }
 
     #[test]
     fn dropping_owner_stops_and_joins_native_thread() {

--- a/prns-ffi/src/bluetooth_auto/macos/backend.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/backend.rs
@@ -737,6 +737,7 @@ mod native_thread_tests {
     use super::*;
     use std::sync::atomic::{AtomicBool, Ordering};
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn foreground_preparation_is_distinct_from_the_platform_default() {
         assert_ne!(

--- a/prns-ffi/src/bluetooth_auto/macos/mod.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/mod.rs
@@ -13,6 +13,9 @@ mod tests;
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
+#[cfg(any(test, target_os = "ios"))]
+use std::fmt;
+
 use objc2::msg_send;
 use objc2::rc::Retained;
 use objc2::runtime::AnyObject;
@@ -49,10 +52,92 @@ impl CoreBluetoothPeerId {
     }
 }
 
-#[cfg(target_os = "ios")]
+#[cfg(any(test, target_os = "ios"))]
 const CENTRAL_RESTORE_IDENTIFIER: &str = "com.personal.prns.ble.central";
-#[cfg(target_os = "ios")]
+#[cfg(any(test, target_os = "ios"))]
 const PERIPHERAL_RESTORE_IDENTIFIER: &str = "com.personal.prns.ble.peripheral";
+
+/// Stable, application-owned identifiers for the two CoreBluetooth managers used by Bluetooth
+/// Auto.
+///
+/// Passing these identifiers opts the caller into CoreBluetooth state preservation and
+/// restoration. The containing application is responsible for declaring the matching central and
+/// peripheral background modes and reinstantiating the managers with the same identifiers when
+/// iOS relaunches it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg(any(test, target_os = "ios"))]
+pub struct CoreBluetoothRestorationIdentifiers {
+    central: String,
+    peripheral: String,
+}
+
+#[cfg(any(test, target_os = "ios"))]
+impl CoreBluetoothRestorationIdentifiers {
+    pub fn new(
+        central: impl Into<String>,
+        peripheral: impl Into<String>,
+    ) -> Result<Self, CoreBluetoothRestorationIdentifiersError> {
+        let central = central.into();
+        if central.is_empty() {
+            return Err(CoreBluetoothRestorationIdentifiersError::EmptyCentral);
+        }
+        let peripheral = peripheral.into();
+        if peripheral.is_empty() {
+            return Err(CoreBluetoothRestorationIdentifiersError::EmptyPeripheral);
+        }
+        if central == peripheral {
+            return Err(CoreBluetoothRestorationIdentifiersError::Duplicate);
+        }
+        Ok(Self {
+            central,
+            peripheral,
+        })
+    }
+
+    #[must_use]
+    pub fn central(&self) -> &str {
+        &self.central
+    }
+
+    #[must_use]
+    pub fn peripheral(&self) -> &str {
+        &self.peripheral
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg(any(test, target_os = "ios"))]
+pub enum CoreBluetoothRestorationIdentifiersError {
+    EmptyCentral,
+    EmptyPeripheral,
+    Duplicate,
+}
+
+#[cfg(any(test, target_os = "ios"))]
+impl fmt::Display for CoreBluetoothRestorationIdentifiersError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyCentral => formatter
+                .write_str("the CoreBluetooth central restoration identifier must not be empty"),
+            Self::EmptyPeripheral => formatter
+                .write_str("the CoreBluetooth peripheral restoration identifier must not be empty"),
+            Self::Duplicate => formatter.write_str(
+                "the CoreBluetooth central and peripheral restoration identifiers must differ",
+            ),
+        }
+    }
+}
+
+#[cfg(any(test, target_os = "ios"))]
+impl std::error::Error for CoreBluetoothRestorationIdentifiersError {}
+
+#[cfg(any(test, target_os = "ios"))]
+fn legacy_restoration_identifiers() -> CoreBluetoothRestorationIdentifiers {
+    CoreBluetoothRestorationIdentifiers {
+        central: CENTRAL_RESTORE_IDENTIFIER.to_owned(),
+        peripheral: PERIPHERAL_RESTORE_IDENTIFIER.to_owned(),
+    }
+}
 
 fn cbuuid(uuid: BleUuid) -> Retained<CBUUID> {
     match uuid {
@@ -121,22 +206,22 @@ fn scan_options() -> Retained<NSDictionary<NSString, AnyObject>> {
 }
 
 #[cfg(target_os = "ios")]
-fn central_manager_options() -> Retained<NSDictionary<NSString, AnyObject>> {
+fn central_manager_options(identifier: &str) -> Retained<NSDictionary<NSString, AnyObject>> {
     use objc2_core_bluetooth::CBCentralManagerOptionRestoreIdentifierKey;
     // SAFETY: CoreBluetooth exports this NSString constant with process lifetime.
     let key: &NSString = unsafe { CBCentralManagerOptionRestoreIdentifierKey };
-    let value = NSString::from_str(CENTRAL_RESTORE_IDENTIFIER);
+    let value = NSString::from_str(identifier);
     let value_ref: &NSString = &value;
     let value_obj: &AnyObject = value_ref;
     NSDictionary::from_slices(&[key], &[value_obj])
 }
 
 #[cfg(target_os = "ios")]
-fn peripheral_manager_options() -> Retained<NSDictionary<NSString, AnyObject>> {
+fn peripheral_manager_options(identifier: &str) -> Retained<NSDictionary<NSString, AnyObject>> {
     use objc2_core_bluetooth::CBPeripheralManagerOptionRestoreIdentifierKey;
     // SAFETY: CoreBluetooth exports this NSString constant with process lifetime.
     let key: &NSString = unsafe { CBPeripheralManagerOptionRestoreIdentifierKey };
-    let value = NSString::from_str(PERIPHERAL_RESTORE_IDENTIFIER);
+    let value = NSString::from_str(identifier);
     let value_ref: &NSString = &value;
     let value_obj: &AnyObject = value_ref;
     NSDictionary::from_slices(&[key], &[value_obj])

--- a/prns-ffi/src/bluetooth_auto/macos/tests.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/tests.rs
@@ -19,14 +19,45 @@ use super::gatt_link::{
     gatt_inbound_channel, gatt_inbound_channel_with_budget, GattInboundSendError,
 };
 use super::gatt_write::{write_admission, GattWriteAdmission, GattWriteMode, GattWritePlan};
+use super::legacy_restoration_identifiers;
 use super::peripheral::{advertising_op, has_session_for_peer, AdvertisingOp};
 use super::MacosBleError;
 use super::{CoreBluetoothPeerId, MacosBleBackend};
+use super::{CoreBluetoothRestorationIdentifiers, CoreBluetoothRestorationIdentifiersError};
 
 fn peer_id(value: u16) -> CoreBluetoothPeerId {
     let mut bytes = [0; 16];
     bytes[..2].copy_from_slice(&value.to_le_bytes());
     CoreBluetoothPeerId(bytes)
+}
+
+#[test]
+fn restoration_identifiers_are_nonempty_and_distinct(
+) -> Result<(), CoreBluetoothRestorationIdentifiersError> {
+    assert_eq!(
+        CoreBluetoothRestorationIdentifiers::new("", "peripheral"),
+        Err(CoreBluetoothRestorationIdentifiersError::EmptyCentral)
+    );
+    assert_eq!(
+        CoreBluetoothRestorationIdentifiers::new("central", ""),
+        Err(CoreBluetoothRestorationIdentifiersError::EmptyPeripheral)
+    );
+    assert_eq!(
+        CoreBluetoothRestorationIdentifiers::new("shared", "shared"),
+        Err(CoreBluetoothRestorationIdentifiersError::Duplicate)
+    );
+
+    let identifiers = CoreBluetoothRestorationIdentifiers::new("central", "peripheral")?;
+    assert_eq!(identifiers.central(), "central");
+    assert_eq!(identifiers.peripheral(), "peripheral");
+    Ok(())
+}
+
+#[test]
+fn legacy_preparation_keeps_personal_hopspot_identifiers() {
+    let identifiers = legacy_restoration_identifiers();
+    assert_eq!(identifiers.central(), "com.personal.prns.ble.central");
+    assert_eq!(identifiers.peripheral(), "com.personal.prns.ble.peripheral");
 }
 
 #[test]

--- a/prns-interfaces/impls/tokio/src/bluetooth_auto/host.rs
+++ b/prns-interfaces/impls/tokio/src/bluetooth_auto/host.rs
@@ -76,16 +76,16 @@ impl AutoBle {
         ))
     }
 
-    /// Creates foreground-only CoreBluetooth managers immediately while leaving radio
-    /// authorization and service readiness to the attached asynchronous supervisor.
+    /// Creates CoreBluetooth managers without state restoration while leaving radio authorization
+    /// and service readiness to the attached asynchronous supervisor.
     ///
     /// This path does not opt into CoreBluetooth state restoration. The selected preparation mode
     /// is retained for every later readiness retry.
     #[cfg(any(target_os = "macos", target_os = "ios"))]
-    pub async fn prepare_foreground(
+    pub async fn prepare_without_restoration(
         identity: BleIdentity,
     ) -> Result<PreparedAutoBle, prns_ffi::bluetooth_auto::macos::MacosBleError> {
-        let manager_preparation = AppleManagerPreparation::ForegroundOnly;
+        let manager_preparation = AppleManagerPreparation::WithoutRestoration;
         let backend = manager_preparation.prepare(identity).await?;
         Ok(PreparedAutoBle::new(
             identity,
@@ -120,12 +120,12 @@ impl AutoBle {
         )
     }
 
-    /// Produces a failed-but-supervised foreground-only Bluetooth LE attachment when native
-    /// manager preparation itself cannot be started. The core node and every other transport
-    /// remain available, and retries never opt into state restoration.
+    /// Produces a failed-but-supervised Bluetooth LE attachment without state restoration when
+    /// native manager preparation itself cannot be started. The core node and every other
+    /// transport remain available, and retries never opt into state restoration.
     #[cfg(any(target_os = "macos", target_os = "ios"))]
-    pub fn unavailable_foreground(identity: BleIdentity) -> PreparedAutoBle {
-        PreparedAutoBle::new(identity, AppleManagerPreparation::ForegroundOnly, None)
+    pub fn unavailable_without_restoration(identity: BleIdentity) -> PreparedAutoBle {
+        PreparedAutoBle::new(identity, AppleManagerPreparation::WithoutRestoration, None)
     }
 }
 
@@ -135,7 +135,7 @@ enum AppleManagerPreparation {
     LegacyRestorationAware,
     #[cfg(target_os = "ios")]
     RestorationAware(CoreBluetoothRestorationIdentifiers),
-    ForegroundOnly,
+    WithoutRestoration,
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -155,7 +155,9 @@ impl AppleManagerPreparation {
             Self::RestorationAware(identifiers) => {
                 MacosBleBackend::prepare_with_restoration(identity, identifiers.clone()).await
             }
-            Self::ForegroundOnly => MacosBleBackend::prepare_foreground(identity).await,
+            Self::WithoutRestoration => {
+                MacosBleBackend::prepare_without_restoration(identity).await
+            }
         }
     }
 }
@@ -682,12 +684,12 @@ mod tests {
     #[test]
     fn unavailable_preparation_retains_the_selected_retry_mode() {
         let identity = BleIdentity::new([0x30; 16]);
-        let foreground = AutoBle::unavailable_foreground(identity);
+        let without_restoration = AutoBle::unavailable_without_restoration(identity);
         assert_eq!(
-            foreground.manager_preparation,
-            AppleManagerPreparation::ForegroundOnly
+            without_restoration.manager_preparation,
+            AppleManagerPreparation::WithoutRestoration
         );
-        assert!(foreground.backend.is_none());
+        assert!(without_restoration.backend.is_none());
 
         let restoration_aware = AutoBle::unavailable(identity);
         assert_eq!(

--- a/prns-interfaces/impls/tokio/src/bluetooth_auto/host.rs
+++ b/prns-interfaces/impls/tokio/src/bluetooth_auto/host.rs
@@ -8,6 +8,11 @@ use prns_runtime::runtime::{Attachable, Fleet, InterfaceSupervisor, PrnsNodeHand
 
 use super::BluetoothAutoStatus;
 
+#[cfg(target_os = "ios")]
+pub use prns_ffi::bluetooth_auto::macos::{
+    CoreBluetoothRestorationIdentifiers, CoreBluetoothRestorationIdentifiersError,
+};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AutoBle {
     identity: BleIdentity,
@@ -44,7 +49,25 @@ impl AutoBle {
     pub async fn prepare(
         identity: BleIdentity,
     ) -> Result<PreparedAutoBle, prns_ffi::bluetooth_auto::macos::MacosBleError> {
-        let manager_preparation = AppleManagerPreparation::RestorationAware;
+        let manager_preparation = AppleManagerPreparation::LegacyRestorationAware;
+        let backend = manager_preparation.prepare(identity).await?;
+        Ok(PreparedAutoBle::new(
+            identity,
+            manager_preparation,
+            Some(backend),
+        ))
+    }
+
+    /// Creates restoration-aware CoreBluetooth managers using identifiers supplied by the
+    /// application that owns their lifecycle.
+    ///
+    /// The selected identifiers are retained for every later readiness retry.
+    #[cfg(target_os = "ios")]
+    pub async fn prepare_with_restoration(
+        identity: BleIdentity,
+        identifiers: CoreBluetoothRestorationIdentifiers,
+    ) -> Result<PreparedAutoBle, prns_ffi::bluetooth_auto::macos::MacosBleError> {
+        let manager_preparation = AppleManagerPreparation::RestorationAware(identifiers);
         let backend = manager_preparation.prepare(identity).await?;
         Ok(PreparedAutoBle::new(
             identity,
@@ -76,7 +99,25 @@ impl AutoBle {
     /// core node and every other transport remain available.
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     pub fn unavailable(identity: BleIdentity) -> PreparedAutoBle {
-        PreparedAutoBle::new(identity, AppleManagerPreparation::RestorationAware, None)
+        PreparedAutoBle::new(
+            identity,
+            AppleManagerPreparation::LegacyRestorationAware,
+            None,
+        )
+    }
+
+    /// Produces a failed-but-supervised restoration-aware Bluetooth LE attachment when native
+    /// manager preparation itself cannot be started. Retries reuse the caller's identifiers.
+    #[cfg(target_os = "ios")]
+    pub fn unavailable_with_restoration(
+        identity: BleIdentity,
+        identifiers: CoreBluetoothRestorationIdentifiers,
+    ) -> PreparedAutoBle {
+        PreparedAutoBle::new(
+            identity,
+            AppleManagerPreparation::RestorationAware(identifiers),
+            None,
+        )
     }
 
     /// Produces a failed-but-supervised foreground-only Bluetooth LE attachment when native
@@ -89,16 +130,18 @@ impl AutoBle {
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 enum AppleManagerPreparation {
-    RestorationAware,
+    LegacyRestorationAware,
+    #[cfg(target_os = "ios")]
+    RestorationAware(CoreBluetoothRestorationIdentifiers),
     ForegroundOnly,
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 impl AppleManagerPreparation {
     async fn prepare(
-        self,
+        &self,
         identity: BleIdentity,
     ) -> Result<
         prns_ffi::bluetooth_auto::macos::PreparedMacosBleBackend,
@@ -107,7 +150,11 @@ impl AppleManagerPreparation {
         use prns_ffi::bluetooth_auto::macos::MacosBleBackend;
 
         match self {
-            Self::RestorationAware => MacosBleBackend::prepare(identity).await,
+            Self::LegacyRestorationAware => MacosBleBackend::prepare(identity).await,
+            #[cfg(target_os = "ios")]
+            Self::RestorationAware(identifiers) => {
+                MacosBleBackend::prepare_with_restoration(identity, identifiers.clone()).await
+            }
             Self::ForegroundOnly => MacosBleBackend::prepare_foreground(identity).await,
         }
     }
@@ -645,7 +692,7 @@ mod tests {
         let restoration_aware = AutoBle::unavailable(identity);
         assert_eq!(
             restoration_aware.manager_preparation,
-            AppleManagerPreparation::RestorationAware
+            AppleManagerPreparation::LegacyRestorationAware
         );
         assert!(restoration_aware.backend.is_none());
     }

--- a/prns-interfaces/impls/tokio/src/bluetooth_auto/host.rs
+++ b/prns-interfaces/impls/tokio/src/bluetooth_auto/host.rs
@@ -44,30 +44,91 @@ impl AutoBle {
     pub async fn prepare(
         identity: BleIdentity,
     ) -> Result<PreparedAutoBle, prns_ffi::bluetooth_auto::macos::MacosBleError> {
-        let backend = prns_ffi::bluetooth_auto::macos::MacosBleBackend::prepare(identity).await?;
-        Ok(PreparedAutoBle {
+        let manager_preparation = AppleManagerPreparation::RestorationAware;
+        let backend = manager_preparation.prepare(identity).await?;
+        Ok(PreparedAutoBle::new(
             identity,
-            policy: prns_runtime::interfaces::bluetooth_auto::defaults_for_bitrate(
-                prns_runtime::interfaces::bluetooth_auto::BLE_BITRATE_GUESS_BPS,
-            )
-            .configured(ConfiguredInterfacePolicy::default()),
-            status: BluetoothAutoStatus::new(),
-            backend: Some(backend),
-        })
+            manager_preparation,
+            Some(backend),
+        ))
+    }
+
+    /// Creates foreground-only CoreBluetooth managers immediately while leaving radio
+    /// authorization and service readiness to the attached asynchronous supervisor.
+    ///
+    /// This path does not opt into CoreBluetooth state restoration. The selected preparation mode
+    /// is retained for every later readiness retry.
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    pub async fn prepare_foreground(
+        identity: BleIdentity,
+    ) -> Result<PreparedAutoBle, prns_ffi::bluetooth_auto::macos::MacosBleError> {
+        let manager_preparation = AppleManagerPreparation::ForegroundOnly;
+        let backend = manager_preparation.prepare(identity).await?;
+        Ok(PreparedAutoBle::new(
+            identity,
+            manager_preparation,
+            Some(backend),
+        ))
     }
 
     /// Produces a failed-but-supervised Bluetooth LE attachment when native manager preparation itself
-    /// cannot be started. The core node and every other transport remain available.
+    /// cannot be started. Retries retain the restoration-aware behavior of [`Self::prepare`]. The
+    /// core node and every other transport remain available.
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     pub fn unavailable(identity: BleIdentity) -> PreparedAutoBle {
-        PreparedAutoBle {
+        PreparedAutoBle::new(identity, AppleManagerPreparation::RestorationAware, None)
+    }
+
+    /// Produces a failed-but-supervised foreground-only Bluetooth LE attachment when native
+    /// manager preparation itself cannot be started. The core node and every other transport
+    /// remain available, and retries never opt into state restoration.
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    pub fn unavailable_foreground(identity: BleIdentity) -> PreparedAutoBle {
+        PreparedAutoBle::new(identity, AppleManagerPreparation::ForegroundOnly, None)
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AppleManagerPreparation {
+    RestorationAware,
+    ForegroundOnly,
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+impl AppleManagerPreparation {
+    async fn prepare(
+        self,
+        identity: BleIdentity,
+    ) -> Result<
+        prns_ffi::bluetooth_auto::macos::PreparedMacosBleBackend,
+        prns_ffi::bluetooth_auto::macos::MacosBleError,
+    > {
+        use prns_ffi::bluetooth_auto::macos::MacosBleBackend;
+
+        match self {
+            Self::RestorationAware => MacosBleBackend::prepare(identity).await,
+            Self::ForegroundOnly => MacosBleBackend::prepare_foreground(identity).await,
+        }
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+impl PreparedAutoBle {
+    fn new(
+        identity: BleIdentity,
+        manager_preparation: AppleManagerPreparation,
+        backend: Option<prns_ffi::bluetooth_auto::macos::PreparedMacosBleBackend>,
+    ) -> Self {
+        Self {
             identity,
             policy: prns_runtime::interfaces::bluetooth_auto::defaults_for_bitrate(
                 prns_runtime::interfaces::bluetooth_auto::BLE_BITRATE_GUESS_BPS,
             )
             .configured(ConfiguredInterfacePolicy::default()),
             status: BluetoothAutoStatus::new(),
-            backend: None,
+            manager_preparation,
+            backend,
         }
     }
 }
@@ -84,6 +145,7 @@ pub struct PreparedAutoBle {
     identity: BleIdentity,
     policy: EffectiveInterfacePolicy,
     status: BluetoothAutoStatus,
+    manager_preparation: AppleManagerPreparation,
     backend: Option<prns_ffi::bluetooth_auto::macos::PreparedMacosBleBackend>,
 }
 
@@ -167,6 +229,7 @@ impl Attachable for PreparedAutoBle {
             identity: self.identity,
             policy: self.policy,
             status: self.status,
+            manager_preparation: self.manager_preparation,
             backend: self.backend,
         });
         AttachedBle { status }
@@ -184,6 +247,7 @@ impl Attachable for PreparedAutoBle {
                 identity: self.identity,
                 policy: self.policy,
                 status: self.status,
+                manager_preparation: self.manager_preparation,
                 backend: self.backend,
             },
             ifac,
@@ -198,6 +262,7 @@ struct PreparedPlatformBluetooth {
     identity: BleIdentity,
     policy: EffectiveInterfacePolicy,
     status: BluetoothAutoStatus,
+    manager_preparation: AppleManagerPreparation,
     backend: Option<prns_ffi::bluetooth_auto::macos::PreparedMacosBleBackend>,
 }
 
@@ -232,6 +297,7 @@ impl InterfaceSupervisor for PreparedPlatformBluetooth {
             self.identity,
             self.status,
             self.policy,
+            self.manager_preparation,
             self.backend,
         )
         .await;
@@ -244,6 +310,7 @@ async fn run_prepared_platform_bluetooth(
     ble_identity: BleIdentity,
     status: BluetoothAutoStatus,
     policy: EffectiveInterfacePolicy,
+    manager_preparation: AppleManagerPreparation,
     backend: Option<prns_ffi::bluetooth_auto::macos::PreparedMacosBleBackend>,
 ) {
     use super::BluetoothAuto;
@@ -256,7 +323,7 @@ async fn run_prepared_platform_bluetooth(
     loop {
         let candidate = match prepared.take() {
             Some(backend) => backend,
-            None => match MacosBleBackend::prepare(ble_identity).await {
+            None => match manager_preparation.prepare(ble_identity).await {
                 Ok(backend) => backend,
                 Err(error) => {
                     status.mark_failed(Some("Bluetooth native manager unavailable"));
@@ -563,6 +630,25 @@ mod tests {
         ManuallyAttached, NoPersistence, PreConfiguredDestination, PrnsNode, PrnsNodeRecipe,
     };
     use prns_runtime::storage::GrowableHeap;
+
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[test]
+    fn unavailable_preparation_retains_the_selected_retry_mode() {
+        let identity = BleIdentity::new([0x30; 16]);
+        let foreground = AutoBle::unavailable_foreground(identity);
+        assert_eq!(
+            foreground.manager_preparation,
+            AppleManagerPreparation::ForegroundOnly
+        );
+        assert!(foreground.backend.is_none());
+
+        let restoration_aware = AutoBle::unavailable(identity);
+        assert_eq!(
+            restoration_aware.manager_preparation,
+            AppleManagerPreparation::RestorationAware
+        );
+        assert!(restoration_aware.backend.is_none());
+    }
 
     #[test]
     fn auto_ble_registers_before_platform_backend_initialization() {

--- a/prns-interfaces/impls/tokio/src/bluetooth_auto/mod.rs
+++ b/prns-interfaces/impls/tokio/src/bluetooth_auto/mod.rs
@@ -7,6 +7,8 @@ pub use host::{
     AttachedBle, AttachedBluetoothLe, AutoBle, AutoBluetoothLe, ConfiguredAutoBle,
     ConfiguredAutoBluetoothLe,
 };
+#[cfg(target_os = "ios")]
+pub use host::{CoreBluetoothRestorationIdentifiers, CoreBluetoothRestorationIdentifiersError};
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 pub use host::{PreparedAutoBle, PreparedAutoBluetoothLe};
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
Let callers choose their central and peripheral restoration identifiers, or create managers without state restoration. Preserve that choice through startup retries while keeping existing defaults for other callers.

The Prns app needs native startup and restoration relaunches to use the same app-owned identifiers, including before React starts. This is not a foreground-only policy: apps still configure their background modes and restoration handling.

Rebased on trunk `c4fd54dfd`. Validation on `626950982`: 53 FFI tests pass with and without logging (one hardware test ignored per run), strict FFI Clippy and iOS Rust compilation pass. The normal publishing gate passed, including the configured firmware resource matrix, Miri/target-ISA checks and selected SDK lanes. Physical background qualification remains separate. App integration: #197.
