### PR TITLE
Update browser smoke tests for the current runtime API

### DIFF
--- a/prns-wasm/examples/browser-playground/outcomes.ts
+++ b/prns-wasm/examples/browser-playground/outcomes.ts
@@ -151,6 +151,7 @@ export function describeInterfaceCloseFailure(
     HostOperationFailed: ({ operation, detail }) => `${operation}: ${detail}`,
     CloseFailed: ({ causes }) =>
       causes.map(describeCleanupFailure).join("; "),
+    RuntimeRejected: ({ operation, detail }) => `${operation}: ${detail}`,
   });
 }
 

--- a/prns-wasm/scripts/stage-event-smoke.mjs
+++ b/prns-wasm/scripts/stage-event-smoke.mjs
@@ -1,11 +1,19 @@
 import { copyFile, mkdir } from "node:fs/promises";
 
+const generatedCasework = new URL(
+  "../../prns-js/dist/casework.js",
+  import.meta.url,
+);
+const smokeCasework = new URL(
+  "../smoke/dist/prns-js/src/casework.js",
+  import.meta.url,
+);
 const sdkDirectory = new URL(
   "../smoke/dist/prns-wasm/examples/browser-playground/sdk/",
   import.meta.url,
 );
 await mkdir(sdkDirectory, { recursive: true });
-await copyFile(
-  new URL("../smoke/dist/prns-js/src/casework.js", import.meta.url),
-  new URL("index.js", sdkDirectory),
-);
+await Promise.all([
+  copyFile(generatedCasework, smokeCasework),
+  copyFile(generatedCasework, new URL("index.js", sdkDirectory)),
+]);

--- a/prns-wasm/smoke/auto-wifi-smoke.ts
+++ b/prns-wasm/smoke/auto-wifi-smoke.ts
@@ -112,7 +112,30 @@ class MockRuntime extends MockRuntimeBase {
   }
 
   snapshot(): unknown {
-    return { type: "snapshot" };
+    const removed = new Set(
+      this.removed.map((entry) => Array.from(entry.interfaceId).join(",")),
+    );
+    return {
+      type: "snapshot",
+      revision: BigInt(
+        this.registered.length + this.removed.length + this.ingested.length,
+      ),
+      ingestedPackets: this.ingested.length,
+      ingestedCommands: 0,
+      routes: 0,
+      scheduledAnnounces: 0,
+      interfaces: this.registered
+        .map((options, index) => ({
+          id: interfaceId(new Uint8Array([0, 0, 0, 0, 0, 0, 0, index + 1])),
+          kind: options.kind,
+          bitrateBps: options.bitrateBps,
+          hardwareMtu: options.hardwareMtu,
+          routes: 0,
+          links: 0,
+          transportedLinks: 0,
+        }))
+        .filter(({ id }) => !removed.has(Array.from(id).join(","))),
+    };
   }
 }
 

--- a/prns-wasm/smoke/casework-smoke.ts
+++ b/prns-wasm/smoke/casework-smoke.ts
@@ -75,7 +75,7 @@ const { MakeTag } = from<Creation>();
 const missing = MakeTag("Missing");
 assert(missing.tag === "Missing", "from constructs data-less union members");
 
-const into = match_into<number>().from<Creation>(ready, {
+const into = match_into<number>().from(ready as Creation, {
   Ready: ({ value }) => value,
   Missing: () => 0,
 });

--- a/prns-wasm/smoke/event-smoke.ts
+++ b/prns-wasm/smoke/event-smoke.ts
@@ -125,6 +125,7 @@ class MockRuntime extends MockRuntimeBase {
   snapshot(): unknown {
     return {
       type: "snapshot",
+      revision: 0n,
       ingestedPackets: 0,
       ingestedCommands: 0,
       routes: 0,

--- a/prns-wasm/smoke/mock_runtime.ts
+++ b/prns-wasm/smoke/mock_runtime.ts
@@ -324,6 +324,20 @@ export class MockRuntimeBase implements PrnsRuntimeBinding {
     return unexpectedRuntimeCall("sendResourceSegment");
   }
 
+  configureBrowserWork(
+    _execution: Parameters<PrnsRuntimeBinding["configureBrowserWork"]>[0],
+  ): ReturnType<PrnsRuntimeBinding["configureBrowserWork"]> {}
+
+  takeBrowserWork(): ReturnType<PrnsRuntimeBinding["takeBrowserWork"]> {
+    return undefined;
+  }
+
+  completeBrowserWork(
+    _options: Parameters<PrnsRuntimeBinding["completeBrowserWork"]>[0],
+  ): ReturnType<PrnsRuntimeBinding["completeBrowserWork"]> {
+    return unexpectedRuntimeCall("completeBrowserWork");
+  }
+
   setLinkResourceStrategy(
     _options: Parameters<
       PrnsRuntimeBinding["setLinkResourceStrategy"]
@@ -396,6 +410,12 @@ export class MockRuntimeBase implements PrnsRuntimeBinding {
 
   snapshot(): ReturnType<PrnsRuntimeBinding["snapshot"]> {
     return unexpectedRuntimeCall("snapshot");
+  }
+
+  projectionSnapshot(
+    _request: Parameters<PrnsRuntimeBinding["projectionSnapshot"]>[0],
+  ): ReturnType<PrnsRuntimeBinding["projectionSnapshot"]> {
+    return unexpectedRuntimeCall("projectionSnapshot");
   }
 }
 

--- a/prns-wasm/smoke/smoke.ts
+++ b/prns-wasm/smoke/smoke.ts
@@ -371,7 +371,7 @@ function describeInterface(snapshot: InterfaceSnapshot): string {
 }
 
 function describeEvent(event: PrnsEvent): string {
-  return match_into<string>().from<PrnsEvent>(event, {
+  return match_into<string>().from(event, {
     AnnounceHeard: ({ destination, hops, sourceInterface }) =>
       `announce destination=${hex(destination)} hops=${hops} interface=${hex(sourceInterface)}`,
     SingleDelivery: ({ destination, plaintext, sourceInterface }) =>

--- a/prns-wasm/smoke/websocket-smoke.ts
+++ b/prns-wasm/smoke/websocket-smoke.ts
@@ -55,11 +55,14 @@ class MockRuntime extends MockRuntimeBase {
   readonly removed: RuntimeRemoveInterfaceInput[] = [];
   readonly ingests: RuntimeIngestOptions[] = [];
   readonly destinations: RuntimeRegisterSingleDestinationOptions[] = [];
+  readonly events: unknown[] = [];
   outbound: unknown[] = [];
+  outboundDrains = 0;
   routeSnapshots: unknown[] = [];
   destinationIdentities: unknown[] = [];
   registerFailure: Error | undefined;
   #revision = 0;
+  #commandId = 0n;
 
   constructor(identity: IdentitySecretKey) {
     super();
@@ -100,7 +103,15 @@ class MockRuntime extends MockRuntimeBase {
   }
 
   announce(_options: RuntimeAnnounceOptions): bigint {
-    return 1n;
+    const id = ++this.#commandId;
+    this.events.push({
+      type: "commandSettled",
+      id,
+      result: "succeeded",
+      kind: "Announced",
+    });
+    this.#revision += 1;
+    return id;
   }
 
   sendSinglePacket(
@@ -121,10 +132,11 @@ class MockRuntime extends MockRuntimeBase {
   }
 
   drainEvents(): unknown[] {
-    return [];
+    return this.events.splice(0);
   }
 
   drainOutbound(): unknown[] {
+    this.outboundDrains += 1;
     const outbound = this.outbound;
     this.outbound = [];
     return outbound;
@@ -350,6 +362,17 @@ async function main(): Promise<void> {
       target: { type: "interface", interfaceId: session.interfaceId },
       bytes: packetFrame(new Uint8Array([9, 8, 7])),
     });
+    const idleDrains = runtime.outboundDrains;
+    await wait(40);
+    assert(
+      runtime.outboundDrains === idleDrains,
+      "idle runtime output is not polled",
+    );
+    assert(
+      Number(socket.sent.length) === 0,
+      "output waits for a runtime activity boundary",
+    );
+    await advanceRuntime(prns);
     await waitFor(() => socket.sent.length === 1, "outbound frame was sent");
     assertBytes(socket.sent[0], [9, 8, 7], "outbound bytes are exact");
     assert(socket.sentPayloads[0] instanceof Uint8Array, "outbound avoids a buffer copy");
@@ -360,6 +383,7 @@ async function main(): Promise<void> {
       target: { type: "interface", interfaceId: session.interfaceId },
       bytes: packetFrame(new Uint8Array([7, 8, 9])),
     });
+    await advanceRuntime(prns);
     await wait(40);
     assert(socket.sent.length === 1, "buffer pressure pauses outbound frames");
     socket.bufferedAmount = 0;
@@ -396,6 +420,7 @@ async function main(): Promise<void> {
       target: { type: "interface", interfaceId: silentAuto.interfaceId },
       bytes: packetFrame(VALID_PACKET),
     });
+    await advanceRuntime(prns);
     await wait(40);
     assert(
       silentAutoSocket.sent.length === 0,
@@ -422,6 +447,7 @@ async function main(): Promise<void> {
       target: { type: "interface", interfaceId: silentAuto.interfaceId },
       bytes: packetFrame(VALID_PACKET),
     });
+    await advanceRuntime(prns);
     await waitFor(
       () => silentAutoSocket.sent.length === 2,
       "outbound resumes after late KISS evidence",
@@ -449,6 +475,7 @@ async function main(): Promise<void> {
       target: { type: "interface", interfaceId: kissAuto.interfaceId },
       bytes: packetFrame(VALID_PACKET),
     });
+    await advanceRuntime(prns);
     await wait(40);
     assert(
       kissAutoSocket.sent.length === 0,
@@ -548,6 +575,7 @@ async function main(): Promise<void> {
       },
       bytes: packetFrame(new Uint8Array([12, 13])),
     });
+    await advanceRuntime(prns);
     await waitFor(
       () => fanoutSocketA.sent.length === 1 && fanoutSocketB.sent.length === 1,
       "broadcast reaches every WebSocket session",
@@ -560,6 +588,7 @@ async function main(): Promise<void> {
       target: { type: "interface", interfaceId: fanoutB.interfaceId },
       bytes: packetFrame(new Uint8Array([14])),
     });
+    await advanceRuntime(prns);
     await wait(40);
     for (let index = 0; index < 65; index += 1) {
       runtime.outbound.push({
@@ -572,6 +601,7 @@ async function main(): Promise<void> {
         bytes: packetFrame(new Uint8Array([index])),
       });
     }
+    await advanceRuntime(prns);
     await waitFor(() => fanoutSocketA.sent.length === 66, "fast fanout keeps draining");
     fanoutSocketB.bufferedAmount = 0;
     await waitFor(
@@ -644,6 +674,7 @@ async function main(): Promise<void> {
       },
       bytes: packetFrame(new Uint8Array([23])),
     });
+    await advanceRuntime(prns);
     await wait(40);
     assert(
       stableRendezvousSocket.sent.length === 1,
@@ -895,6 +926,16 @@ function fixedIdentityStore(): IdentityStore {
 
 function fixedEntropy(length: number) {
   return Tag("Filled", entropyBytes(new Uint8Array(length).fill(42)));
+}
+
+async function advanceRuntime(prns: Prns): Promise<void> {
+  // The event-driven runtime sleeps until a command or ingress advances it.
+  // Queuing fixture output alone must not wake or poll its outbound consumers.
+  const outcome = await prns.announce(destinationHash(new Uint8Array(16).fill(1)));
+  assert(
+    outcome.tag === "Succeeded" && outcome.data.tag === "Announced",
+    "the public command advances and settles the mock runtime",
+  );
 }
 
 function sendBytes(data: string | ArrayBufferLike | Blob | ArrayBufferView): Uint8Array {


### PR DESCRIPTION
Update browser smoke fixtures for the current runtime events, connection state, and transport behavior. Refresh matcher calls, copy casework's built JavaScript into the smoke output, and drive WebSocket output through a public runtime command. Only tests and examples change.

The Prns app's pairing work adds shared runtime events. These checks exercise the browser bindings as well as the native runtime and provide the validation baseline for #210 and #211.

Rebased onto trunk `c4fd54dfd`. The SDK code build, TypeScript check, and event, Auto Wi-Fi, and WebSocket smokes pass. The normal local publishing gate, including its browser suite and all 14 configured firmware profiles, passes.

The separate `check:casework` smoke still fails: its structural-superset matching assertion is not supported by the pinned casework 0.2.2 runtime. That test remains enabled and unchanged; it is not selected by the normal pre-push browser suite. Resolving the dependency/fixture contract is outside this PR.

[Review this change](https://github.com/evelant/Prns/compare/c4fd54dfd7a83048fc2cf5096a09fec6fa17a0ec...prns-app-wasm-event-smoke-refresh).
