### PR TITLE
Schedule pairing persistence without bypassing retry delays

### DIFF
--- a/prns-runtime/impls/embassy/src/manifold/driver/pooled_topology/tests.rs
+++ b/prns-runtime/impls/embassy/src/manifold/driver/pooled_topology/tests.rs
@@ -72,9 +72,10 @@ impl<S: StorageLayout> ManifoldPersistence<S> for AlwaysDuePersistence {
         _snapshot: &crate::runtime::RemoteControlAuthorizationSnapshot,
         _now: InstantMillis,
     ) -> crate::runtime::StoreRemoteControlAuthorizationSnapshotOutcome {
-        crate::runtime::StoreRemoteControlAuthorizationSnapshotOutcome::Failed(
-            crate::runtime::EmbeddedPersistenceFailure::Flash,
-        )
+        crate::runtime::StoreRemoteControlAuthorizationSnapshotOutcome::Failed {
+            failure: crate::runtime::EmbeddedPersistenceFailure::Flash,
+            retry_at: None,
+        }
     }
 }
 

--- a/prns-runtime/impls/embassy/src/runtime/embedded_persistence.rs
+++ b/prns-runtime/impls/embassy/src/runtime/embedded_persistence.rs
@@ -266,7 +266,11 @@ pub(crate) enum RemoteControlAuthorizationSnapshotKind {
 pub(crate) enum StoreRemoteControlAuthorizationSnapshotOutcome {
     Stored,
     CompactionInProgress,
-    Failed(EmbeddedPersistenceFailure),
+    Failed {
+        failure: EmbeddedPersistenceFailure,
+        // The store owns retry policy; None means it cannot schedule a retry.
+        retry_at: Option<InstantMillis>,
+    },
 }
 
 struct EncodedDelta {
@@ -779,9 +783,10 @@ where
         now: InstantMillis,
     ) -> StoreRemoteControlAuthorizationSnapshotOutcome {
         if self.retry_not_before.is_some_and(|retry| now.0 < retry.0) {
-            return StoreRemoteControlAuthorizationSnapshotOutcome::Failed(
-                EmbeddedPersistenceFailure::Flash,
-            );
+            return StoreRemoteControlAuthorizationSnapshotOutcome::Failed {
+                failure: EmbeddedPersistenceFailure::Flash,
+                retry_at: self.retry_not_before,
+            };
         }
         if self.compaction.is_some() {
             self.progress_compaction(engine, now).await;
@@ -796,9 +801,10 @@ where
             }
         };
         let Some(journal) = self.journal.as_mut() else {
-            return StoreRemoteControlAuthorizationSnapshotOutcome::Failed(
-                EmbeddedPersistenceFailure::Flash,
-            );
+            return StoreRemoteControlAuthorizationSnapshotOutcome::Failed {
+                failure: EmbeddedPersistenceFailure::Flash,
+                retry_at: None,
+            };
         };
         match journal.append(record_kind, snapshot).await {
             Ok(()) => {
@@ -816,23 +822,28 @@ where
                 self.require_snapshot(EmbeddedPersistenceTarget::CriticalState, now);
                 let allowed = self.next_compaction_not_before.unwrap_or(now);
                 if now.0 < allowed.0 {
-                    return StoreRemoteControlAuthorizationSnapshotOutcome::Failed(
-                        EmbeddedPersistenceFailure::Capacity,
-                    );
+                    return StoreRemoteControlAuthorizationSnapshotOutcome::Failed {
+                        failure: EmbeddedPersistenceFailure::Capacity,
+                        retry_at: Some(allowed),
+                    };
                 }
                 self.try_start_compaction(engine, now);
                 if self.compaction.is_some() {
                     StoreRemoteControlAuthorizationSnapshotOutcome::CompactionInProgress
                 } else {
-                    StoreRemoteControlAuthorizationSnapshotOutcome::Failed(
-                        EmbeddedPersistenceFailure::Capacity,
-                    )
+                    StoreRemoteControlAuthorizationSnapshotOutcome::Failed {
+                        failure: EmbeddedPersistenceFailure::Capacity,
+                        retry_at: self.retry_not_before,
+                    }
                 }
             }
             Err(error) => {
                 let failure = failure_from_journal(error);
                 self.note_write_failure(now, failure);
-                StoreRemoteControlAuthorizationSnapshotOutcome::Failed(failure)
+                StoreRemoteControlAuthorizationSnapshotOutcome::Failed {
+                    failure,
+                    retry_at: self.retry_not_before,
+                }
             }
         }
     }
@@ -1265,7 +1276,10 @@ impl<S: StorageLayout> ManifoldPersistence<S> for NoManifoldPersistence {
         _snapshot: &RemoteControlAuthorizationSnapshot,
         _now: InstantMillis,
     ) -> StoreRemoteControlAuthorizationSnapshotOutcome {
-        StoreRemoteControlAuthorizationSnapshotOutcome::Failed(EmbeddedPersistenceFailure::Flash)
+        StoreRemoteControlAuthorizationSnapshotOutcome::Failed {
+            failure: EmbeddedPersistenceFailure::Flash,
+            retry_at: None,
+        }
     }
 }
 
@@ -2496,6 +2510,177 @@ mod tests {
         assert_eq!(report.remote_control_target_accesses_restored_count, 1);
         assert_eq!(report.remote_control_target_accesses_refused_count, 1);
         assert_eq!(report.remote_control_target_accesses_dropped_count, 0);
+    }
+
+    #[test]
+    fn authorization_store_returns_the_flash_retry_policy_deadline() {
+        embassy_futures::block_on(async {
+            let (flash, fail_next_write) = TestFlash::controlled();
+            let mut policy =
+                EmbeddedPersistencePolicy::hopspot_default(EmbeddedCompactionPolicy::hopspot(0));
+            policy.retry_interval_millis = 1_234;
+            let mut persistence =
+                EmbeddedFlashPersistence::<_, FixedRouteSnapshotKeys<8>, _, 4>::new(
+                    flash,
+                    LAYOUT,
+                    policy,
+                    FixedRouteSnapshotKeys::new(),
+                    (|_| {}) as fn(EmbeddedPersistenceDiagnostic),
+                );
+            let mut engine = EngineState::<crate::storage::GrowableHeap>::default();
+            restore_without_remote_control(&mut persistence, &mut engine, InstantMillis(0)).await;
+            let snapshot = RemoteControlAuthorizationSnapshot::from_slice(&[0x80]).unwrap();
+            fail_next_write.set(true);
+            for now in [8, 9, 1_241] {
+                assert_eq!(
+                    persistence
+                        .store_remote_control_authorization_snapshot(
+                            &engine,
+                            RemoteControlAuthorizationSnapshotKind::TargetAccesses,
+                            &snapshot,
+                            InstantMillis(now),
+                        )
+                        .await,
+                    StoreRemoteControlAuthorizationSnapshotOutcome::Failed {
+                        failure: EmbeddedPersistenceFailure::Flash,
+                        retry_at: Some(InstantMillis(1_242)),
+                    },
+                );
+            }
+            assert_eq!(
+                persistence
+                    .store_remote_control_authorization_snapshot(
+                        &engine,
+                        RemoteControlAuthorizationSnapshotKind::TargetAccesses,
+                        &snapshot,
+                        InstantMillis(1_242),
+                    )
+                    .await,
+                StoreRemoteControlAuthorizationSnapshotOutcome::Stored,
+            );
+        });
+    }
+
+    #[test]
+    fn authorization_store_returns_the_compaction_cooldown_deadline() {
+        embassy_futures::block_on(async {
+            let mut persistence = ready();
+            let engine = EngineState::<crate::storage::GrowableHeap>::default();
+            let snapshot = RemoteControlAuthorizationSnapshot::from_slice(&[0; 512]).unwrap();
+            assert_eq!(
+                persistence
+                    .store_remote_control_authorization_snapshot(
+                        &engine,
+                        RemoteControlAuthorizationSnapshotKind::ControllerGrants,
+                        &snapshot,
+                        InstantMillis(8),
+                    )
+                    .await,
+                StoreRemoteControlAuthorizationSnapshotOutcome::Stored,
+            );
+            assert_eq!(
+                persistence
+                    .store_remote_control_authorization_snapshot(
+                        &engine,
+                        RemoteControlAuthorizationSnapshotKind::ControllerGrants,
+                        &snapshot,
+                        InstantMillis(9),
+                    )
+                    .await,
+                StoreRemoteControlAuthorizationSnapshotOutcome::Failed {
+                    failure: EmbeddedPersistenceFailure::Capacity,
+                    retry_at: Some(InstantMillis(HOPSPOT_MINIMUM_COMPACTION_INTERVAL_MILLIS)),
+                },
+            );
+            assert_eq!(
+                persistence
+                    .store_remote_control_authorization_snapshot(
+                        &engine,
+                        RemoteControlAuthorizationSnapshotKind::ControllerGrants,
+                        &snapshot,
+                        InstantMillis(HOPSPOT_MINIMUM_COMPACTION_INTERVAL_MILLIS),
+                    )
+                    .await,
+                StoreRemoteControlAuthorizationSnapshotOutcome::CompactionInProgress,
+            );
+            assert!(persistence.compaction.is_some());
+        });
+    }
+
+    #[test]
+    fn authorization_store_exposes_retry_after_a_failed_compaction_step() {
+        embassy_futures::block_on(async {
+            let (flash, fail_next_write) = TestFlash::controlled();
+            let mut persistence =
+                EmbeddedFlashPersistence::<_, FixedRouteSnapshotKeys<8>, _, 4>::new(
+                    flash,
+                    LAYOUT,
+                    EmbeddedPersistencePolicy::hopspot_default(EmbeddedCompactionPolicy::hopspot(
+                        0,
+                    )),
+                    FixedRouteSnapshotKeys::new(),
+                    (|_| {}) as fn(EmbeddedPersistenceDiagnostic),
+                );
+            let mut engine = EngineState::<crate::storage::GrowableHeap>::default();
+            restore_without_remote_control(&mut persistence, &mut engine, InstantMillis(0)).await;
+            persistence
+                .require_snapshot(EmbeddedPersistenceTarget::CriticalState, InstantMillis(8));
+            persistence.try_start_compaction(&engine, InstantMillis(8));
+            assert!(persistence.compaction.is_some());
+            fail_next_write.set(true);
+            let snapshot = RemoteControlAuthorizationSnapshot::new();
+            assert_eq!(
+                persistence
+                    .store_remote_control_authorization_snapshot(
+                        &engine,
+                        RemoteControlAuthorizationSnapshotKind::ControllerGrants,
+                        &snapshot,
+                        InstantMillis(8),
+                    )
+                    .await,
+                StoreRemoteControlAuthorizationSnapshotOutcome::CompactionInProgress,
+            );
+            assert!(persistence.compaction.is_none());
+            // progress_compaction records failure internally. One more store call
+            // exposes its retry deadline; the wrapper must then stop calling early.
+            assert_eq!(
+                persistence
+                    .store_remote_control_authorization_snapshot(
+                        &engine,
+                        RemoteControlAuthorizationSnapshotKind::ControllerGrants,
+                        &snapshot,
+                        InstantMillis(9),
+                    )
+                    .await,
+                StoreRemoteControlAuthorizationSnapshotOutcome::Failed {
+                    failure: EmbeddedPersistenceFailure::Flash,
+                    retry_at: Some(InstantMillis(8 + persistence.policy.retry_interval_millis)),
+                },
+            );
+        });
+    }
+
+    #[test]
+    fn unavailable_authorization_store_has_no_retry_schedule() {
+        embassy_futures::block_on(async {
+            let mut persistence = ready();
+            persistence.journal = None;
+            let engine = EngineState::<crate::storage::GrowableHeap>::default();
+            assert_eq!(
+                persistence
+                    .store_remote_control_authorization_snapshot(
+                        &engine,
+                        RemoteControlAuthorizationSnapshotKind::TargetAccesses,
+                        &RemoteControlAuthorizationSnapshot::new(),
+                        InstantMillis(8),
+                    )
+                    .await,
+                StoreRemoteControlAuthorizationSnapshotOutcome::Failed {
+                    failure: EmbeddedPersistenceFailure::Flash,
+                    retry_at: None,
+                },
+            );
+        });
     }
 
     #[test]

--- a/prns-runtime/impls/embassy/src/runtime/remote_control_pairing_persistence.rs
+++ b/prns-runtime/impls/embassy/src/runtime/remote_control_pairing_persistence.rs
@@ -408,7 +408,9 @@ where
             self.pending_request = self.stores.try_take_request();
         }
         if self.pending_failure.is_some() || self.pending_request.is_some() {
-            self.persistence.deadline(now).or(Some(now))
+            // Pairing finalization is waiting on this work, so it must preempt any future
+            // deadline advertised by the underlying persistence implementation.
+            Some(now)
         } else {
             self.persistence.deadline(now)
         }
@@ -1057,6 +1059,7 @@ mod tests {
     use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 
     struct ScriptedPersistence {
+        deadline: Option<InstantMillis>,
         fail_first_store: bool,
         store_attempts: u8,
         observed_failure: Option<EmbeddedRemoteControlPairingPersistenceFailure>,
@@ -1066,7 +1069,7 @@ mod tests {
         fn observe(&mut self, _journaled: &Journaled<'_>, _now: InstantMillis) {}
 
         fn deadline(&mut self, _now: InstantMillis) -> Option<InstantMillis> {
-            None
+            self.deadline
         }
 
         fn observe_remote_control_pairing_failure(
@@ -1098,10 +1101,11 @@ mod tests {
     }
 
     #[test]
-    fn initial_store_wakes_the_manifold_and_returns_the_exact_failure() {
+    fn pending_initial_store_preempts_a_future_deadline_and_returns_the_exact_failure() {
         embassy_futures::block_on(async {
             let stores = RemoteControlAuthorizationStoreExchange::<CriticalSectionRawMutex>::new();
             let mut persistence = ScriptedPersistence {
+                deadline: Some(InstantMillis(60_000)),
                 fail_first_store: true,
                 store_attempts: 0,
                 observed_failure: None,
@@ -1132,6 +1136,7 @@ mod tests {
         embassy_futures::block_on(async {
             let stores = RemoteControlAuthorizationStoreExchange::<CriticalSectionRawMutex>::new();
             let mut persistence = ScriptedPersistence {
+                deadline: Some(InstantMillis(60_000)),
                 fail_first_store: true,
                 store_attempts: 0,
                 observed_failure: None,
@@ -1160,10 +1165,11 @@ mod tests {
     }
 
     #[test]
-    fn pairing_failure_wakes_the_manifold_and_preserves_its_exact_cause() {
+    fn pending_pairing_failure_preempts_a_future_deadline_and_preserves_its_exact_cause() {
         embassy_futures::block_on(async {
             let stores = RemoteControlAuthorizationStoreExchange::<CriticalSectionRawMutex>::new();
             let mut persistence = ScriptedPersistence {
+                deadline: Some(InstantMillis(60_000)),
                 fail_first_store: false,
                 store_attempts: 0,
                 observed_failure: None,

--- a/prns-runtime/impls/embassy/src/runtime/remote_control_pairing_persistence.rs
+++ b/prns-runtime/impls/embassy/src/runtime/remote_control_pairing_persistence.rs
@@ -287,6 +287,11 @@ struct RemoteControlAuthorizationStoreRequest {
     requirement: RemoteControlAuthorizationStoreRequirement,
 }
 
+struct PendingRemoteControlAuthorizationStore {
+    request: RemoteControlAuthorizationStoreRequest,
+    ready_at: Option<crate::engine::InstantMillis>,
+}
+
 pub(super) struct RemoteControlAuthorizationStoreExchange<M: RawMutex> {
     requests: Signal<M, RemoteControlAuthorizationStoreRequest>,
     failures: Channel<M, EmbeddedRemoteControlPairingPersistenceFailure, 1>,
@@ -358,7 +363,7 @@ where
 {
     persistence: &'a mut P,
     stores: &'a RemoteControlAuthorizationStoreExchange<M>,
-    pending_request: Option<RemoteControlAuthorizationStoreRequest>,
+    pending_request: Option<PendingRemoteControlAuthorizationStore>,
     pending_failure: Option<EmbeddedRemoteControlPairingPersistenceFailure>,
 }
 
@@ -405,14 +410,26 @@ where
             self.pending_failure = self.stores.try_take_failure();
         }
         if self.pending_request.is_none() {
-            self.pending_request = self.stores.try_take_request();
+            self.pending_request = self.stores.try_take_request().map(|request| {
+                PendingRemoteControlAuthorizationStore {
+                    request,
+                    ready_at: Some(now),
+                }
+            });
         }
-        if self.pending_failure.is_some() || self.pending_request.is_some() {
-            // Pairing finalization is waiting on this work, so it must preempt any future
-            // deadline advertised by the underlying persistence implementation.
-            Some(now)
-        } else {
-            self.persistence.deadline(now)
+        if self.pending_failure.is_some() {
+            return Some(now);
+        }
+        // New work and compaction steps are immediate, but a retained failed rollback
+        // must respect the store's retry schedule. Unrelated persistence can still run.
+        let store_ready = self
+            .pending_request
+            .as_ref()
+            .and_then(|pending| pending.ready_at);
+        match (store_ready, self.persistence.deadline(now)) {
+            (Some(store), Some(other)) => Some(crate::engine::InstantMillis(store.0.min(other.0))),
+            (Some(ready), None) | (None, Some(ready)) => Some(ready),
+            (None, None) => None,
         }
     }
 
@@ -440,10 +457,15 @@ where
                 .observe_remote_control_pairing_failure(failure);
             return;
         }
-        let Some(request) = self.pending_request.as_ref() else {
+        let Some(pending) = self
+            .pending_request
+            .as_mut()
+            .filter(|pending| pending.ready_at.is_some_and(|ready| now.0 >= ready.0))
+        else {
             self.persistence.progress(engine, now).await;
             return;
         };
+        let request = &pending.request;
         match self
             .persistence
             .store_remote_control_authorization_snapshot(
@@ -458,14 +480,18 @@ where
                 self.pending_request = None;
                 self.stores.settle(Ok(()));
             }
-            StoreRemoteControlAuthorizationSnapshotOutcome::CompactionInProgress => {}
-            StoreRemoteControlAuthorizationSnapshotOutcome::Failed(failure) => {
+            StoreRemoteControlAuthorizationSnapshotOutcome::CompactionInProgress => {
+                pending.ready_at = Some(now);
+            }
+            StoreRemoteControlAuthorizationSnapshotOutcome::Failed { failure, retry_at } => {
                 match request.requirement {
                     RemoteControlAuthorizationStoreRequirement::Initial => {
                         self.pending_request = None;
                         self.stores.settle(Err(failure));
                     }
-                    RemoteControlAuthorizationStoreRequirement::Rollback => {}
+                    RemoteControlAuthorizationStoreRequirement::Rollback => {
+                        pending.ready_at = retry_at;
+                    }
                 }
             }
         }
@@ -1060,8 +1086,11 @@ mod tests {
 
     struct ScriptedPersistence {
         deadline: Option<InstantMillis>,
-        fail_first_store: bool,
+        fail_store_attempt: Option<u8>,
+        retry_at: Option<InstantMillis>,
+        compaction_steps: u8,
         store_attempts: u8,
+        progress_calls: u8,
         observed_failure: Option<EmbeddedRemoteControlPairingPersistenceFailure>,
     }
 
@@ -1080,6 +1109,8 @@ mod tests {
         }
 
         async fn progress(&mut self, _engine: &mut EngineState<GrowableHeap>, _now: InstantMillis) {
+            self.progress_calls += 1;
+            self.deadline = None;
         }
 
         async fn store_remote_control_authorization_snapshot(
@@ -1087,13 +1118,21 @@ mod tests {
             _engine: &EngineState<GrowableHeap>,
             _kind: RemoteControlAuthorizationSnapshotKind,
             _snapshot: &RemoteControlAuthorizationSnapshot,
-            _now: InstantMillis,
+            now: InstantMillis,
         ) -> StoreRemoteControlAuthorizationSnapshotOutcome {
             self.store_attempts = self.store_attempts.saturating_add(1);
-            if self.fail_first_store && self.store_attempts == 1 {
-                StoreRemoteControlAuthorizationSnapshotOutcome::Failed(
-                    EmbeddedPersistenceFailure::Flash,
-                )
+            if self.fail_store_attempt.is_some_and(|attempt| {
+                self.store_attempts == attempt
+                    || (self.store_attempts > attempt
+                        && self.retry_at.is_some_and(|retry| now.0 < retry.0))
+            }) {
+                StoreRemoteControlAuthorizationSnapshotOutcome::Failed {
+                    failure: EmbeddedPersistenceFailure::Flash,
+                    retry_at: self.retry_at,
+                }
+            } else if self.compaction_steps > 0 {
+                self.compaction_steps -= 1;
+                StoreRemoteControlAuthorizationSnapshotOutcome::CompactionInProgress
             } else {
                 StoreRemoteControlAuthorizationSnapshotOutcome::Stored
             }
@@ -1106,8 +1145,11 @@ mod tests {
             let stores = RemoteControlAuthorizationStoreExchange::<CriticalSectionRawMutex>::new();
             let mut persistence = ScriptedPersistence {
                 deadline: Some(InstantMillis(60_000)),
-                fail_first_store: true,
+                fail_store_attempt: Some(1),
+                retry_at: Some(InstantMillis(60_000)),
+                compaction_steps: 0,
                 store_attempts: 0,
+                progress_calls: 0,
                 observed_failure: None,
             };
             let mut manifold =
@@ -1137,8 +1179,11 @@ mod tests {
             let stores = RemoteControlAuthorizationStoreExchange::<CriticalSectionRawMutex>::new();
             let mut persistence = ScriptedPersistence {
                 deadline: Some(InstantMillis(60_000)),
-                fail_first_store: true,
+                fail_store_attempt: Some(1),
+                retry_at: Some(InstantMillis(9)),
+                compaction_steps: 0,
                 store_attempts: 0,
+                progress_calls: 0,
                 observed_failure: None,
             };
             let mut manifold =
@@ -1170,8 +1215,11 @@ mod tests {
             let stores = RemoteControlAuthorizationStoreExchange::<CriticalSectionRawMutex>::new();
             let mut persistence = ScriptedPersistence {
                 deadline: Some(InstantMillis(60_000)),
-                fail_first_store: false,
+                fail_store_attempt: None,
+                retry_at: None,
+                compaction_steps: 0,
                 store_attempts: 0,
+                progress_calls: 0,
                 observed_failure: None,
             };
             let mut manifold =
@@ -1194,6 +1242,223 @@ mod tests {
             let ((), ()) = join(report, drive).await;
             drop(manifold);
             assert_eq!(persistence.observed_failure, Some(failure));
+        });
+    }
+
+    #[test]
+    fn failed_rollback_honors_store_backoff_without_delaying_failure_reports() {
+        embassy_futures::block_on(async {
+            let stores = RemoteControlAuthorizationStoreExchange::<CriticalSectionRawMutex>::new();
+            let mut persistence = ScriptedPersistence {
+                // An unrelated batching deadline must not postpone the store's retry.
+                deadline: Some(InstantMillis(80_000)),
+                fail_store_attempt: Some(1),
+                retry_at: Some(InstantMillis(60_000)),
+                compaction_steps: 0,
+                store_attempts: 0,
+                progress_calls: 0,
+                observed_failure: None,
+            };
+            let mut manifold =
+                RemoteControlPairingManifoldPersistence::new(&mut persistence, &stores);
+            let mut engine = EngineState::<GrowableHeap>::default();
+            stores.submit(
+                RemoteControlAuthorizationSnapshotKind::TargetAccesses,
+                RemoteControlAuthorizationSnapshot::new(),
+                RemoteControlAuthorizationStoreRequirement::Rollback,
+            );
+            assert_eq!(manifold.deadline(InstantMillis(8)), Some(InstantMillis(8)));
+            manifold.progress(&mut engine, InstantMillis(8)).await;
+            // Bound the former driver hot loop and count calls, not just deadlines.
+            for _ in 0..32 {
+                if manifold
+                    .deadline(InstantMillis(9))
+                    .is_some_and(|due| due.0 <= 9)
+                {
+                    manifold.progress(&mut engine, InstantMillis(9)).await;
+                }
+            }
+            assert_eq!(manifold.persistence.store_attempts, 1);
+            assert_eq!(
+                manifold.deadline(InstantMillis(9)),
+                Some(InstantMillis(60_000))
+            );
+            assert_eq!(stores.completed.try_take(), None);
+
+            let failure = EmbeddedRemoteControlPairingPersistenceFailure::SettlementBusy {
+                attempt_id: super::super::node_facade::test_remote_control_pairing_attempt(0x92),
+                operation: EmbeddedRemoteControlPairingPersistenceOperation::SettleFailed,
+            };
+            stores.report_failure(failure).await;
+            assert_eq!(
+                manifold.deadline(InstantMillis(10)),
+                Some(InstantMillis(10))
+            );
+            manifold.progress(&mut engine, InstantMillis(10)).await;
+            assert_eq!(manifold.persistence.observed_failure, Some(failure));
+            assert_eq!(manifold.persistence.store_attempts, 1);
+            assert_eq!(
+                manifold.deadline(InstantMillis(59_999)),
+                Some(InstantMillis(60_000))
+            );
+
+            manifold.progress(&mut engine, InstantMillis(60_000)).await;
+            assert_eq!(manifold.persistence.store_attempts, 2);
+            assert_eq!(stores.completed.try_take(), Some(Ok(())));
+            assert!(manifold.pending_request.is_none());
+        });
+    }
+
+    #[test]
+    fn unrelated_persistence_can_progress_without_retrying_rollback_early() {
+        embassy_futures::block_on(async {
+            let stores = RemoteControlAuthorizationStoreExchange::<CriticalSectionRawMutex>::new();
+            let mut persistence = ScriptedPersistence {
+                deadline: Some(InstantMillis(12)),
+                fail_store_attempt: Some(1),
+                retry_at: Some(InstantMillis(60_000)),
+                compaction_steps: 0,
+                store_attempts: 0,
+                progress_calls: 0,
+                observed_failure: None,
+            };
+            let mut manifold =
+                RemoteControlPairingManifoldPersistence::new(&mut persistence, &stores);
+            let mut engine = EngineState::<GrowableHeap>::default();
+            stores.submit(
+                RemoteControlAuthorizationSnapshotKind::ControllerGrants,
+                RemoteControlAuthorizationSnapshot::new(),
+                RemoteControlAuthorizationStoreRequirement::Rollback,
+            );
+            assert_eq!(manifold.deadline(InstantMillis(8)), Some(InstantMillis(8)));
+            manifold.progress(&mut engine, InstantMillis(8)).await;
+            assert_eq!(manifold.deadline(InstantMillis(9)), Some(InstantMillis(12)));
+            manifold.progress(&mut engine, InstantMillis(12)).await;
+            assert_eq!(manifold.persistence.progress_calls, 1);
+            assert_eq!(manifold.persistence.store_attempts, 1);
+            assert_eq!(
+                manifold.deadline(InstantMillis(12)),
+                Some(InstantMillis(60_000))
+            );
+            assert_eq!(stores.completed.try_take(), None);
+            manifold.progress(&mut engine, InstantMillis(60_000)).await;
+            assert_eq!(stores.completed.try_take(), Some(Ok(())));
+        });
+    }
+
+    #[test]
+    fn unavailable_rollback_store_does_not_invent_a_retry_or_report_success() {
+        embassy_futures::block_on(async {
+            let stores = RemoteControlAuthorizationStoreExchange::<CriticalSectionRawMutex>::new();
+            let mut persistence = ScriptedPersistence {
+                deadline: None,
+                fail_store_attempt: Some(1),
+                retry_at: None,
+                compaction_steps: 0,
+                store_attempts: 0,
+                progress_calls: 0,
+                observed_failure: None,
+            };
+            let mut manifold =
+                RemoteControlPairingManifoldPersistence::new(&mut persistence, &stores);
+            let mut engine = EngineState::<GrowableHeap>::default();
+            stores.submit(
+                RemoteControlAuthorizationSnapshotKind::TargetAccesses,
+                RemoteControlAuthorizationSnapshot::new(),
+                RemoteControlAuthorizationStoreRequirement::Rollback,
+            );
+            assert_eq!(manifold.deadline(InstantMillis(8)), Some(InstantMillis(8)));
+            manifold.progress(&mut engine, InstantMillis(8)).await;
+            assert_eq!(manifold.deadline(InstantMillis(9)), None);
+            // Even a wake for unrelated work must not retry an unavailable store.
+            manifold.progress(&mut engine, InstantMillis(60_000)).await;
+            assert_eq!(manifold.persistence.store_attempts, 1);
+            assert_eq!(stores.completed.try_take(), None);
+            assert!(manifold.pending_request.is_some());
+        });
+    }
+
+    #[test]
+    fn compaction_steps_remain_immediately_runnable_until_the_store_completes() {
+        embassy_futures::block_on(async {
+            let stores = RemoteControlAuthorizationStoreExchange::<CriticalSectionRawMutex>::new();
+            let mut persistence = ScriptedPersistence {
+                deadline: Some(InstantMillis(60_000)),
+                fail_store_attempt: None,
+                retry_at: None,
+                compaction_steps: 2,
+                store_attempts: 0,
+                progress_calls: 0,
+                observed_failure: None,
+            };
+            let mut manifold =
+                RemoteControlPairingManifoldPersistence::new(&mut persistence, &stores);
+            let mut engine = EngineState::<GrowableHeap>::default();
+            stores.submit(
+                RemoteControlAuthorizationSnapshotKind::ControllerGrants,
+                RemoteControlAuthorizationSnapshot::new(),
+                RemoteControlAuthorizationStoreRequirement::Initial,
+            );
+            for now in 8..10 {
+                assert!(manifold
+                    .deadline(InstantMillis(now))
+                    .is_some_and(|due| due.0 <= now));
+                manifold.progress(&mut engine, InstantMillis(now)).await;
+                assert_eq!(stores.completed.try_take(), None);
+            }
+            assert!(manifold
+                .deadline(InstantMillis(10))
+                .is_some_and(|due| due.0 <= 10));
+            manifold.progress(&mut engine, InstantMillis(10)).await;
+            assert_eq!(manifold.persistence.store_attempts, 3);
+            assert_eq!(stores.completed.try_take(), Some(Ok(())));
+        });
+    }
+
+    #[test]
+    fn failed_compaction_enters_rollback_cooldown_on_the_next_store_outcome() {
+        embassy_futures::block_on(async {
+            let stores = RemoteControlAuthorizationStoreExchange::<CriticalSectionRawMutex>::new();
+            let mut persistence = ScriptedPersistence {
+                deadline: Some(InstantMillis(80_000)),
+                fail_store_attempt: Some(2),
+                retry_at: Some(InstantMillis(60_000)),
+                compaction_steps: 1,
+                store_attempts: 0,
+                progress_calls: 0,
+                observed_failure: None,
+            };
+            let mut manifold =
+                RemoteControlPairingManifoldPersistence::new(&mut persistence, &stores);
+            let mut engine = EngineState::<GrowableHeap>::default();
+            stores.submit(
+                RemoteControlAuthorizationSnapshotKind::ControllerGrants,
+                RemoteControlAuthorizationSnapshot::new(),
+                RemoteControlAuthorizationStoreRequirement::Rollback,
+            );
+            assert_eq!(manifold.deadline(InstantMillis(8)), Some(InstantMillis(8)));
+            manifold.progress(&mut engine, InstantMillis(8)).await;
+            assert!(manifold
+                .deadline(InstantMillis(9))
+                .is_some_and(|due| due.0 <= 9));
+            manifold.progress(&mut engine, InstantMillis(9)).await;
+            for _ in 0..32 {
+                if manifold
+                    .deadline(InstantMillis(10))
+                    .is_some_and(|due| due.0 <= 10)
+                {
+                    manifold.progress(&mut engine, InstantMillis(10)).await;
+                }
+            }
+            assert_eq!(manifold.persistence.store_attempts, 2);
+            assert_eq!(
+                manifold.deadline(InstantMillis(10)),
+                Some(InstantMillis(60_000))
+            );
+            assert_eq!(stores.completed.try_take(), None);
+            manifold.progress(&mut engine, InstantMillis(60_000)).await;
+            assert_eq!(manifold.persistence.store_attempts, 3);
+            assert_eq!(stores.completed.try_take(), Some(Ok(())));
         });
     }
 }


### PR DESCRIPTION
Wake new pairing writes and failure reports promptly, while respecting the flash store's retry deadline for retained rollback work. Allow unrelated persistence to progress during that backoff.

This addresses the board-side “Saving grant...” stall seen during Prns app pairing. The phone needs a timely result, and a failed flash write must not turn into a busy retry loop. Upstream's authorization transaction, durable rollback ordering, and wire format are preserved.

Keep failure reports in their existing bounded queue until they are observed, avoiding a redundant resident payload. This also recovers the small T096 RAM overrun exposed when rebasing the pairing stack; memory limits and stack reservations are unchanged.

Rebased onto trunk `c4fd54dfd`. All 131 Embassy tests pass with all features, plus two doctests. Coverage includes initial-save rollback, retry deadlines (including an unavailable retry), compaction, unrelated persistence, failure ordering, and pending sender wake-up. The normal local publishing gate passes on this branch, including all 14 configured firmware profiles. Physical-device qualification is separate.

[Review this change](https://github.com/evelant/Prns/compare/c4fd54dfd7a83048fc2cf5096a09fec6fa17a0ec...prns-app-pairing-persistence-wake).
