### PR TITLE
Clarify CoreBluetooth scan-startup logs

### DIFF
--- a/audits/unsafe-snapshot.json
+++ b/audits/unsafe-snapshot.json
@@ -16840,11 +16840,11 @@
       "name": "prns-ffi",
       "source": "prns-ffi",
       "unsafe": {
-        "blocks": 124,
+        "blocks": 138,
         "externs": 3,
         "functions": 0,
         "impls": 22,
-        "tokens": 185
+        "tokens": 199
       },
       "version": "0.3.7"
     },

--- a/personal-rns/src/interface_families/bluetooth_auto.rs
+++ b/personal-rns/src/interface_families/bluetooth_auto.rs
@@ -4,6 +4,11 @@ pub use prns_interfaces_tokio::bluetooth_auto::{
     BluetoothPeer, ConfiguredAutoBle, ConfiguredAutoBluetoothLe,
 };
 
+#[cfg(all(feature = "tokio-host", target_os = "ios"))]
+pub use prns_interfaces_tokio::bluetooth_auto::{
+    CoreBluetoothRestorationIdentifiers, CoreBluetoothRestorationIdentifiersError,
+};
+
 #[cfg(all(feature = "embassy-host", not(feature = "tokio-host")))]
 pub use prns_interfaces_embassy::bluetooth_auto::{
     connection_slots, BluetoothAuto, BluetoothAutoShared, BluetoothAutoStatus,

--- a/personal-rns/src/interface_families/bluetooth_auto.rs
+++ b/personal-rns/src/interface_families/bluetooth_auto.rs
@@ -6,7 +6,8 @@ pub use prns_interfaces_tokio::bluetooth_auto::{
 
 #[cfg(all(feature = "tokio-host", target_os = "ios"))]
 pub use prns_interfaces_tokio::bluetooth_auto::{
-    CoreBluetoothRestorationIdentifiers, CoreBluetoothRestorationIdentifiersError,
+    CoreBluetoothCentralRestorationIdentifier, CoreBluetoothRestorationIdentifiers,
+    CoreBluetoothRestorationIdentifiersError,
 };
 
 #[cfg(all(feature = "embassy-host", not(feature = "tokio-host")))]

--- a/prns-ffi/src/bluetooth_auto/macos/backend.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/backend.rs
@@ -42,6 +42,7 @@ const DIAL_TIMEOUT: Duration = Duration::from_secs(15);
 /// Maximum recovery latency for a CoreBluetooth scan that claims to be active but has stopped
 /// delivering callbacks. Any discovery callback renews the scan lease without touching the radio.
 const RADIO_LIVENESS_INTERVAL: Duration = Duration::from_secs(60);
+const STARTUP_SIGHTINGS_PER_PEER: usize = 4;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum ScanLease {
@@ -112,6 +113,123 @@ impl StartupReadiness {
     }
 }
 
+pub(super) struct StartupBacklog<L> {
+    inbound: VecDeque<L>,
+    sightings: VecDeque<(BleAddress, Option<i8>)>,
+}
+
+impl<L> Default for StartupBacklog<L> {
+    fn default() -> Self {
+        Self {
+            inbound: VecDeque::new(),
+            sightings: VecDeque::new(),
+        }
+    }
+}
+
+impl<L> StartupBacklog<L> {
+    fn push_inbound(&mut self, link: L, capacity: usize) -> Option<L> {
+        if self.inbound.len() >= capacity {
+            Some(link)
+        } else {
+            self.inbound.push_back(link);
+            None
+        }
+    }
+
+    fn note_sighting(
+        &mut self,
+        address: BleAddress,
+        rssi: Option<i8>,
+        capacity: usize,
+    ) -> Option<(BleAddress, Option<i8>)> {
+        if let Some(position) = self
+            .sightings
+            .iter()
+            .position(|(observed, _)| *observed == address)
+        {
+            self.sightings.remove(position);
+            self.sightings.push_back((address, rssi));
+            return None;
+        }
+        let evicted = if self.sightings.len() >= capacity {
+            self.sightings.pop_front()
+        } else {
+            None
+        };
+        if capacity > 0 {
+            self.sightings.push_back((address, rssi));
+        }
+        evicted
+    }
+
+    pub(super) fn pop_inbound(&mut self) -> Option<L> {
+        self.inbound.pop_front()
+    }
+
+    pub(super) fn pop_sighting(&mut self) -> Option<(BleAddress, Option<i8>)> {
+        self.sightings.pop_front()
+    }
+}
+
+pub(super) fn pop_unseen_startup_sighting<L>(
+    backlog: &mut StartupBacklog<L>,
+    seen: &mut HashSet<[u8; 6]>,
+) -> Option<BleAddress> {
+    while let Some((address, _)) = backlog.pop_sighting() {
+        if seen.insert(*address.octets()) {
+            return Some(address);
+        }
+    }
+    None
+}
+
+pub(super) enum StartupProgress<L> {
+    Waiting,
+    Ready(Psm),
+    InboundOverflow(L),
+    SightingEvicted {
+        address: BleAddress,
+        rssi: Option<i8>,
+    },
+}
+
+pub(super) fn stage_startup_event<L>(
+    readiness: &mut StartupReadiness,
+    backlog: &mut StartupBacklog<L>,
+    event: Event<L>,
+    inbound_capacity: usize,
+    sighting_capacity: usize,
+) -> Result<StartupProgress<L>, MacosBleError> {
+    match event {
+        Event::CentralPowered => readiness.note_central_powered(),
+        Event::GattServicePublished => readiness.note_gatt_service_published(),
+        Event::L2capPublished { psm } => readiness.note_l2cap_published(psm)?,
+        Event::GattServicePublishFailed => {
+            crate::diagnostic_log::error!("bluetooth: GATT service publication failed at startup");
+            return Err(MacosBleError::PublishFailed);
+        }
+        Event::L2capPublishFailed => {
+            crate::diagnostic_log::error!("bluetooth: L2CAP publication failed at startup");
+            return Err(MacosBleError::PublishFailed);
+        }
+        Event::Inbound(link) => {
+            if let Some(link) = backlog.push_inbound(link, inbound_capacity) {
+                return Ok(StartupProgress::InboundOverflow(link));
+            }
+        }
+        Event::Sighting { address, rssi } => {
+            if let Some((address, rssi)) = backlog.note_sighting(address, rssi, sighting_capacity) {
+                return Ok(StartupProgress::SightingEvicted { address, rssi });
+            }
+        }
+    }
+    Ok(match readiness.ready_psm() {
+        Some(psm) => StartupProgress::Ready(psm),
+        None => StartupProgress::Waiting,
+    })
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum DialAdmission {
     AttachCentralSession,
@@ -146,6 +264,18 @@ fn cancel_connection(central: &SendCentralManager, peripheral: &SendPeripheral) 
     // SAFETY: both retained objects remain alive through this call and are messaged only on the
     // CoreBluetooth serial dispatch queue.
     unsafe { central.0.cancelPeripheralConnection(&peripheral.0) };
+}
+
+fn close_overflow_inbound(delegate: &SendPeripheralDelegate, link: GattLink) {
+    let address = link.address;
+    crate::diagnostic_log::warn!(
+        "bluetooth: rejecting pre-ready inbound link from {:02x?} — startup queue is full",
+        address.octets()
+    );
+    // Dropping both receivers marks the queue-confined peripheral session closed; its delegate
+    // then removes that session and any pending L2CAP channel state.
+    drop(link);
+    delegate.0.clear_closed_peer(address);
 }
 
 fn apply_scanning(central: SendCentralManager, enabled: bool, restart: bool) {
@@ -260,6 +390,7 @@ pub struct MacosBleBackend {
     /// Restored peers whose synthesized sighting has been handed to the Host. The first dial
     /// consumes the marker so later system-owned connections keep the ordinary admission policy.
     restored_connections: HashSet<CoreBluetoothPeerId>,
+    startup_backlog: StartupBacklog<GattLink>,
     dials: JoinSet<DialTaskOutcome>,
     queue: DispatchRetained<DispatchQueue>,
     scan_enabled: bool,
@@ -467,6 +598,11 @@ impl MacosBleBackend {
 
     pub async fn next_sighting(&mut self) -> Option<BleAddress> {
         loop {
+            if let Some(address) =
+                pop_unseen_startup_sighting(&mut self.startup_backlog, &mut self.seen)
+            {
+                return Some(address);
+            }
             match self.events.recv().await? {
                 Event::Sighting { address, .. } => {
                     if self.seen.insert(*address.octets()) {
@@ -487,35 +623,32 @@ impl PreparedMacosBleBackend {
             peripheral_delegate,
             queue,
         } = self.handles;
+        let mut startup_backlog = StartupBacklog::default();
+        let inbound_capacity = MacosBleBackend::MAX_PEERS;
+        let sighting_capacity = inbound_capacity.saturating_mul(STARTUP_SIGHTINGS_PER_PEER);
 
         let readiness = tokio::time::timeout(POWER_ON_TIMEOUT, async {
             let mut readiness = StartupReadiness::default();
             loop {
-                match self.events.recv().await {
-                    Some(Event::CentralPowered) => readiness.note_central_powered(),
-                    Some(Event::GattServicePublished) => {
-                        readiness.note_gatt_service_published();
+                let event = self.events.recv().await.ok_or(MacosBleError::Closed)?;
+                match stage_startup_event(
+                    &mut readiness,
+                    &mut startup_backlog,
+                    event,
+                    inbound_capacity,
+                    sighting_capacity,
+                )? {
+                    StartupProgress::Waiting => {}
+                    StartupProgress::Ready(psm) => return Ok(psm),
+                    StartupProgress::InboundOverflow(link) => {
+                        close_overflow_inbound(&peripheral_delegate, link);
                     }
-                    Some(Event::L2capPublished { psm }) => {
-                        readiness.note_l2cap_published(psm)?;
-                    }
-                    Some(Event::GattServicePublishFailed) => {
-                        crate::diagnostic_log::error!(
-                            "bluetooth: GATT service publication failed at startup"
+                    StartupProgress::SightingEvicted { address, rssi } => {
+                        crate::diagnostic_log::warn!(
+                            "bluetooth: evicted pre-ready advisory sighting {:02x?} rssi={rssi:?} — startup queue is full",
+                            address.octets()
                         );
-                        return Err(MacosBleError::PublishFailed);
                     }
-                    Some(Event::L2capPublishFailed) => {
-                        crate::diagnostic_log::error!(
-                            "bluetooth: L2CAP publication failed at startup"
-                        );
-                        return Err(MacosBleError::PublishFailed);
-                    }
-                    Some(_) => {}
-                    None => return Err(MacosBleError::Closed),
-                }
-                if let Some(psm) = readiness.ready_psm() {
-                    return Ok(psm);
                 }
             }
         })
@@ -544,6 +677,7 @@ impl PreparedMacosBleBackend {
             peripherals: self.peripherals,
             restored: self.restored,
             restored_connections: HashSet::new(),
+            startup_backlog,
             dials: JoinSet::new(),
             queue,
             scan_enabled: false,
@@ -580,6 +714,9 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
 
     async fn next_event(&mut self) -> BleEvent<GattLink> {
         loop {
+            if let Some(link) = self.startup_backlog.pop_inbound() {
+                return BleEvent::Inbound(link);
+            }
             if let Some(peer_id) = self
                 .restored
                 .lock()
@@ -591,6 +728,13 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
                     address: peer_id.address(),
                     rssi: None,
                 };
+            }
+            if let Some((address, rssi)) = self.startup_backlog.pop_sighting() {
+                crate::diagnostic_log::debug!(
+                    "bluetooth: handing off pre-ready Prns sighting {:02x?} rssi={rssi:?}",
+                    address.octets()
+                );
+                return BleEvent::Sighting { address, rssi };
             }
             let pending_dials = !self.dials.is_empty();
             tokio::select! {

--- a/prns-ffi/src/bluetooth_auto/macos/backend.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/backend.rs
@@ -1,8 +1,8 @@
 use core::time::Duration;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc as sync_mpsc;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use dispatch2::{DispatchQueue, DispatchRetained};
 use objc2::rc::Retained;
@@ -17,14 +17,16 @@ use tokio::sync::{mpsc as tokio_mpsc, oneshot, watch};
 use tokio::task::JoinSet;
 
 use prns_core::interfaces::bluetooth_auto::{
-    AdvertisingMode, BleBackend, BleEvent, DialOutcome, Origin, ScanningMode,
+    AdvertisingMode, BleBackend, BleEvent, DialOutcome, Origin, RadioMode, ScanningMode,
 };
 use prns_core::interfaces::bluetooth_auto::{BleAddress, BleIdentity, Control, Psm};
 
 use super::central::{
-    discover_prns_services, is_system_connected, CentralDelegate, CentralPeerSession, DialCommand,
-    DialCompletion, CENTRAL_CONTROL_INBOUND_CAPACITY,
+    discover_prns_services, is_system_connected, CentralDelegate, CentralDialCandidate,
+    CentralPeerSession, DialCommand, DialCompletion, DialRejection,
+    CENTRAL_CONTROL_INBOUND_CAPACITY,
 };
+use super::discovery::PeripheralLinkState;
 use super::gatt_link::{gatt_inbound_channel, ControlPlane, GattLink};
 use super::peripheral::PeripheralDelegate;
 #[cfg(target_os = "ios")]
@@ -34,16 +36,66 @@ use super::{
 };
 use super::{
     manager_signal_channel, start_scan, CoreBluetoothPeerId, L2capPublicationState, MacosBleError,
-    ManagerSignals, PeripheralTable, PublicationState, RestoredPeripherals, SendCentralDelegate,
-    SendCentralManager, SendPeripheral, SendPeripheralDelegate, Sighting,
+    ManagerSignals, PublicationState, SendCentralDelegate, SendCentralManager, SendPeripheral,
+    SendPeripheralDelegate, Sighting,
 };
 
 const POWER_ON_TIMEOUT: Duration = Duration::from_secs(10);
 const DIAL_TIMEOUT: Duration = Duration::from_secs(15);
+const RADIO_TRANSITION_TIMEOUT: Duration = Duration::from_secs(2);
 /// Maximum recovery latency for a CoreBluetooth scan that claims to be active but has stopped
 /// delivering callbacks. Any discovery callback renews the scan lease without touching the radio.
 const RADIO_LIVENESS_INTERVAL: Duration = Duration::from_secs(60);
 const SIGHTING_INGRESS_PER_PEER: usize = 4;
+
+pub(super) const fn central_peripheral_capacity(max_peers: usize) -> usize {
+    max_peers.saturating_mul(SIGHTING_INGRESS_PER_PEER)
+}
+
+pub(super) struct BoundedRecentSet<T> {
+    capacity: usize,
+    entries: VecDeque<T>,
+}
+
+impl<T: Eq> BoundedRecentSet<T> {
+    pub(super) fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            entries: VecDeque::new(),
+        }
+    }
+
+    /// Returns true for a newly retained value. Existing values refresh their LRU position but are
+    /// not reported again; after eviction a later observation is intentionally new again.
+    pub(super) fn insert(&mut self, value: T) -> bool {
+        if self.capacity == 0 {
+            return false;
+        }
+        if let Some(position) = self.entries.iter().position(|stored| *stored == value) {
+            self.entries.remove(position);
+            self.entries.push_back(value);
+            return false;
+        }
+        if self.entries.len() >= self.capacity {
+            self.entries.pop_front();
+        }
+        self.entries.push_back(value);
+        true
+    }
+
+    pub(super) fn pop_front(&mut self) -> Option<T> {
+        self.entries.pop_front()
+    }
+
+    pub(super) fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    #[cfg(test)]
+    pub(super) fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum ScanLease {
@@ -122,6 +174,12 @@ pub(super) enum DialAdmission {
     /// CoreBluetooth restored this central-role connection for the application. Reattach the
     /// delegate and session, then resume discovery without issuing another connection request.
     ResumeRestoredSession,
+    /// CoreBluetooth restored a pending connection. Reattach the session and let the existing
+    /// request complete through `didConnect` instead of issuing a duplicate request.
+    AwaitRestoredConnection,
+    /// The restored peripheral is already disconnecting or reports an unknown state. Do not
+    /// attach protocol state to a connection whose completion semantics are unavailable.
+    RejectRestoredConnection,
     YieldToSystemConnection,
     /// The target peer already owns an inbound peripheral session. Dialing that same peer as a
     /// central would create the dual-role link that handshake policy is trying to eliminate.
@@ -131,16 +189,21 @@ pub(super) enum DialAdmission {
 pub(super) const fn dial_admission(
     already_system_connected: bool,
     target_has_inbound_session: bool,
-    restored_connection: bool,
+    restored_state: Option<PeripheralLinkState>,
 ) -> DialAdmission {
     if target_has_inbound_session {
         DialAdmission::YieldToInboundSession
-    } else if already_system_connected {
-        if restored_connection {
-            DialAdmission::ResumeRestoredSession
-        } else {
-            DialAdmission::YieldToSystemConnection
+    } else if let Some(state) = restored_state {
+        match state {
+            PeripheralLinkState::Connected => DialAdmission::ResumeRestoredSession,
+            PeripheralLinkState::Connecting => DialAdmission::AwaitRestoredConnection,
+            PeripheralLinkState::Disconnected => DialAdmission::AttachCentralSession,
+            PeripheralLinkState::Disconnecting | PeripheralLinkState::Unknown => {
+                DialAdmission::RejectRestoredConnection
+            }
         }
+    } else if already_system_connected {
+        DialAdmission::YieldToSystemConnection
     } else {
         DialAdmission::AttachCentralSession
     }
@@ -150,6 +213,18 @@ fn cancel_connection(central: &SendCentralManager, peripheral: &SendPeripheral) 
     // SAFETY: both retained objects remain alive through this call and are messaged only on the
     // CoreBluetooth serial dispatch queue.
     unsafe { central.0.cancelPeripheralConnection(&peripheral.0) };
+}
+
+fn schedule_failed_dial_cleanup(
+    queue: &DispatchRetained<DispatchQueue>,
+    delegate: &SendCentralDelegate,
+    peer_id: CoreBluetoothPeerId,
+) {
+    let delegate = SendCentralDelegate(delegate.0.clone());
+    queue.exec_async(move || {
+        let delegate = delegate;
+        delegate.0.fail_peer(peer_id);
+    });
 }
 
 fn apply_scanning(central: SendCentralManager, enabled: bool, restart: bool) {
@@ -178,6 +253,29 @@ fn apply_scanning(central: SendCentralManager, enabled: bool, restart: bool) {
     }
 }
 
+fn enqueue_radio_transition(
+    queue: &DispatchRetained<DispatchQueue>,
+    central: &SendCentralManager,
+    central_delegate: &SendCentralDelegate,
+    peripheral_delegate: &SendPeripheralDelegate,
+    enabled: bool,
+    completion: Option<oneshot::Sender<()>>,
+) {
+    let central = SendCentralManager(central.0.clone());
+    let central_delegate = SendCentralDelegate(central_delegate.0.clone());
+    let peripheral_delegate = SendPeripheralDelegate(peripheral_delegate.0.clone());
+    queue.exec_async(move || {
+        let central = central;
+        let central_delegate = central_delegate;
+        let peripheral_delegate = peripheral_delegate;
+        central_delegate.0.set_radio_enabled(&central.0, enabled);
+        peripheral_delegate.0.set_radio_enabled(enabled);
+        if let Some(completion) = completion {
+            let _ = completion.send(());
+        }
+    });
+}
+
 fn begin_dial(command: DialCommand, target_has_inbound_session: bool, restored_connection: bool) {
     let DialCommand {
         central,
@@ -186,19 +284,26 @@ fn begin_dial(command: DialCommand, target_has_inbound_session: bool, restored_c
         peer_id,
         session,
     } = command;
+    // SAFETY: this exact retained peripheral is queried on its CoreBluetooth serial queue.
+    let restored_state =
+        restored_connection.then(|| PeripheralLinkState::from(unsafe { peripheral.state() }));
+    // The system-wide query remains only a guard for an ordinary observation. Restored admission
+    // uses the exact peripheral's state because Apple's restoration array also includes pending
+    // connections and may coexist with connections owned by another app.
+    let already_system_connected = !restored_connection && is_system_connected(&central, peer_id);
     let admission = dial_admission(
-        is_system_connected(&central, peer_id),
+        already_system_connected,
         target_has_inbound_session,
-        restored_connection,
+        restored_state,
     );
-    let resume_restored = match admission {
+    let start = match admission {
         DialAdmission::YieldToSystemConnection => {
             crate::diagnostic_log::debug!(
                 "bluetooth: yielding dial to {:02x?} — peer is already connected system-wide outside this manager's restored state",
                 peer_id.address().octets()
             );
-            delegate.discard_restored_callbacks(peer_id);
-            session.reject();
+            delegate.discard_peer(peer_id);
+            session.reject(DialRejection::YieldToSystemConnection);
             return;
         }
         DialAdmission::YieldToInboundSession => {
@@ -206,32 +311,63 @@ fn begin_dial(command: DialCommand, target_has_inbound_session: bool, restored_c
                 "bluetooth: yielding dial to {:02x?} — this peer already owns an inbound peripheral session",
                 peer_id.address().octets()
             );
-            delegate.discard_restored_callbacks(peer_id);
-            session.reject();
+            if restored_connection {
+                cancel_connection(
+                    &SendCentralManager(central.clone()),
+                    &SendPeripheral(peripheral.clone()),
+                );
+            }
+            delegate.discard_peer(peer_id);
+            session.reject(DialRejection::YieldToInboundSession);
             return;
         }
-        DialAdmission::AttachCentralSession => false,
-        DialAdmission::ResumeRestoredSession => true,
+        DialAdmission::RejectRestoredConnection => {
+            crate::diagnostic_log::warn!(
+                "bluetooth: restored connection to {:02x?} is not usable in state {restored_state:?}",
+                peer_id.address().octets()
+            );
+            delegate.discard_peer(peer_id);
+            session.reject(DialRejection::RestoredConnectionUnavailable);
+            return;
+        }
+        DialAdmission::AttachCentralSession => DialStart::Connect,
+        DialAdmission::ResumeRestoredSession => DialStart::Discover,
+        DialAdmission::AwaitRestoredConnection => DialStart::AwaitConnection,
     };
     // SAFETY: both retained Objective-C objects stay alive for the delegate assignment, which runs
     // on the CoreBluetooth serial dispatch queue.
     unsafe {
         peripheral.setDelegate(Some(ProtocolObject::from_ref(&*delegate)));
     }
-    if !delegate.begin_session(peer_id, session) {
+    if !delegate.begin_session(&central, peer_id, session) {
         return;
     }
-    if resume_restored {
-        crate::diagnostic_log::debug!(
-            "bluetooth: resumed restored connection to {:02x?}, discovering Prns service",
-            peer_id.address().octets()
-        );
-        discover_prns_services(&peripheral);
-    } else {
-        // SAFETY: the retained manager and peripheral are owned by this queue-confined command,
-        // and CoreBluetooth connection calls are serialized on their dispatch queue.
-        unsafe { central.connectPeripheral_options(&peripheral, None) };
+    match start {
+        DialStart::Discover => {
+            crate::diagnostic_log::debug!(
+                "bluetooth: resumed restored connection to {:02x?}, discovering Prns service",
+                peer_id.address().octets()
+            );
+            discover_prns_services(&peripheral);
+        }
+        DialStart::AwaitConnection => {
+            crate::diagnostic_log::debug!(
+                "bluetooth: resumed pending connection to {:02x?}, awaiting CoreBluetooth completion",
+                peer_id.address().octets()
+            );
+        }
+        DialStart::Connect => {
+            // SAFETY: the retained manager and peripheral are owned by this queue-confined command,
+            // and CoreBluetooth connection calls are serialized on their dispatch queue.
+            unsafe { central.connectPeripheral_options(&peripheral, None) };
+        }
     }
+}
+
+enum DialStart {
+    Connect,
+    AwaitConnection,
+    Discover,
 }
 
 struct Handles {
@@ -257,22 +393,19 @@ pub struct MacosBleBackend {
     manager_signals_open: bool,
     central_powered_generation: u64,
     inbound: tokio_mpsc::Receiver<GattLink>,
-    sightings: tokio_mpsc::Receiver<Sighting>,
+    sighting_events: tokio_mpsc::Receiver<()>,
     psm: Psm,
-    seen: HashSet<[u8; 6]>,
+    seen: BoundedRecentSet<[u8; 6]>,
     central: SendCentralManager,
     central_delegate: SendCentralDelegate,
     peripheral_delegate: SendPeripheralDelegate,
-    peripherals: PeripheralTable,
-    restored: RestoredPeripherals,
-    /// Restored peers whose synthesized sighting has been handed to the Host. The first dial
-    /// consumes the marker so later system-owned connections keep the ordinary admission policy.
-    restored_connections: HashSet<CoreBluetoothPeerId>,
+    dial_failures: BoundedRecentSet<BleAddress>,
     dials: JoinSet<DialTaskOutcome>,
     queue: DispatchRetained<DispatchQueue>,
     scan_enabled: bool,
     advertise_enabled: bool,
     scan_activity: Arc<AtomicBool>,
+    radio_enabled: Arc<AtomicBool>,
     scan_liveness_at: tokio::time::Instant,
     advertising_reconcile_at: tokio::time::Instant,
 }
@@ -297,10 +430,9 @@ pub struct PreparedMacosBleBackend {
     native_thread: NativeThread,
     manager_signals: watch::Receiver<ManagerSignals>,
     inbound: tokio_mpsc::Receiver<GattLink>,
-    sightings: tokio_mpsc::Receiver<Sighting>,
-    peripherals: PeripheralTable,
-    restored: RestoredPeripherals,
+    sighting_events: tokio_mpsc::Receiver<()>,
     scan_activity: Arc<AtomicBool>,
+    radio_enabled: Arc<AtomicBool>,
     handles: Handles,
 }
 
@@ -376,17 +508,18 @@ impl MacosBleBackend {
         let _ = manager_preparation;
         let (manager_signals_tx, manager_signals_rx) = manager_signal_channel();
         let (inbound_tx, inbound_rx) = tokio_mpsc::channel::<GattLink>(Self::MAX_PEERS);
-        let (sightings_tx, sightings_rx) =
-            tokio_mpsc::channel::<Sighting>(Self::MAX_PEERS * SIGHTING_INGRESS_PER_PEER);
+        let peripheral_capacity = central_peripheral_capacity(Self::MAX_PEERS);
+        let (sighting_wake, sighting_events) = tokio_mpsc::channel::<()>(1);
         let (keepalive, shutdown_rx) = sync_mpsc::channel::<()>();
         let (handles_tx, handles_rx) = oneshot::channel::<Handles>();
-        let peripherals: PeripheralTable = Arc::new(Mutex::new(HashMap::new()));
-        let restored: RestoredPeripherals = Arc::new(Mutex::new(VecDeque::new()));
         let scan_activity = Arc::new(AtomicBool::new(false));
+        // CoreBluetooth restoration can arrive during preparation, before the runtime's first
+        // set_radio_mode(On), so preparation begins logically enabled.
+        let radio_enabled = Arc::new(AtomicBool::new(true));
         let central_manager_signals = manager_signals_tx.clone();
-        let peripherals_for_thread = peripherals.clone();
-        let restored_for_thread = restored.clone();
         let scan_activity_for_thread = Arc::clone(&scan_activity);
+        let radio_enabled_for_central = Arc::clone(&radio_enabled);
+        let radio_enabled_for_peripheral = Arc::clone(&radio_enabled);
 
         let join = std::thread::Builder::new()
             .name("prns-corebluetooth".into())
@@ -395,10 +528,11 @@ impl MacosBleBackend {
 
                 let central_delegate = CentralDelegate::new(
                     central_manager_signals,
-                    sightings_tx,
-                    peripherals_for_thread,
-                    restored_for_thread,
+                    sighting_wake,
                     scan_activity_for_thread,
+                    radio_enabled_for_central,
+                    peripheral_capacity,
+                    Self::MAX_PEERS,
                 );
                 let central_proto = ProtocolObject::from_ref(&*central_delegate);
                 #[cfg(target_os = "ios")]
@@ -425,6 +559,8 @@ impl MacosBleBackend {
                     inbound_tx,
                     queue.clone(),
                     identity,
+                    radio_enabled_for_peripheral,
+                    Self::MAX_PEERS,
                 );
                 let peripheral_proto = ProtocolObject::from_ref(&*peripheral_delegate);
                 #[cfg(target_os = "ios")]
@@ -469,10 +605,9 @@ impl MacosBleBackend {
             native_thread,
             manager_signals: manager_signals_rx,
             inbound: inbound_rx,
-            sightings: sightings_rx,
-            peripherals,
-            restored,
+            sighting_events,
             scan_activity,
+            radio_enabled,
             handles,
         })
     }
@@ -500,10 +635,107 @@ impl MacosBleBackend {
         }
     }
 
+    fn offer_restored(&self) -> Option<CoreBluetoothPeerId> {
+        let (result_tx, result_rx) = sync_mpsc::sync_channel(1);
+        let delegate = SendCentralDelegate(self.central_delegate.0.clone());
+        self.queue.exec_sync(move || {
+            let delegate = delegate;
+            let _ = result_tx.try_send(delegate.0.offer_restored());
+        });
+        result_rx.try_recv().ok().flatten()
+    }
+
+    fn pop_sighting(&self) -> Option<Sighting> {
+        let (result_tx, result_rx) = sync_mpsc::sync_channel(1);
+        let delegate = SendCentralDelegate(self.central_delegate.0.clone());
+        self.queue.exec_sync(move || {
+            let delegate = delegate;
+            let _ = result_tx.try_send(delegate.0.pop_sighting());
+        });
+        result_rx.try_recv().ok().flatten()
+    }
+
+    fn claim(&self, address: BleAddress) -> CentralDialCandidate<SendPeripheral> {
+        let (result_tx, result_rx) = sync_mpsc::sync_channel(1);
+        let central = SendCentralManager(self.central.0.clone());
+        let delegate = SendCentralDelegate(self.central_delegate.0.clone());
+        self.queue.exec_sync(move || {
+            let central = central;
+            let delegate = delegate;
+            let candidate = delegate.0.claim(&central.0, address);
+            let _ = result_tx.try_send(candidate);
+        });
+        result_rx
+            .try_recv()
+            .unwrap_or(CentralDialCandidate::Missing)
+    }
+
+    fn clear_local_radio_state(&mut self) {
+        while let Ok(link) = self.inbound.try_recv() {
+            drop(link);
+        }
+        while self.sighting_events.try_recv().is_ok() {}
+        self.seen.clear();
+        self.dial_failures.clear();
+        self.scan_activity.store(false, Ordering::Release);
+        self.scan_liveness_at = tokio::time::Instant::now() + RADIO_LIVENESS_INTERVAL;
+        self.advertising_reconcile_at = tokio::time::Instant::now() + RADIO_LIVENESS_INTERVAL;
+    }
+
+    async fn transition_radio(&mut self, enabled: bool) -> Result<(), MacosBleError> {
+        // The atomic gate closes synchronously, before any already-enqueued CoreBluetooth callback
+        // can publish fresh async work. Queue-owned maps and framework connections are then cleaned
+        // on their sole owning queue.
+        if !enabled {
+            self.radio_enabled.store(false, Ordering::Release);
+            self.scan_enabled = false;
+            self.advertise_enabled = false;
+            self.clear_local_radio_state();
+        }
+
+        let (completion_tx, completion_rx) = oneshot::channel();
+        enqueue_radio_transition(
+            &self.queue,
+            &self.central,
+            &self.central_delegate,
+            &self.peripheral_delegate,
+            enabled,
+            Some(completion_tx),
+        );
+
+        let mut dials = (!enabled).then(|| core::mem::take(&mut self.dials));
+        if let Some(dials) = dials.as_mut() {
+            dials.abort_all();
+        }
+        let transition = async move {
+            if let Some(mut dials) = dials {
+                dials.shutdown().await;
+            }
+            completion_rx.await.map_err(|_| MacosBleError::Closed)
+        };
+        let result = match tokio::time::timeout(RADIO_TRANSITION_TIMEOUT, transition).await {
+            Ok(result) => result,
+            Err(_) => {
+                crate::diagnostic_log::error!(
+                    "bluetooth: timed out waiting for queue-confined radio transition"
+                );
+                Err(MacosBleError::RadioTransitionTimeout)
+            }
+        };
+        if !enabled {
+            // Callbacks ordered before the queue cleanup may already have emitted bounded wakeups
+            // or links. Once the acknowledgement arrives, the atomic gate prevents replacements.
+            self.clear_local_radio_state();
+        }
+        result
+    }
+
     pub async fn next_sighting(&mut self) -> Option<BleAddress> {
         loop {
+            if let Some(peer_id) = self.offer_restored() {
+                return Some(peer_id.address());
+            }
             tokio::select! {
-                biased;
                 changed = self.manager_signals.changed(), if self.manager_signals_open => {
                     if changed.is_err() {
                         self.manager_signals_open = false;
@@ -511,8 +743,11 @@ impl MacosBleBackend {
                         self.reconcile_manager_signals();
                     }
                 }
-                sighting = self.sightings.recv() => {
-                    let Sighting { address, .. } = sighting?;
+                wake = self.sighting_events.recv() => {
+                    wake?;
+                    let Some(Sighting { address, .. }) = self.pop_sighting() else {
+                        continue;
+                    };
                     if self.seen.insert(*address.octets()) {
                         return Some(address);
                     }
@@ -554,20 +789,21 @@ impl PreparedMacosBleBackend {
             manager_signals_open: true,
             central_powered_generation,
             inbound: self.inbound,
-            sightings: self.sightings,
+            sighting_events: self.sighting_events,
             psm,
-            seen: HashSet::new(),
+            seen: BoundedRecentSet::new(central_peripheral_capacity(MacosBleBackend::MAX_PEERS)),
             central,
             central_delegate,
             peripheral_delegate,
-            peripherals: self.peripherals,
-            restored: self.restored,
-            restored_connections: HashSet::new(),
+            dial_failures: BoundedRecentSet::new(central_peripheral_capacity(
+                MacosBleBackend::MAX_PEERS,
+            )),
             dials: JoinSet::new(),
             queue,
             scan_enabled: false,
             advertise_enabled: false,
             scan_activity: self.scan_activity,
+            radio_enabled: self.radio_enabled,
             scan_liveness_at: tokio::time::Instant::now() + RADIO_LIVENESS_INTERVAL,
             advertising_reconcile_at: tokio::time::Instant::now() + RADIO_LIVENESS_INTERVAL,
         })
@@ -577,6 +813,18 @@ impl PreparedMacosBleBackend {
 impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
     type Error = MacosBleError;
     type Link = GattLink;
+
+    async fn set_radio_mode(&mut self, mode: RadioMode) -> Result<(), MacosBleError> {
+        let enabled = mode.is_on();
+        let result = self.transition_radio(enabled).await;
+        if result.is_ok() {
+            crate::diagnostic_log::debug!(
+                "bluetooth: CoreBluetooth logical radio resources {}",
+                if enabled { "up" } else { "down" }
+            );
+        }
+        result
+    }
 
     async fn set_advertising(&mut self, mode: AdvertisingMode) -> Result<(), MacosBleError> {
         self.advertise_enabled = mode.is_on();
@@ -591,7 +839,11 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
         self.scan_liveness_at = tokio::time::Instant::now() + RADIO_LIVENESS_INTERVAL;
         let restart = cfg!(target_os = "macos") && self.scan_enabled;
         let central = SendCentralManager(self.central.0.clone());
+        let radio_enabled = Arc::clone(&self.radio_enabled);
         self.queue.exec_async(move || {
+            if mode.is_on() && !radio_enabled.load(Ordering::Acquire) {
+                return;
+            }
             apply_scanning(central, mode.is_on(), restart);
         });
         Ok(())
@@ -599,21 +851,17 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
 
     async fn next_event(&mut self) -> BleEvent<GattLink> {
         loop {
-            if let Some(peer_id) = self
-                .restored
-                .lock()
-                .ok()
-                .and_then(|mut queue| queue.pop_front())
-            {
-                self.restored_connections.insert(peer_id);
+            if let Some(peer_id) = self.offer_restored() {
                 return BleEvent::Sighting {
                     address: peer_id.address(),
                     rssi: None,
                 };
             }
+            if let Some(address) = self.dial_failures.pop_front() {
+                return BleEvent::DialFailed { address };
+            }
             let pending_dials = !self.dials.is_empty();
             tokio::select! {
-                biased;
                 changed = self.manager_signals.changed(), if self.manager_signals_open => {
                     if changed.is_err() {
                         self.manager_signals_open = false;
@@ -641,8 +889,11 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
                         Err(_) => continue,
                     }
                 }
-                sighting = self.sightings.recv() => match sighting {
-                    Some(Sighting { address, rssi }) => {
+                wake = self.sighting_events.recv() => match wake {
+                    Some(()) => {
+                        let Some(Sighting { address, rssi }) = self.pop_sighting() else {
+                            continue;
+                        };
                         crate::diagnostic_log::debug!(
                             "bluetooth: sighted Prns peer {:02x?} rssi={rssi:?}",
                             address.octets()
@@ -681,18 +932,29 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
     }
 
     async fn dial(&mut self, address: BleAddress) -> DialOutcome {
+        if !self.radio_enabled.load(Ordering::Acquire) {
+            return DialOutcome::RadioOff;
+        }
         let token = *address.octets();
-        let Some((peer_id, peripheral, peer_rssi)) = self.peripherals.lock().ok().and_then(|map| {
-            map.iter()
-                .find(|(peer_id, _)| peer_id.address().octets() == &token)
-                .map(|(peer_id, (peripheral, rssi))| (*peer_id, peripheral.0.clone(), *rssi))
-        }) else {
-            crate::diagnostic_log::warn!(
-                "bluetooth: dial to {token:02x?} — peripheral not yet sighted"
-            );
-            self.dials
-                .spawn(async move { DialTaskOutcome::Failed { address } });
-            return DialOutcome::Started;
+        let candidate = self.claim(address);
+        let (peer_id, peripheral, peer_rssi, restored_connection) = match candidate {
+            CentralDialCandidate::Ready {
+                peer_id,
+                peripheral,
+                rssi,
+                restored,
+            } => (peer_id, peripheral, rssi, restored),
+            CentralDialCandidate::Busy => {
+                self.dial_failures.insert(address);
+                return DialOutcome::Started;
+            }
+            CentralDialCandidate::Missing => {
+                crate::diagnostic_log::warn!(
+                    "bluetooth: dial to {token:02x?} — peripheral not yet sighted"
+                );
+                self.dial_failures.insert(address);
+                return DialOutcome::Started;
+            }
         };
         let (control_tx, control_rx) =
             tokio_mpsc::channel::<Control>(CENTRAL_CONTROL_INBOUND_CAPACITY);
@@ -701,39 +963,47 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
         let command = DialCommand {
             central: self.central.0.clone(),
             delegate: self.central_delegate.0.clone(),
-            peripheral: peripheral.clone(),
+            peripheral: peripheral.0.clone(),
             peer_id,
             session: CentralPeerSession::new(address, control_tx, completion_tx, data_inbound_tx),
         };
-        let restored_connection = self.restored_connections.remove(&peer_id);
         crate::diagnostic_log::debug!("bluetooth: dialing {token:02x?} over LE (central role)");
         let peripheral_for_admission = SendPeripheralDelegate(self.peripheral_delegate.0.clone());
         self.queue.exec_async(move || {
             let target_has_inbound_session = peripheral_for_admission.has_inbound_session(peer_id);
             begin_dial(command, target_has_inbound_session, restored_connection);
         });
-        let send_peripheral = SendPeripheral(peripheral);
+        let send_peripheral = peripheral;
         let send_peripheral_manager = SendPeripheralDelegate(self.peripheral_delegate.0.clone());
-        let central = SendCentralManager(self.central.0.clone());
         let delegate = SendCentralDelegate(self.central_delegate.0.clone());
         let queue = self.queue.clone();
         self.dials.spawn(async move {
             let chars = match tokio::time::timeout(DIAL_TIMEOUT, completion_rx).await {
                 Ok(Ok(DialCompletion::Ready(chars))) => chars,
-                Ok(Ok(DialCompletion::Rejected)) => {
+                Ok(Ok(DialCompletion::Rejected(rejection))) => {
+                    crate::diagnostic_log::debug!(
+                        "bluetooth: dial to {token:02x?} rejected: {rejection:?}"
+                    );
                     return DialTaskOutcome::Failed { address };
                 }
-                Ok(Ok(DialCompletion::Failed)) | Ok(Err(_)) | Err(_) => {
+                Ok(Ok(DialCompletion::Failed)) => {
                     crate::diagnostic_log::warn!(
                         "bluetooth: dial to {token:02x?} did not reach control-ready"
                     );
-                    queue.exec_async(move || {
-                        let central = central;
-                        let delegate = delegate;
-                        let peripheral = send_peripheral;
-                        delegate.0.remove_session(peer_id);
-                        cancel_connection(&central, &peripheral);
-                    });
+                    return DialTaskOutcome::Failed { address };
+                }
+                Ok(Err(_)) => {
+                    crate::diagnostic_log::warn!(
+                        "bluetooth: dial to {token:02x?} closed before reaching control-ready"
+                    );
+                    schedule_failed_dial_cleanup(&queue, &delegate, peer_id);
+                    return DialTaskOutcome::Failed { address };
+                }
+                Err(_) => {
+                    crate::diagnostic_log::warn!(
+                        "bluetooth: dial to {token:02x?} timed out before reaching control-ready"
+                    );
+                    schedule_failed_dial_cleanup(&queue, &delegate, peer_id);
                     return DialTaskOutcome::Failed { address };
                 }
             };
@@ -762,25 +1032,32 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
     }
 
     async fn on_link_closed(&mut self, address: BleAddress) {
-        let token = *address.octets();
-        if let Some((peer_id, peripheral)) = self.peripherals.lock().ok().and_then(|map| {
-            map.iter()
-                .find(|(peer_id, _)| peer_id.address().octets() == &token)
-                .map(|(peer_id, (peripheral, _))| (*peer_id, peripheral.0.clone()))
-        }) {
-            let peripheral = SendPeripheral(peripheral);
-            let central = SendCentralManager(self.central.0.clone());
-            let delegate = SendCentralDelegate(self.central_delegate.0.clone());
-            self.queue.exec_async(move || {
-                let central = central;
-                let delegate = delegate;
-                let peripheral = peripheral;
-                if delegate.0.remove_closed_session(peer_id) {
-                    cancel_connection(&central, &peripheral);
-                }
-            });
-        }
+        let central = SendCentralManager(self.central.0.clone());
+        let delegate = SendCentralDelegate(self.central_delegate.0.clone());
+        self.queue.exec_async(move || {
+            let central = central;
+            let delegate = delegate;
+            delegate.0.reap_closed_sessions(&central.0);
+        });
         self.peripheral_delegate.0.clear_closed_peer(address);
+    }
+}
+
+impl Drop for MacosBleBackend {
+    fn drop(&mut self) {
+        // Drop can run from an arbitrary Tokio or CoreBluetooth-adjacent thread. Close callback
+        // ingress immediately, abort owned tasks, and enqueue retained cleanup without synchronously
+        // entering the serial dispatch queue.
+        self.radio_enabled.store(false, Ordering::Release);
+        self.dials.abort_all();
+        enqueue_radio_transition(
+            &self.queue,
+            &self.central,
+            &self.central_delegate,
+            &self.peripheral_delegate,
+            false,
+            None,
+        );
     }
 }
 

--- a/prns-ffi/src/bluetooth_auto/macos/backend.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/backend.rs
@@ -275,7 +275,7 @@ enum ManagerPreparation {
     RestorationAware(CoreBluetoothRestorationIdentifiers),
     #[cfg(not(target_os = "ios"))]
     PlatformDefault,
-    ForegroundOnly,
+    WithoutRestoration,
 }
 
 impl ManagerPreparation {
@@ -283,7 +283,7 @@ impl ManagerPreparation {
     fn restoration_identifiers(&self) -> Option<&CoreBluetoothRestorationIdentifiers> {
         match self {
             Self::RestorationAware(identifiers) => Some(identifiers),
-            Self::ForegroundOnly => None,
+            Self::WithoutRestoration => None,
         }
     }
 }
@@ -297,8 +297,8 @@ impl MacosBleBackend {
     /// Creates CoreBluetooth managers with the existing iOS restoration identifiers.
     ///
     /// Applications using this path are responsible for the matching background modes and
-    /// restoration lifecycle. Use [`Self::prepare_foreground`] when the owner intentionally has no
-    /// CoreBluetooth state-restoration contract.
+    /// restoration lifecycle. Use [`Self::prepare_without_restoration`] when the owner
+    /// intentionally has no CoreBluetooth state-restoration contract.
     pub async fn prepare(identity: BleIdentity) -> Result<PreparedMacosBleBackend, MacosBleError> {
         #[cfg(target_os = "ios")]
         let manager_preparation =
@@ -325,10 +325,10 @@ impl MacosBleBackend {
     ///
     /// Central and peripheral operation remain available while the application is running, but
     /// CoreBluetooth will not preserve or restore these managers after process termination.
-    pub async fn prepare_foreground(
+    pub async fn prepare_without_restoration(
         identity: BleIdentity,
     ) -> Result<PreparedMacosBleBackend, MacosBleError> {
-        Self::prepare_with(identity, ManagerPreparation::ForegroundOnly).await
+        Self::prepare_with(identity, ManagerPreparation::WithoutRestoration).await
     }
 
     async fn prepare_with(
@@ -739,9 +739,9 @@ mod native_thread_tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn foreground_preparation_is_distinct_from_the_platform_default() {
+    fn preparation_without_restoration_is_distinct_from_the_platform_default() {
         assert_ne!(
-            ManagerPreparation::ForegroundOnly,
+            ManagerPreparation::WithoutRestoration,
             ManagerPreparation::PlatformDefault
         );
     }

--- a/prns-ffi/src/bluetooth_auto/macos/backend.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/backend.rs
@@ -23,7 +23,7 @@ use prns_core::interfaces::bluetooth_auto::{BleAddress, BleIdentity, Control, Ps
 
 use super::central::{
     discover_prns_services, is_system_connected, CentralDelegate, CentralPeerSession, DialCommand,
-    DialCompletion,
+    DialCompletion, CENTRAL_CONTROL_INBOUND_CAPACITY,
 };
 use super::gatt_link::{gatt_inbound_channel, ControlPlane, GattLink};
 use super::peripheral::PeripheralDelegate;
@@ -193,6 +193,7 @@ fn begin_dial(command: DialCommand, target_has_inbound_session: bool, restored_c
                 "bluetooth: yielding dial to {:02x?} — peer is already connected system-wide outside this manager's restored state",
                 peer_id.address().octets()
             );
+            delegate.discard_restored_callbacks(peer_id);
             session.reject();
             return;
         }
@@ -201,6 +202,7 @@ fn begin_dial(command: DialCommand, target_has_inbound_session: bool, restored_c
                 "bluetooth: yielding dial to {:02x?} — this peer already owns an inbound peripheral session",
                 peer_id.address().octets()
             );
+            delegate.discard_restored_callbacks(peer_id);
             session.reject();
             return;
         }
@@ -669,7 +671,8 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
                 .spawn(async move { DialTaskOutcome::Failed { address } });
             return DialOutcome::Started;
         };
-        let (control_tx, control_rx) = tokio_mpsc::channel::<Control>(8);
+        let (control_tx, control_rx) =
+            tokio_mpsc::channel::<Control>(CENTRAL_CONTROL_INBOUND_CAPACITY);
         let (completion_tx, completion_rx) = oneshot::channel::<DialCompletion>();
         let (data_inbound_tx, data_inbound_rx) = gatt_inbound_channel();
         let command = DialCommand {

--- a/prns-ffi/src/bluetooth_auto/macos/backend.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/backend.rs
@@ -22,7 +22,8 @@ use prns_core::interfaces::bluetooth_auto::{
 use prns_core::interfaces::bluetooth_auto::{BleAddress, BleIdentity, Control, Psm};
 
 use super::central::{
-    is_system_connected, CentralDelegate, CentralPeerSession, DialCommand, DialCompletion,
+    discover_prns_services, is_system_connected, CentralDelegate, CentralPeerSession, DialCommand,
+    DialCompletion,
 };
 use super::gatt_link::{gatt_inbound_channel, ControlPlane, GattLink};
 use super::peripheral::PeripheralDelegate;
@@ -32,8 +33,8 @@ use super::{
     CoreBluetoothRestorationIdentifiers,
 };
 use super::{
-    start_scan, Event, MacosBleError, PeripheralTable, RestoredPeripherals, SendCentralDelegate,
-    SendCentralManager, SendPeripheral, SendPeripheralDelegate,
+    start_scan, CoreBluetoothPeerId, Event, MacosBleError, PeripheralTable, RestoredPeripherals,
+    SendCentralDelegate, SendCentralManager, SendPeripheral, SendPeripheralDelegate,
 };
 
 const POWER_ON_TIMEOUT: Duration = Duration::from_secs(10);
@@ -114,6 +115,9 @@ impl StartupReadiness {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum DialAdmission {
     AttachCentralSession,
+    /// CoreBluetooth restored this central-role connection for the application. Reattach the
+    /// delegate and session, then resume discovery without issuing another connection request.
+    ResumeRestoredSession,
     YieldToSystemConnection,
     /// The target peer already owns an inbound peripheral session. Dialing that same peer as a
     /// central would create the dual-role link that handshake policy is trying to eliminate.
@@ -123,11 +127,16 @@ pub(super) enum DialAdmission {
 pub(super) const fn dial_admission(
     already_system_connected: bool,
     target_has_inbound_session: bool,
+    restored_connection: bool,
 ) -> DialAdmission {
-    if already_system_connected {
-        DialAdmission::YieldToSystemConnection
-    } else if target_has_inbound_session {
+    if target_has_inbound_session {
         DialAdmission::YieldToInboundSession
+    } else if already_system_connected {
+        if restored_connection {
+            DialAdmission::ResumeRestoredSession
+        } else {
+            DialAdmission::YieldToSystemConnection
+        }
     } else {
         DialAdmission::AttachCentralSession
     }
@@ -165,7 +174,7 @@ fn apply_scanning(central: SendCentralManager, enabled: bool, restart: bool) {
     }
 }
 
-fn begin_dial(command: DialCommand, target_has_inbound_session: bool) {
+fn begin_dial(command: DialCommand, target_has_inbound_session: bool, restored_connection: bool) {
     let DialCommand {
         central,
         delegate,
@@ -173,13 +182,15 @@ fn begin_dial(command: DialCommand, target_has_inbound_session: bool) {
         peer_id,
         session,
     } = command;
-    match dial_admission(
+    let admission = dial_admission(
         is_system_connected(&central, peer_id),
         target_has_inbound_session,
-    ) {
+        restored_connection,
+    );
+    let resume_restored = match admission {
         DialAdmission::YieldToSystemConnection => {
             crate::diagnostic_log::debug!(
-                "bluetooth: yielding dial to {:02x?} — peer is already connected system-wide; inbound session retains connection ownership",
+                "bluetooth: yielding dial to {:02x?} — peer is already connected system-wide outside this manager's restored state",
                 peer_id.address().octets()
             );
             session.reject();
@@ -193,8 +204,9 @@ fn begin_dial(command: DialCommand, target_has_inbound_session: bool) {
             session.reject();
             return;
         }
-        DialAdmission::AttachCentralSession => {}
-    }
+        DialAdmission::AttachCentralSession => false,
+        DialAdmission::ResumeRestoredSession => true,
+    };
     // SAFETY: both retained Objective-C objects stay alive for the delegate assignment, which runs
     // on the CoreBluetooth serial dispatch queue.
     unsafe {
@@ -203,9 +215,17 @@ fn begin_dial(command: DialCommand, target_has_inbound_session: bool) {
     if !delegate.begin_session(peer_id, session) {
         return;
     }
-    // SAFETY: the retained manager and peripheral are owned by this queue-confined command, and
-    // CoreBluetooth connection calls are serialized on their dispatch queue.
-    unsafe { central.connectPeripheral_options(&peripheral, None) };
+    if resume_restored {
+        crate::diagnostic_log::debug!(
+            "bluetooth: resumed restored connection to {:02x?}, discovering Prns service",
+            peer_id.address().octets()
+        );
+        discover_prns_services(&peripheral);
+    } else {
+        // SAFETY: the retained manager and peripheral are owned by this queue-confined command,
+        // and CoreBluetooth connection calls are serialized on their dispatch queue.
+        unsafe { central.connectPeripheral_options(&peripheral, None) };
+    }
 }
 
 struct Handles {
@@ -235,6 +255,9 @@ pub struct MacosBleBackend {
     peripheral_delegate: SendPeripheralDelegate,
     peripherals: PeripheralTable,
     restored: RestoredPeripherals,
+    /// Restored peers whose synthesized sighting has been handed to the Host. The first dial
+    /// consumes the marker so later system-owned connections keep the ordinary admission policy.
+    restored_connections: HashSet<CoreBluetoothPeerId>,
     dials: JoinSet<DialTaskOutcome>,
     queue: DispatchRetained<DispatchQueue>,
     scan_enabled: bool,
@@ -518,6 +541,7 @@ impl PreparedMacosBleBackend {
             peripheral_delegate,
             peripherals: self.peripherals,
             restored: self.restored,
+            restored_connections: HashSet::new(),
             dials: JoinSet::new(),
             queue,
             scan_enabled: false,
@@ -560,6 +584,7 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
                 .ok()
                 .and_then(|mut queue| queue.pop_front())
             {
+                self.restored_connections.insert(peer_id);
                 return BleEvent::Sighting {
                     address: peer_id.address(),
                     rssi: None,
@@ -654,11 +679,12 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
             peer_id,
             session: CentralPeerSession::new(address, control_tx, completion_tx, data_inbound_tx),
         };
+        let restored_connection = self.restored_connections.remove(&peer_id);
         crate::diagnostic_log::debug!("bluetooth: dialing {token:02x?} over LE (central role)");
         let peripheral_for_admission = SendPeripheralDelegate(self.peripheral_delegate.0.clone());
         self.queue.exec_async(move || {
             let target_has_inbound_session = peripheral_for_admission.has_inbound_session(peer_id);
-            begin_dial(command, target_has_inbound_session);
+            begin_dial(command, target_has_inbound_session, restored_connection);
         });
         let send_peripheral = SendPeripheral(peripheral);
         let send_peripheral_manager = SendPeripheralDelegate(self.peripheral_delegate.0.clone());

--- a/prns-ffi/src/bluetooth_auto/macos/backend.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/backend.rs
@@ -27,7 +27,10 @@ use super::central::{
 use super::gatt_link::{gatt_inbound_channel, ControlPlane, GattLink};
 use super::peripheral::PeripheralDelegate;
 #[cfg(target_os = "ios")]
-use super::{central_manager_options, peripheral_manager_options};
+use super::{
+    central_manager_options, legacy_restoration_identifiers, peripheral_manager_options,
+    CoreBluetoothRestorationIdentifiers,
+};
 use super::{
     start_scan, Event, MacosBleError, PeripheralTable, RestoredPeripherals, SendCentralDelegate,
     SendCentralManager, SendPeripheral, SendPeripheralDelegate,
@@ -266,15 +269,22 @@ pub struct PreparedMacosBleBackend {
     handles: Handles,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 enum ManagerPreparation {
-    RestorationAware,
+    #[cfg(target_os = "ios")]
+    RestorationAware(CoreBluetoothRestorationIdentifiers),
+    #[cfg(not(target_os = "ios"))]
+    PlatformDefault,
     ForegroundOnly,
 }
 
 impl ManagerPreparation {
-    const fn uses_state_restoration(self) -> bool {
-        matches!(self, Self::RestorationAware)
+    #[cfg(target_os = "ios")]
+    fn restoration_identifiers(&self) -> Option<&CoreBluetoothRestorationIdentifiers> {
+        match self {
+            Self::RestorationAware(identifiers) => Some(identifiers),
+            Self::ForegroundOnly => None,
+        }
     }
 }
 
@@ -290,7 +300,25 @@ impl MacosBleBackend {
     /// restoration lifecycle. Use [`Self::prepare_foreground`] when the owner intentionally has no
     /// CoreBluetooth state-restoration contract.
     pub async fn prepare(identity: BleIdentity) -> Result<PreparedMacosBleBackend, MacosBleError> {
-        Self::prepare_with(identity, ManagerPreparation::RestorationAware).await
+        #[cfg(target_os = "ios")]
+        let manager_preparation =
+            ManagerPreparation::RestorationAware(legacy_restoration_identifiers());
+        #[cfg(not(target_os = "ios"))]
+        let manager_preparation = ManagerPreparation::PlatformDefault;
+        Self::prepare_with(identity, manager_preparation).await
+    }
+
+    /// Creates CoreBluetooth managers with stable restoration identifiers supplied by the
+    /// application that owns their lifecycle.
+    ///
+    /// The containing application must declare both matching CoreBluetooth background modes and
+    /// recreate the managers with these exact identifiers during an iOS restoration launch.
+    #[cfg(target_os = "ios")]
+    pub async fn prepare_with_restoration(
+        identity: BleIdentity,
+        identifiers: CoreBluetoothRestorationIdentifiers,
+    ) -> Result<PreparedMacosBleBackend, MacosBleError> {
+        Self::prepare_with(identity, ManagerPreparation::RestorationAware(identifiers)).await
     }
 
     /// Creates CoreBluetooth managers without opting into iOS state restoration.
@@ -307,9 +335,10 @@ impl MacosBleBackend {
         identity: BleIdentity,
         manager_preparation: ManagerPreparation,
     ) -> Result<PreparedMacosBleBackend, MacosBleError> {
-        let uses_state_restoration = manager_preparation.uses_state_restoration();
+        #[cfg(target_os = "ios")]
+        let restoration_identifiers = manager_preparation.restoration_identifiers().cloned();
         #[cfg(not(target_os = "ios"))]
-        let _ = uses_state_restoration;
+        let _ = manager_preparation;
         let (events_tx, events_rx) = tokio_mpsc::unbounded_channel::<Event>();
         let (keepalive, shutdown_rx) = sync_mpsc::channel::<()>();
         let (handles_tx, handles_rx) = oneshot::channel::<Handles>();
@@ -334,7 +363,9 @@ impl MacosBleBackend {
                 );
                 let central_proto = ProtocolObject::from_ref(&*central_delegate);
                 #[cfg(target_os = "ios")]
-                let central_options = uses_state_restoration.then(central_manager_options);
+                let central_options = restoration_identifiers
+                    .as_ref()
+                    .map(|identifiers| central_manager_options(identifiers.central()));
                 #[cfg(not(target_os = "ios"))]
                 let central_options: Option<
                     Retained<NSDictionary<NSString, AnyObject>>,
@@ -354,7 +385,9 @@ impl MacosBleBackend {
                     PeripheralDelegate::new(events_tx, queue.clone(), identity);
                 let peripheral_proto = ProtocolObject::from_ref(&*peripheral_delegate);
                 #[cfg(target_os = "ios")]
-                let peripheral_options = uses_state_restoration.then(peripheral_manager_options);
+                let peripheral_options = restoration_identifiers
+                    .as_ref()
+                    .map(|identifiers| peripheral_manager_options(identifiers.peripheral()));
                 #[cfg(not(target_os = "ios"))]
                 let peripheral_options: Option<
                     Retained<NSDictionary<NSString, AnyObject>>,
@@ -705,9 +738,11 @@ mod native_thread_tests {
     use std::sync::atomic::{AtomicBool, Ordering};
 
     #[test]
-    fn foreground_preparation_does_not_request_state_restoration() {
-        assert!(!ManagerPreparation::ForegroundOnly.uses_state_restoration());
-        assert!(ManagerPreparation::RestorationAware.uses_state_restoration());
+    fn foreground_preparation_is_distinct_from_the_platform_default() {
+        assert_ne!(
+            ManagerPreparation::ForegroundOnly,
+            ManagerPreparation::PlatformDefault
+        );
     }
 
     #[test]

--- a/prns-ffi/src/bluetooth_auto/macos/backend.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/backend.rs
@@ -125,6 +125,18 @@ pub(super) enum ScanOp {
     None,
 }
 
+impl ScanOp {
+    pub(super) const fn diagnostic_label(self, enabled: bool) -> &'static str {
+        match self {
+            Self::Start => "bluetooth: scan decision start",
+            Self::Restart => "bluetooth: scan decision restart",
+            Self::Stop => "bluetooth: scan decision stop",
+            Self::None if enabled => "bluetooth: scan decision already scanning",
+            Self::None => "bluetooth: scan decision already stopped",
+        }
+    }
+}
+
 pub(super) const fn scan_op(enabled: bool, is_scanning: bool, restart: bool) -> ScanOp {
     if enabled {
         if is_scanning {
@@ -284,10 +296,13 @@ fn schedule_failed_dial_cleanup(
 }
 
 fn apply_scanning(central: SendCentralManager, enabled: bool, restart: bool) {
+    crate::diagnostic_log::debug!("bluetooth: querying scan state");
     // SAFETY: this authoritative CoreBluetooth state query runs on the retained manager's
     // serial dispatch queue.
     let is_scanning = unsafe { central.0.isScanning() };
-    match scan_op(enabled, is_scanning, restart) {
+    let operation = scan_op(enabled, is_scanning, restart);
+    crate::diagnostic_log::debug!("{}", operation.diagnostic_label(enabled));
+    match operation {
         ScanOp::Restart => {
             // SAFETY: the retained central manager is only messaged on its serial dispatch queue.
             unsafe { central.0.stopScan() };
@@ -1053,6 +1068,11 @@ impl BleBackend<{ MAX_PEERS }> for CoreBluetoothBackend {
     }
 
     async fn set_scanning(&mut self, mode: ScanningMode) -> Result<(), MacosBleError> {
+        if mode.is_on() {
+            crate::diagnostic_log::debug!("bluetooth: scanning requested on");
+        } else {
+            crate::diagnostic_log::debug!("bluetooth: scanning requested off");
+        }
         self.scan_enabled = mode.is_on();
         self.scan_activity.store(false, Ordering::Relaxed);
         self.scan_liveness_at = tokio::time::Instant::now() + RADIO_LIVENESS_INTERVAL;
@@ -1060,7 +1080,9 @@ impl BleBackend<{ MAX_PEERS }> for CoreBluetoothBackend {
         let central = SendCentralManager(self.central.0.clone());
         let radio_enabled = Arc::clone(&self.radio_enabled);
         self.queue.exec_async(move || {
+            crate::diagnostic_log::debug!("bluetooth: scan job started");
             if mode.is_on() && !radio_enabled.load(Ordering::Acquire) {
+                crate::diagnostic_log::debug!("bluetooth: scan job skipped radio disabled");
                 return;
             }
             apply_scanning(central, mode.is_on(), restart);

--- a/prns-ffi/src/bluetooth_auto/macos/backend.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/backend.rs
@@ -13,7 +13,7 @@ use objc2::AnyThread;
 use objc2_core_bluetooth::{CBCentralManager, CBPeripheralManager};
 #[cfg(not(target_os = "ios"))]
 use objc2_foundation::{NSDictionary, NSString};
-use tokio::sync::{mpsc as tokio_mpsc, oneshot};
+use tokio::sync::{mpsc as tokio_mpsc, oneshot, watch};
 use tokio::task::JoinSet;
 
 use prns_core::interfaces::bluetooth_auto::{
@@ -33,8 +33,9 @@ use super::{
     CoreBluetoothRestorationIdentifiers,
 };
 use super::{
-    start_scan, CoreBluetoothPeerId, Event, MacosBleError, PeripheralTable, RestoredPeripherals,
-    SendCentralDelegate, SendCentralManager, SendPeripheral, SendPeripheralDelegate,
+    manager_signal_channel, start_scan, CoreBluetoothPeerId, L2capPublicationState, MacosBleError,
+    ManagerSignals, PeripheralTable, PublicationState, RestoredPeripherals, SendCentralDelegate,
+    SendCentralManager, SendPeripheral, SendPeripheralDelegate, Sighting,
 };
 
 const POWER_ON_TIMEOUT: Duration = Duration::from_secs(10);
@@ -42,7 +43,7 @@ const DIAL_TIMEOUT: Duration = Duration::from_secs(15);
 /// Maximum recovery latency for a CoreBluetooth scan that claims to be active but has stopped
 /// delivering callbacks. Any discovery callback renews the scan lease without touching the radio.
 const RADIO_LIVENESS_INTERVAL: Duration = Duration::from_secs(60);
-const STARTUP_SIGHTINGS_PER_PEER: usize = 4;
+const SIGHTING_INGRESS_PER_PEER: usize = 4;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum ScanLease {
@@ -85,149 +86,34 @@ pub(super) const fn scan_op(enabled: bool, is_scanning: bool, restart: bool) -> 
     }
 }
 
-#[derive(Default)]
-pub(super) struct StartupReadiness {
-    central_powered: bool,
-    gatt_service_published: bool,
-    l2cap_psm: Option<Psm>,
+pub(super) fn manager_readiness(signals: ManagerSignals) -> Result<Option<Psm>, MacosBleError> {
+    if signals.gatt == PublicationState::Failed {
+        crate::diagnostic_log::error!("bluetooth: GATT service publication failed at startup");
+        return Err(MacosBleError::PublishFailed);
+    }
+    if signals.l2cap == L2capPublicationState::Failed {
+        crate::diagnostic_log::error!("bluetooth: L2CAP publication failed at startup");
+        return Err(MacosBleError::PublishFailed);
+    }
+    let L2capPublicationState::Published(psm) = signals.l2cap else {
+        return Ok(None);
+    };
+    if signals.central_powered_generation == 0 || signals.gatt != PublicationState::Published {
+        return Ok(None);
+    }
+    Ok(Some(Psm::new(psm).ok_or(MacosBleError::PublishFailed)?))
 }
 
-impl StartupReadiness {
-    pub(super) fn note_central_powered(&mut self) {
-        self.central_powered = true;
-    }
-
-    pub(super) fn note_gatt_service_published(&mut self) {
-        self.gatt_service_published = true;
-    }
-
-    pub(super) fn note_l2cap_published(&mut self, psm: u16) -> Result<(), MacosBleError> {
-        self.l2cap_psm = Some(Psm::new(psm).ok_or(MacosBleError::PublishFailed)?);
-        Ok(())
-    }
-
-    pub(super) fn ready_psm(&self) -> Option<Psm> {
-        (self.central_powered && self.gatt_service_published)
-            .then_some(self.l2cap_psm)
-            .flatten()
-    }
-}
-
-pub(super) struct StartupBacklog<L> {
-    inbound: VecDeque<L>,
-    sightings: VecDeque<(BleAddress, Option<i8>)>,
-}
-
-impl<L> Default for StartupBacklog<L> {
-    fn default() -> Self {
-        Self {
-            inbound: VecDeque::new(),
-            sightings: VecDeque::new(),
+async fn wait_for_readiness(
+    signals: &mut watch::Receiver<ManagerSignals>,
+) -> Result<(Psm, u64), MacosBleError> {
+    loop {
+        let current = *signals.borrow_and_update();
+        if let Some(psm) = manager_readiness(current)? {
+            return Ok((psm, current.central_powered_generation));
         }
+        signals.changed().await.map_err(|_| MacosBleError::Closed)?;
     }
-}
-
-impl<L> StartupBacklog<L> {
-    fn push_inbound(&mut self, link: L, capacity: usize) -> Option<L> {
-        if self.inbound.len() >= capacity {
-            Some(link)
-        } else {
-            self.inbound.push_back(link);
-            None
-        }
-    }
-
-    fn note_sighting(
-        &mut self,
-        address: BleAddress,
-        rssi: Option<i8>,
-        capacity: usize,
-    ) -> Option<(BleAddress, Option<i8>)> {
-        if let Some(position) = self
-            .sightings
-            .iter()
-            .position(|(observed, _)| *observed == address)
-        {
-            self.sightings.remove(position);
-            self.sightings.push_back((address, rssi));
-            return None;
-        }
-        let evicted = if self.sightings.len() >= capacity {
-            self.sightings.pop_front()
-        } else {
-            None
-        };
-        if capacity > 0 {
-            self.sightings.push_back((address, rssi));
-        }
-        evicted
-    }
-
-    pub(super) fn pop_inbound(&mut self) -> Option<L> {
-        self.inbound.pop_front()
-    }
-
-    pub(super) fn pop_sighting(&mut self) -> Option<(BleAddress, Option<i8>)> {
-        self.sightings.pop_front()
-    }
-}
-
-pub(super) fn pop_unseen_startup_sighting<L>(
-    backlog: &mut StartupBacklog<L>,
-    seen: &mut HashSet<[u8; 6]>,
-) -> Option<BleAddress> {
-    while let Some((address, _)) = backlog.pop_sighting() {
-        if seen.insert(*address.octets()) {
-            return Some(address);
-        }
-    }
-    None
-}
-
-pub(super) enum StartupProgress<L> {
-    Waiting,
-    Ready(Psm),
-    InboundOverflow(L),
-    SightingEvicted {
-        address: BleAddress,
-        rssi: Option<i8>,
-    },
-}
-
-pub(super) fn stage_startup_event<L>(
-    readiness: &mut StartupReadiness,
-    backlog: &mut StartupBacklog<L>,
-    event: Event<L>,
-    inbound_capacity: usize,
-    sighting_capacity: usize,
-) -> Result<StartupProgress<L>, MacosBleError> {
-    match event {
-        Event::CentralPowered => readiness.note_central_powered(),
-        Event::GattServicePublished => readiness.note_gatt_service_published(),
-        Event::L2capPublished { psm } => readiness.note_l2cap_published(psm)?,
-        Event::GattServicePublishFailed => {
-            crate::diagnostic_log::error!("bluetooth: GATT service publication failed at startup");
-            return Err(MacosBleError::PublishFailed);
-        }
-        Event::L2capPublishFailed => {
-            crate::diagnostic_log::error!("bluetooth: L2CAP publication failed at startup");
-            return Err(MacosBleError::PublishFailed);
-        }
-        Event::Inbound(link) => {
-            if let Some(link) = backlog.push_inbound(link, inbound_capacity) {
-                return Ok(StartupProgress::InboundOverflow(link));
-            }
-        }
-        Event::Sighting { address, rssi } => {
-            if let Some((address, rssi)) = backlog.note_sighting(address, rssi, sighting_capacity) {
-                return Ok(StartupProgress::SightingEvicted { address, rssi });
-            }
-        }
-    }
-    Ok(match readiness.ready_psm() {
-        Some(psm) => StartupProgress::Ready(psm),
-        None => StartupProgress::Waiting,
-    })
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -264,18 +150,6 @@ fn cancel_connection(central: &SendCentralManager, peripheral: &SendPeripheral) 
     // SAFETY: both retained objects remain alive through this call and are messaged only on the
     // CoreBluetooth serial dispatch queue.
     unsafe { central.0.cancelPeripheralConnection(&peripheral.0) };
-}
-
-fn close_overflow_inbound(delegate: &SendPeripheralDelegate, link: GattLink) {
-    let address = link.address;
-    crate::diagnostic_log::warn!(
-        "bluetooth: rejecting pre-ready inbound link from {:02x?} — startup queue is full",
-        address.octets()
-    );
-    // Dropping both receivers marks the queue-confined peripheral session closed; its delegate
-    // then removes that session and any pending L2CAP channel state.
-    drop(link);
-    delegate.0.clear_closed_peer(address);
 }
 
 fn apply_scanning(central: SendCentralManager, enabled: bool, restart: bool) {
@@ -379,7 +253,11 @@ enum DialTaskOutcome {
 
 pub struct MacosBleBackend {
     _native_thread: NativeThread,
-    events: tokio_mpsc::UnboundedReceiver<Event>,
+    manager_signals: watch::Receiver<ManagerSignals>,
+    manager_signals_open: bool,
+    central_powered_generation: u64,
+    inbound: tokio_mpsc::Receiver<GattLink>,
+    sightings: tokio_mpsc::Receiver<Sighting>,
     psm: Psm,
     seen: HashSet<[u8; 6]>,
     central: SendCentralManager,
@@ -390,7 +268,6 @@ pub struct MacosBleBackend {
     /// Restored peers whose synthesized sighting has been handed to the Host. The first dial
     /// consumes the marker so later system-owned connections keep the ordinary admission policy.
     restored_connections: HashSet<CoreBluetoothPeerId>,
-    startup_backlog: StartupBacklog<GattLink>,
     dials: JoinSet<DialTaskOutcome>,
     queue: DispatchRetained<DispatchQueue>,
     scan_enabled: bool,
@@ -418,7 +295,9 @@ impl Drop for NativeThread {
 /// authorization, service publication, and L2CAP readiness remain asynchronous.
 pub struct PreparedMacosBleBackend {
     native_thread: NativeThread,
-    events: tokio_mpsc::UnboundedReceiver<Event>,
+    manager_signals: watch::Receiver<ManagerSignals>,
+    inbound: tokio_mpsc::Receiver<GattLink>,
+    sightings: tokio_mpsc::Receiver<Sighting>,
     peripherals: PeripheralTable,
     restored: RestoredPeripherals,
     scan_activity: Arc<AtomicBool>,
@@ -495,13 +374,16 @@ impl MacosBleBackend {
         let restoration_identifiers = manager_preparation.restoration_identifiers().cloned();
         #[cfg(not(target_os = "ios"))]
         let _ = manager_preparation;
-        let (events_tx, events_rx) = tokio_mpsc::unbounded_channel::<Event>();
+        let (manager_signals_tx, manager_signals_rx) = manager_signal_channel();
+        let (inbound_tx, inbound_rx) = tokio_mpsc::channel::<GattLink>(Self::MAX_PEERS);
+        let (sightings_tx, sightings_rx) =
+            tokio_mpsc::channel::<Sighting>(Self::MAX_PEERS * SIGHTING_INGRESS_PER_PEER);
         let (keepalive, shutdown_rx) = sync_mpsc::channel::<()>();
         let (handles_tx, handles_rx) = oneshot::channel::<Handles>();
         let peripherals: PeripheralTable = Arc::new(Mutex::new(HashMap::new()));
         let restored: RestoredPeripherals = Arc::new(Mutex::new(VecDeque::new()));
         let scan_activity = Arc::new(AtomicBool::new(false));
-        let central_events = events_tx.clone();
+        let central_manager_signals = manager_signals_tx.clone();
         let peripherals_for_thread = peripherals.clone();
         let restored_for_thread = restored.clone();
         let scan_activity_for_thread = Arc::clone(&scan_activity);
@@ -512,7 +394,8 @@ impl MacosBleBackend {
                 let queue = DispatchQueue::new("com.personal.prns.ble", None);
 
                 let central_delegate = CentralDelegate::new(
-                    central_events,
+                    central_manager_signals,
+                    sightings_tx,
                     peripherals_for_thread,
                     restored_for_thread,
                     scan_activity_for_thread,
@@ -537,8 +420,12 @@ impl MacosBleBackend {
                     )
                 };
 
-                let peripheral_delegate =
-                    PeripheralDelegate::new(events_tx, queue.clone(), identity);
+                let peripheral_delegate = PeripheralDelegate::new(
+                    manager_signals_tx,
+                    inbound_tx,
+                    queue.clone(),
+                    identity,
+                );
                 let peripheral_proto = ProtocolObject::from_ref(&*peripheral_delegate);
                 #[cfg(target_os = "ios")]
                 let peripheral_options = restoration_identifiers
@@ -580,7 +467,9 @@ impl MacosBleBackend {
         // callers use `ready` after installing the rest of their lifecycle supervision.
         Ok(PreparedMacosBleBackend {
             native_thread,
-            events: events_rx,
+            manager_signals: manager_signals_rx,
+            inbound: inbound_rx,
+            sightings: sightings_rx,
             peripherals,
             restored,
             scan_activity,
@@ -596,20 +485,38 @@ impl MacosBleBackend {
         self.psm
     }
 
+    fn reconcile_manager_signals(&mut self) {
+        let generation = self
+            .manager_signals
+            .borrow_and_update()
+            .central_powered_generation;
+        let powered_again = generation != self.central_powered_generation;
+        self.central_powered_generation = generation;
+        if powered_again && self.scan_enabled {
+            let central = SendCentralManager(self.central.0.clone());
+            self.queue.exec_async(move || {
+                apply_scanning(central, true, true);
+            });
+        }
+    }
+
     pub async fn next_sighting(&mut self) -> Option<BleAddress> {
         loop {
-            if let Some(address) =
-                pop_unseen_startup_sighting(&mut self.startup_backlog, &mut self.seen)
-            {
-                return Some(address);
-            }
-            match self.events.recv().await? {
-                Event::Sighting { address, .. } => {
+            tokio::select! {
+                biased;
+                changed = self.manager_signals.changed(), if self.manager_signals_open => {
+                    if changed.is_err() {
+                        self.manager_signals_open = false;
+                    } else {
+                        self.reconcile_manager_signals();
+                    }
+                }
+                sighting = self.sightings.recv() => {
+                    let Sighting { address, .. } = sighting?;
                     if self.seen.insert(*address.octets()) {
                         return Some(address);
                     }
                 }
-                _ => continue,
             }
         }
     }
@@ -623,37 +530,12 @@ impl PreparedMacosBleBackend {
             peripheral_delegate,
             queue,
         } = self.handles;
-        let mut startup_backlog = StartupBacklog::default();
-        let inbound_capacity = MacosBleBackend::MAX_PEERS;
-        let sighting_capacity = inbound_capacity.saturating_mul(STARTUP_SIGHTINGS_PER_PEER);
-
-        let readiness = tokio::time::timeout(POWER_ON_TIMEOUT, async {
-            let mut readiness = StartupReadiness::default();
-            loop {
-                let event = self.events.recv().await.ok_or(MacosBleError::Closed)?;
-                match stage_startup_event(
-                    &mut readiness,
-                    &mut startup_backlog,
-                    event,
-                    inbound_capacity,
-                    sighting_capacity,
-                )? {
-                    StartupProgress::Waiting => {}
-                    StartupProgress::Ready(psm) => return Ok(psm),
-                    StartupProgress::InboundOverflow(link) => {
-                        close_overflow_inbound(&peripheral_delegate, link);
-                    }
-                    StartupProgress::SightingEvicted { address, rssi } => {
-                        crate::diagnostic_log::warn!(
-                            "bluetooth: evicted pre-ready advisory sighting {:02x?} rssi={rssi:?} — startup queue is full",
-                            address.octets()
-                        );
-                    }
-                }
-            }
-        })
+        let readiness = tokio::time::timeout(
+            POWER_ON_TIMEOUT,
+            wait_for_readiness(&mut self.manager_signals),
+        )
         .await;
-        let psm = match readiness {
+        let (psm, central_powered_generation) = match readiness {
             Ok(result) => result?,
             Err(_) => {
                 crate::diagnostic_log::error!(
@@ -668,7 +550,11 @@ impl PreparedMacosBleBackend {
         );
         Ok(MacosBleBackend {
             _native_thread: self.native_thread,
-            events: self.events,
+            manager_signals: self.manager_signals,
+            manager_signals_open: true,
+            central_powered_generation,
+            inbound: self.inbound,
+            sightings: self.sightings,
             psm,
             seen: HashSet::new(),
             central,
@@ -677,7 +563,6 @@ impl PreparedMacosBleBackend {
             peripherals: self.peripherals,
             restored: self.restored,
             restored_connections: HashSet::new(),
-            startup_backlog,
             dials: JoinSet::new(),
             queue,
             scan_enabled: false,
@@ -714,9 +599,6 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
 
     async fn next_event(&mut self) -> BleEvent<GattLink> {
         loop {
-            if let Some(link) = self.startup_backlog.pop_inbound() {
-                return BleEvent::Inbound(link);
-            }
             if let Some(peer_id) = self
                 .restored
                 .lock()
@@ -729,32 +611,19 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
                     rssi: None,
                 };
             }
-            if let Some((address, rssi)) = self.startup_backlog.pop_sighting() {
-                crate::diagnostic_log::debug!(
-                    "bluetooth: handing off pre-ready Prns sighting {:02x?} rssi={rssi:?}",
-                    address.octets()
-                );
-                return BleEvent::Sighting { address, rssi };
-            }
             let pending_dials = !self.dials.is_empty();
             tokio::select! {
-                event = self.events.recv() => match event {
-                    Some(Event::Sighting { address, rssi }) => {
-                        crate::diagnostic_log::debug!(
-                            "bluetooth: sighted Prns peer {:02x?} rssi={rssi:?}",
-                            address.octets()
-                        );
-                        return BleEvent::Sighting { address, rssi };
+                biased;
+                changed = self.manager_signals.changed(), if self.manager_signals_open => {
+                    if changed.is_err() {
+                        self.manager_signals_open = false;
+                    } else {
+                        self.reconcile_manager_signals();
                     }
-                    Some(Event::Inbound(link)) => return BleEvent::Inbound(link),
-                    Some(Event::CentralPowered) if self.scan_enabled => {
-                        let central = SendCentralManager(self.central.0.clone());
-                        self.queue.exec_async(move || {
-                            apply_scanning(central, true, true);
-                        });
-                        continue;
-                    }
-                    Some(_) => continue,
+                    continue;
+                }
+                inbound = self.inbound.recv() => match inbound {
+                    Some(link) => return BleEvent::Inbound(link),
                     None => core::future::pending().await,
                 },
                 Some(done) = self.dials.join_next(), if pending_dials => {
@@ -772,6 +641,16 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
                         Err(_) => continue,
                     }
                 }
+                sighting = self.sightings.recv() => match sighting {
+                    Some(Sighting { address, rssi }) => {
+                        crate::diagnostic_log::debug!(
+                            "bluetooth: sighted Prns peer {:02x?} rssi={rssi:?}",
+                            address.octets()
+                        );
+                        return BleEvent::Sighting { address, rssi };
+                    }
+                    None => core::future::pending().await,
+                },
                 _ = tokio::time::sleep_until(self.scan_liveness_at),
                     if cfg!(target_os = "macos") && self.scan_enabled => {
                     let scan_activity = self.scan_activity.swap(false, Ordering::Relaxed);

--- a/prns-ffi/src/bluetooth_auto/macos/backend.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/backend.rs
@@ -509,7 +509,9 @@ struct PreparedCoreBluetoothBackend {
 }
 
 /// Prepared dual-role CoreBluetooth managers.
-pub struct PreparedMacosBleBackend(PreparedCoreBluetoothBackend);
+pub struct PreparedMacosBleBackend {
+    backend: PreparedCoreBluetoothBackend,
+}
 
 /// Prepared central-only CoreBluetooth manager.
 pub struct PreparedCentralOnlyMacosBleBackend(PreparedCoreBluetoothBackend);
@@ -572,7 +574,7 @@ impl MacosBleBackend {
         let manager_preparation = ManagerPreparation::PlatformDefault;
         Self::prepare_with(identity, manager_preparation)
             .await
-            .map(PreparedMacosBleBackend)
+            .map(|backend| PreparedMacosBleBackend { backend })
     }
 
     /// Creates CoreBluetooth managers with stable restoration identifiers supplied by the
@@ -587,7 +589,7 @@ impl MacosBleBackend {
     ) -> Result<PreparedMacosBleBackend, MacosBleError> {
         Self::prepare_with(identity, ManagerPreparation::RestorationAware(identifiers))
             .await
-            .map(PreparedMacosBleBackend)
+            .map(|backend| PreparedMacosBleBackend { backend })
     }
 
     /// Creates CoreBluetooth managers without opting into iOS state restoration.
@@ -602,7 +604,7 @@ impl MacosBleBackend {
             ManagerPreparation::WithoutRestoration(CoreBluetoothRole::DualRole),
         )
         .await
-        .map(PreparedMacosBleBackend)
+        .map(|backend| PreparedMacosBleBackend { backend })
     }
 
     async fn prepare_with(
@@ -995,7 +997,7 @@ impl PreparedCoreBluetoothBackend {
 
 impl PreparedMacosBleBackend {
     pub async fn ready(self) -> Result<MacosBleBackend, MacosBleError> {
-        let ready = self.0.ready().await?;
+        let ready = self.backend.ready().await?;
         let psm = ready.local_psm.ok_or(MacosBleError::PublishFailed)?;
         Ok(MacosBleBackend {
             backend: ready.backend,

--- a/prns-ffi/src/bluetooth_auto/macos/backend.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/backend.rs
@@ -17,7 +17,8 @@ use tokio::sync::{mpsc as tokio_mpsc, oneshot, watch};
 use tokio::task::JoinSet;
 
 use prns_core::interfaces::bluetooth_auto::{
-    AdvertisingMode, BleBackend, BleEvent, DialOutcome, Origin, RadioMode, ScanningMode,
+    AdvertisingMode, BleBackend, BleEvent, DialOutcome, LinkCapabilities, Origin, RadioMode,
+    ScanningMode,
 };
 use prns_core::interfaces::bluetooth_auto::{BleAddress, BleIdentity, Control, Psm};
 
@@ -32,7 +33,7 @@ use super::peripheral::PeripheralDelegate;
 #[cfg(target_os = "ios")]
 use super::{
     central_manager_options, legacy_restoration_identifiers, peripheral_manager_options,
-    CoreBluetoothRestorationIdentifiers,
+    CoreBluetoothCentralRestorationIdentifier, CoreBluetoothRestorationIdentifiers,
 };
 use super::{
     manager_signal_channel, start_scan, CoreBluetoothPeerId, L2capPublicationState, MacosBleError,
@@ -47,6 +48,10 @@ const RADIO_TRANSITION_TIMEOUT: Duration = Duration::from_secs(2);
 /// delivering callbacks. Any discovery callback renews the scan lease without touching the radio.
 const RADIO_LIVENESS_INTERVAL: Duration = Duration::from_secs(60);
 const SIGHTING_INGRESS_PER_PEER: usize = 4;
+#[cfg(target_os = "ios")]
+const MAX_PEERS: usize = 7;
+#[cfg(target_os = "macos")]
+const MAX_PEERS: usize = 8;
 
 pub(super) const fn central_peripheral_capacity(max_peers: usize) -> usize {
     max_peers.saturating_mul(SIGHTING_INGRESS_PER_PEER)
@@ -138,7 +143,54 @@ pub(super) const fn scan_op(enabled: bool, is_scanning: bool, restart: bool) -> 
     }
 }
 
-pub(super) fn manager_readiness(signals: ManagerSignals) -> Result<Option<Psm>, MacosBleError> {
+pub(super) fn take_inbound_event<T>(event: Option<T>, inbound_open: &mut bool) -> Option<T> {
+    if event.is_none() {
+        *inbound_open = false;
+    }
+    event
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum CoreBluetoothRole {
+    DualRole,
+    CentralOnly,
+}
+
+impl CoreBluetoothRole {
+    const fn has_peripheral_manager(self) -> bool {
+        matches!(self, Self::DualRole)
+    }
+}
+
+pub(super) const fn role_capabilities(
+    role: CoreBluetoothRole,
+    mut configured: LinkCapabilities,
+) -> LinkCapabilities {
+    if matches!(role, CoreBluetoothRole::CentralOnly) {
+        configured.l2cap = None;
+    }
+    configured
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct ManagerReadiness {
+    pub(super) local_psm: Option<Psm>,
+    pub(super) central_powered_generation: u64,
+}
+
+pub(super) fn manager_readiness(
+    role: CoreBluetoothRole,
+    signals: ManagerSignals,
+) -> Result<Option<ManagerReadiness>, MacosBleError> {
+    if role == CoreBluetoothRole::CentralOnly {
+        if signals.central_powered_generation == 0 {
+            return Ok(None);
+        }
+        return Ok(Some(ManagerReadiness {
+            local_psm: None,
+            central_powered_generation: signals.central_powered_generation,
+        }));
+    }
     if signals.gatt == PublicationState::Failed {
         crate::diagnostic_log::error!("bluetooth: GATT service publication failed at startup");
         return Err(MacosBleError::PublishFailed);
@@ -153,16 +205,20 @@ pub(super) fn manager_readiness(signals: ManagerSignals) -> Result<Option<Psm>, 
     if signals.central_powered_generation == 0 || signals.gatt != PublicationState::Published {
         return Ok(None);
     }
-    Ok(Some(Psm::new(psm).ok_or(MacosBleError::PublishFailed)?))
+    Ok(Some(ManagerReadiness {
+        local_psm: Some(Psm::new(psm).ok_or(MacosBleError::PublishFailed)?),
+        central_powered_generation: signals.central_powered_generation,
+    }))
 }
 
 async fn wait_for_readiness(
+    role: CoreBluetoothRole,
     signals: &mut watch::Receiver<ManagerSignals>,
-) -> Result<(Psm, u64), MacosBleError> {
+) -> Result<ManagerReadiness, MacosBleError> {
     loop {
         let current = *signals.borrow_and_update();
-        if let Some(psm) = manager_readiness(current)? {
-            return Ok((psm, current.central_powered_generation));
+        if let Some(readiness) = manager_readiness(role, current)? {
+            return Ok(readiness);
         }
         signals.changed().await.map_err(|_| MacosBleError::Closed)?;
     }
@@ -257,19 +313,22 @@ fn enqueue_radio_transition(
     queue: &DispatchRetained<DispatchQueue>,
     central: &SendCentralManager,
     central_delegate: &SendCentralDelegate,
-    peripheral_delegate: &SendPeripheralDelegate,
+    peripheral_delegate: Option<&SendPeripheralDelegate>,
     enabled: bool,
     completion: Option<oneshot::Sender<()>>,
 ) {
     let central = SendCentralManager(central.0.clone());
     let central_delegate = SendCentralDelegate(central_delegate.0.clone());
-    let peripheral_delegate = SendPeripheralDelegate(peripheral_delegate.0.clone());
+    let peripheral_delegate =
+        peripheral_delegate.map(|delegate| SendPeripheralDelegate(delegate.0.clone()));
     queue.exec_async(move || {
         let central = central;
         let central_delegate = central_delegate;
         let peripheral_delegate = peripheral_delegate;
         central_delegate.0.set_radio_enabled(&central.0, enabled);
-        peripheral_delegate.0.set_radio_enabled(enabled);
+        if let Some(peripheral_delegate) = peripheral_delegate {
+            peripheral_delegate.0.set_radio_enabled(enabled);
+        }
         if let Some(completion) = completion {
             let _ = completion.send(());
         }
@@ -373,7 +432,7 @@ enum DialStart {
 struct Handles {
     central: SendCentralManager,
     central_delegate: SendCentralDelegate,
-    peripheral_delegate: SendPeripheralDelegate,
+    peripheral_delegate: Option<SendPeripheralDelegate>,
     queue: DispatchRetained<DispatchQueue>,
 }
 
@@ -387,18 +446,19 @@ enum DialTaskOutcome {
     },
 }
 
-pub struct MacosBleBackend {
+struct CoreBluetoothBackend {
     _native_thread: NativeThread,
     manager_signals: watch::Receiver<ManagerSignals>,
     manager_signals_open: bool,
     central_powered_generation: u64,
+    role: CoreBluetoothRole,
     inbound: tokio_mpsc::Receiver<GattLink>,
+    inbound_open: bool,
     sighting_events: tokio_mpsc::Receiver<()>,
-    psm: Psm,
     seen: BoundedRecentSet<[u8; 6]>,
     central: SendCentralManager,
     central_delegate: SendCentralDelegate,
-    peripheral_delegate: SendPeripheralDelegate,
+    peripheral_delegate: Option<SendPeripheralDelegate>,
     dial_failures: BoundedRecentSet<BleAddress>,
     dials: JoinSet<DialTaskOutcome>,
     queue: DispatchRetained<DispatchQueue>,
@@ -408,6 +468,17 @@ pub struct MacosBleBackend {
     radio_enabled: Arc<AtomicBool>,
     scan_liveness_at: tokio::time::Instant,
     advertising_reconcile_at: tokio::time::Instant,
+}
+
+/// Dual-role CoreBluetooth backend retained for source compatibility.
+pub struct MacosBleBackend {
+    backend: CoreBluetoothBackend,
+    psm: Psm,
+}
+
+/// CoreBluetooth backend which owns only a central manager.
+pub struct CentralOnlyMacosBleBackend {
+    backend: CoreBluetoothBackend,
 }
 
 struct NativeThread {
@@ -424,42 +495,69 @@ impl Drop for NativeThread {
     }
 }
 
-/// Prepared CoreBluetooth managers whose delegates and serial queue already exist, while radio
-/// authorization, service publication, and L2CAP readiness remain asynchronous.
-pub struct PreparedMacosBleBackend {
+/// Prepared CoreBluetooth ownership whose delegates and serial queue already exist, while the
+/// capabilities selected for that role remain asynchronous.
+struct PreparedCoreBluetoothBackend {
     native_thread: NativeThread,
     manager_signals: watch::Receiver<ManagerSignals>,
     inbound: tokio_mpsc::Receiver<GattLink>,
     sighting_events: tokio_mpsc::Receiver<()>,
     scan_activity: Arc<AtomicBool>,
     radio_enabled: Arc<AtomicBool>,
+    role: CoreBluetoothRole,
     handles: Handles,
 }
+
+/// Prepared dual-role CoreBluetooth managers.
+pub struct PreparedMacosBleBackend(PreparedCoreBluetoothBackend);
+
+/// Prepared central-only CoreBluetooth manager.
+pub struct PreparedCentralOnlyMacosBleBackend(PreparedCoreBluetoothBackend);
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum ManagerPreparation {
     #[cfg(target_os = "ios")]
     RestorationAware(CoreBluetoothRestorationIdentifiers),
+    #[cfg(target_os = "ios")]
+    CentralOnlyRestorationAware(CoreBluetoothCentralRestorationIdentifier),
     #[cfg(not(target_os = "ios"))]
     PlatformDefault,
-    WithoutRestoration,
+    WithoutRestoration(CoreBluetoothRole),
 }
 
 impl ManagerPreparation {
-    #[cfg(target_os = "ios")]
-    fn restoration_identifiers(&self) -> Option<&CoreBluetoothRestorationIdentifiers> {
+    const fn role(&self) -> CoreBluetoothRole {
         match self {
-            Self::RestorationAware(identifiers) => Some(identifiers),
-            Self::WithoutRestoration => None,
+            #[cfg(target_os = "ios")]
+            Self::RestorationAware(_) => CoreBluetoothRole::DualRole,
+            #[cfg(target_os = "ios")]
+            Self::CentralOnlyRestorationAware(_) => CoreBluetoothRole::CentralOnly,
+            #[cfg(not(target_os = "ios"))]
+            Self::PlatformDefault => CoreBluetoothRole::DualRole,
+            Self::WithoutRestoration(role) => *role,
+        }
+    }
+
+    #[cfg(target_os = "ios")]
+    fn central_restoration_identifier(&self) -> Option<&str> {
+        match self {
+            Self::RestorationAware(identifiers) => Some(identifiers.central()),
+            Self::CentralOnlyRestorationAware(identifier) => Some(identifier.as_str()),
+            Self::WithoutRestoration(_) => None,
+        }
+    }
+
+    #[cfg(target_os = "ios")]
+    fn peripheral_restoration_identifier(&self) -> Option<&str> {
+        match self {
+            Self::RestorationAware(identifiers) => Some(identifiers.peripheral()),
+            Self::CentralOnlyRestorationAware(_) | Self::WithoutRestoration(_) => None,
         }
     }
 }
 
 impl MacosBleBackend {
-    #[cfg(target_os = "ios")]
-    pub const MAX_PEERS: usize = 7;
-    #[cfg(target_os = "macos")]
-    pub const MAX_PEERS: usize = 8;
+    pub const MAX_PEERS: usize = MAX_PEERS;
 
     /// Creates CoreBluetooth managers with the existing iOS restoration identifiers.
     ///
@@ -472,7 +570,9 @@ impl MacosBleBackend {
             ManagerPreparation::RestorationAware(legacy_restoration_identifiers());
         #[cfg(not(target_os = "ios"))]
         let manager_preparation = ManagerPreparation::PlatformDefault;
-        Self::prepare_with(identity, manager_preparation).await
+        Self::prepare_with(identity, manager_preparation)
+            .await
+            .map(PreparedMacosBleBackend)
     }
 
     /// Creates CoreBluetooth managers with stable restoration identifiers supplied by the
@@ -485,7 +585,9 @@ impl MacosBleBackend {
         identity: BleIdentity,
         identifiers: CoreBluetoothRestorationIdentifiers,
     ) -> Result<PreparedMacosBleBackend, MacosBleError> {
-        Self::prepare_with(identity, ManagerPreparation::RestorationAware(identifiers)).await
+        Self::prepare_with(identity, ManagerPreparation::RestorationAware(identifiers))
+            .await
+            .map(PreparedMacosBleBackend)
     }
 
     /// Creates CoreBluetooth managers without opting into iOS state restoration.
@@ -495,15 +597,27 @@ impl MacosBleBackend {
     pub async fn prepare_without_restoration(
         identity: BleIdentity,
     ) -> Result<PreparedMacosBleBackend, MacosBleError> {
-        Self::prepare_with(identity, ManagerPreparation::WithoutRestoration).await
+        Self::prepare_with(
+            identity,
+            ManagerPreparation::WithoutRestoration(CoreBluetoothRole::DualRole),
+        )
+        .await
+        .map(PreparedMacosBleBackend)
     }
 
     async fn prepare_with(
         identity: BleIdentity,
         manager_preparation: ManagerPreparation,
-    ) -> Result<PreparedMacosBleBackend, MacosBleError> {
+    ) -> Result<PreparedCoreBluetoothBackend, MacosBleError> {
+        let role = manager_preparation.role();
         #[cfg(target_os = "ios")]
-        let restoration_identifiers = manager_preparation.restoration_identifiers().cloned();
+        let central_restoration_identifier = manager_preparation
+            .central_restoration_identifier()
+            .map(str::to_owned);
+        #[cfg(target_os = "ios")]
+        let peripheral_restoration_identifier = manager_preparation
+            .peripheral_restoration_identifier()
+            .map(str::to_owned);
         #[cfg(not(target_os = "ios"))]
         let _ = manager_preparation;
         let (manager_signals_tx, manager_signals_rx) = manager_signal_channel();
@@ -536,9 +650,9 @@ impl MacosBleBackend {
                 );
                 let central_proto = ProtocolObject::from_ref(&*central_delegate);
                 #[cfg(target_os = "ios")]
-                let central_options = restoration_identifiers
-                    .as_ref()
-                    .map(|identifiers| central_manager_options(identifiers.central()));
+                let central_options = central_restoration_identifier
+                    .as_deref()
+                    .map(central_manager_options);
                 #[cfg(not(target_os = "ios"))]
                 let central_options: Option<
                     Retained<NSDictionary<NSString, AnyObject>>,
@@ -554,43 +668,53 @@ impl MacosBleBackend {
                     )
                 };
 
-                let peripheral_delegate = PeripheralDelegate::new(
-                    manager_signals_tx,
-                    inbound_tx,
-                    queue.clone(),
-                    identity,
-                    radio_enabled_for_peripheral,
-                    Self::MAX_PEERS,
-                );
-                let peripheral_proto = ProtocolObject::from_ref(&*peripheral_delegate);
-                #[cfg(target_os = "ios")]
-                let peripheral_options = restoration_identifiers
-                    .as_ref()
-                    .map(|identifiers| peripheral_manager_options(identifiers.peripheral()));
-                #[cfg(not(target_os = "ios"))]
-                let peripheral_options: Option<
-                    Retained<NSDictionary<NSString, AnyObject>>,
-                > = None;
-                // SAFETY: the delegate and dispatch queue are retained for at least as long as the
-                // manager, and every Objective-C argument has the framework-declared type.
-                let peripheral: Retained<CBPeripheralManager> = unsafe {
-                    CBPeripheralManager::initWithDelegate_queue_options(
-                        CBPeripheralManager::alloc(),
-                        Some(peripheral_proto),
-                        Some(&queue),
-                        peripheral_options.as_deref(),
-                    )
+                let peripheral = if role.has_peripheral_manager() {
+                    let peripheral_delegate = PeripheralDelegate::new(
+                        manager_signals_tx,
+                        inbound_tx,
+                        queue.clone(),
+                        identity,
+                        radio_enabled_for_peripheral,
+                        MAX_PEERS,
+                    );
+                    let peripheral_proto = ProtocolObject::from_ref(&*peripheral_delegate);
+                    #[cfg(target_os = "ios")]
+                    let peripheral_options = peripheral_restoration_identifier
+                        .as_deref()
+                        .map(peripheral_manager_options);
+                    #[cfg(not(target_os = "ios"))]
+                    let peripheral_options: Option<
+                        Retained<NSDictionary<NSString, AnyObject>>,
+                    > = None;
+                    // SAFETY: the delegate and dispatch queue are retained for at least as long as
+                    // the manager, and every Objective-C argument has the framework-declared type.
+                    let peripheral_manager: Retained<CBPeripheralManager> = unsafe {
+                        CBPeripheralManager::initWithDelegate_queue_options(
+                            CBPeripheralManager::alloc(),
+                            Some(peripheral_proto),
+                            Some(&queue),
+                            peripheral_options.as_deref(),
+                        )
+                    };
+                    Some((peripheral_delegate, peripheral_manager))
+                } else {
+                    drop(inbound_tx);
+                    None
                 };
+
+                let peripheral_delegate = peripheral
+                    .as_ref()
+                    .map(|(delegate, _)| SendPeripheralDelegate(delegate.clone()));
 
                 let _ = handles_tx.send(Handles {
                     central: SendCentralManager(central.clone()),
                     central_delegate: SendCentralDelegate(central_delegate.clone()),
-                    peripheral_delegate: SendPeripheralDelegate(peripheral_delegate.clone()),
+                    peripheral_delegate,
                     queue: queue.clone(),
                 });
 
                 let _ = shutdown_rx.recv();
-                let _hold = (central, central_delegate, peripheral_delegate, peripheral);
+                let _hold = (central, central_delegate, peripheral);
             })
             .map_err(|_| MacosBleError::Closed)?;
         let native_thread = NativeThread {
@@ -601,13 +725,14 @@ impl MacosBleBackend {
         let handles = handles_rx.await.map_err(|_| MacosBleError::Closed)?;
         // Manager creation has completed. Do not await radio authorization or publication here:
         // callers use `ready` after installing the rest of their lifecycle supervision.
-        Ok(PreparedMacosBleBackend {
+        Ok(PreparedCoreBluetoothBackend {
             native_thread,
             manager_signals: manager_signals_rx,
             inbound: inbound_rx,
             sighting_events,
             scan_activity,
             radio_enabled,
+            role,
             handles,
         })
     }
@@ -620,6 +745,46 @@ impl MacosBleBackend {
         self.psm
     }
 
+    pub async fn next_sighting(&mut self) -> Option<BleAddress> {
+        self.backend.next_sighting().await
+    }
+}
+
+impl CentralOnlyMacosBleBackend {
+    pub const MAX_PEERS: usize = MAX_PEERS;
+
+    /// Creates only a CoreBluetooth central manager with application-owned iOS restoration.
+    #[cfg(target_os = "ios")]
+    pub async fn prepare_with_restoration(
+        identity: BleIdentity,
+        identifier: CoreBluetoothCentralRestorationIdentifier,
+    ) -> Result<PreparedCentralOnlyMacosBleBackend, MacosBleError> {
+        MacosBleBackend::prepare_with(
+            identity,
+            ManagerPreparation::CentralOnlyRestorationAware(identifier),
+        )
+        .await
+        .map(PreparedCentralOnlyMacosBleBackend)
+    }
+
+    /// Creates only a CoreBluetooth central manager without state restoration.
+    pub async fn prepare_without_restoration(
+        identity: BleIdentity,
+    ) -> Result<PreparedCentralOnlyMacosBleBackend, MacosBleError> {
+        MacosBleBackend::prepare_with(
+            identity,
+            ManagerPreparation::WithoutRestoration(CoreBluetoothRole::CentralOnly),
+        )
+        .await
+        .map(PreparedCentralOnlyMacosBleBackend)
+    }
+
+    pub async fn next_sighting(&mut self) -> Option<BleAddress> {
+        self.backend.next_sighting().await
+    }
+}
+
+impl CoreBluetoothBackend {
     fn reconcile_manager_signals(&mut self) {
         let generation = self
             .manager_signals
@@ -698,7 +863,7 @@ impl MacosBleBackend {
             &self.queue,
             &self.central,
             &self.central_delegate,
-            &self.peripheral_delegate,
+            self.peripheral_delegate.as_ref(),
             enabled,
             Some(completion_tx),
         );
@@ -757,8 +922,13 @@ impl MacosBleBackend {
     }
 }
 
-impl PreparedMacosBleBackend {
-    pub async fn ready(mut self) -> Result<MacosBleBackend, MacosBleError> {
+struct ReadyCoreBluetoothBackend {
+    backend: CoreBluetoothBackend,
+    local_psm: Option<Psm>,
+}
+
+impl PreparedCoreBluetoothBackend {
+    async fn ready(mut self) -> Result<ReadyCoreBluetoothBackend, MacosBleError> {
         let Handles {
             central,
             central_delegate,
@@ -767,50 +937,86 @@ impl PreparedMacosBleBackend {
         } = self.handles;
         let readiness = tokio::time::timeout(
             POWER_ON_TIMEOUT,
-            wait_for_readiness(&mut self.manager_signals),
+            wait_for_readiness(self.role, &mut self.manager_signals),
         )
         .await;
-        let (psm, central_powered_generation) = match readiness {
+        let readiness = match readiness {
             Ok(result) => result?,
             Err(_) => {
-                crate::diagnostic_log::error!(
-                    "bluetooth: timed out waiting for central power, GATT publication, and L2CAP publication — is Bluetooth on and permission granted?"
-                );
+                match self.role {
+                    CoreBluetoothRole::DualRole => crate::diagnostic_log::error!(
+                        "bluetooth: timed out waiting for central power, GATT publication, and L2CAP publication — is Bluetooth on and permission granted?"
+                    ),
+                    CoreBluetoothRole::CentralOnly => crate::diagnostic_log::error!(
+                        "bluetooth: timed out waiting for central power — is Bluetooth on and permission granted?"
+                    ),
+                }
                 return Err(MacosBleError::PowerOnTimeout);
             }
         };
-        crate::diagnostic_log::debug!(
-            "bluetooth: central powered, GATT service published, L2CAP listener on PSM {:#06x}",
-            psm.get()
-        );
-        Ok(MacosBleBackend {
-            _native_thread: self.native_thread,
-            manager_signals: self.manager_signals,
-            manager_signals_open: true,
-            central_powered_generation,
-            inbound: self.inbound,
-            sighting_events: self.sighting_events,
-            psm,
-            seen: BoundedRecentSet::new(central_peripheral_capacity(MacosBleBackend::MAX_PEERS)),
-            central,
-            central_delegate,
-            peripheral_delegate,
-            dial_failures: BoundedRecentSet::new(central_peripheral_capacity(
-                MacosBleBackend::MAX_PEERS,
-            )),
-            dials: JoinSet::new(),
-            queue,
-            scan_enabled: false,
-            advertise_enabled: false,
-            scan_activity: self.scan_activity,
-            radio_enabled: self.radio_enabled,
-            scan_liveness_at: tokio::time::Instant::now() + RADIO_LIVENESS_INTERVAL,
-            advertising_reconcile_at: tokio::time::Instant::now() + RADIO_LIVENESS_INTERVAL,
+        match readiness.local_psm {
+            Some(psm) => crate::diagnostic_log::debug!(
+                "bluetooth: central powered, GATT service published, L2CAP listener on PSM {:#06x}",
+                psm.get()
+            ),
+            None => crate::diagnostic_log::debug!(
+                "bluetooth: central-only CoreBluetooth manager powered; no local peripheral capability"
+            ),
+        }
+        let inbound_open = self.role.has_peripheral_manager();
+        Ok(ReadyCoreBluetoothBackend {
+            local_psm: readiness.local_psm,
+            backend: CoreBluetoothBackend {
+                _native_thread: self.native_thread,
+                manager_signals: self.manager_signals,
+                manager_signals_open: true,
+                central_powered_generation: readiness.central_powered_generation,
+                role: self.role,
+                inbound: self.inbound,
+                inbound_open,
+                sighting_events: self.sighting_events,
+                seen: BoundedRecentSet::new(central_peripheral_capacity(MAX_PEERS)),
+                central,
+                central_delegate,
+                peripheral_delegate,
+                dial_failures: BoundedRecentSet::new(central_peripheral_capacity(MAX_PEERS)),
+                dials: JoinSet::new(),
+                queue,
+                scan_enabled: false,
+                advertise_enabled: false,
+                scan_activity: self.scan_activity,
+                radio_enabled: self.radio_enabled,
+                scan_liveness_at: tokio::time::Instant::now() + RADIO_LIVENESS_INTERVAL,
+                advertising_reconcile_at: tokio::time::Instant::now() + RADIO_LIVENESS_INTERVAL,
+            },
         })
     }
 }
 
-impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
+impl PreparedMacosBleBackend {
+    pub async fn ready(self) -> Result<MacosBleBackend, MacosBleError> {
+        let ready = self.0.ready().await?;
+        let psm = ready.local_psm.ok_or(MacosBleError::PublishFailed)?;
+        Ok(MacosBleBackend {
+            backend: ready.backend,
+            psm,
+        })
+    }
+}
+
+impl PreparedCentralOnlyMacosBleBackend {
+    pub async fn ready(self) -> Result<CentralOnlyMacosBleBackend, MacosBleError> {
+        let ready = self.0.ready().await?;
+        if ready.local_psm.is_some() {
+            return Err(MacosBleError::PublishFailed);
+        }
+        Ok(CentralOnlyMacosBleBackend {
+            backend: ready.backend,
+        })
+    }
+}
+
+impl BleBackend<{ MAX_PEERS }> for CoreBluetoothBackend {
     type Error = MacosBleError;
     type Link = GattLink;
 
@@ -826,10 +1032,21 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
         result
     }
 
+    async fn local_capabilities(
+        &mut self,
+        configured: LinkCapabilities,
+    ) -> Result<LinkCapabilities, MacosBleError> {
+        Ok(role_capabilities(self.role, configured))
+    }
+
     async fn set_advertising(&mut self, mode: AdvertisingMode) -> Result<(), MacosBleError> {
+        let Some(peripheral_delegate) = self.peripheral_delegate.as_ref() else {
+            self.advertise_enabled = false;
+            return Ok(());
+        };
         self.advertise_enabled = mode.is_on();
         self.advertising_reconcile_at = tokio::time::Instant::now() + RADIO_LIVENESS_INTERVAL;
-        self.peripheral_delegate.0.set_advertising(mode);
+        peripheral_delegate.0.set_advertising(mode);
         Ok(())
     }
 
@@ -870,9 +1087,11 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
                     }
                     continue;
                 }
-                inbound = self.inbound.recv() => match inbound {
-                    Some(link) => return BleEvent::Inbound(link),
-                    None => core::future::pending().await,
+                inbound = self.inbound.recv(), if self.inbound_open => {
+                    if let Some(link) = take_inbound_event(inbound, &mut self.inbound_open) {
+                        return BleEvent::Inbound(link);
+                    }
+                    continue;
                 },
                 Some(done) = self.dials.join_next(), if pending_dials => {
                     match done {
@@ -920,9 +1139,9 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
                     // Reconcile desired advertising with CoreBluetooth's authoritative state.
                     // Healthy advertising remains untouched; a false state is restarted without
                     // bouncing live inbound sessions.
-                    self.peripheral_delegate
-                        .0
-                        .set_advertising(AdvertisingMode::On);
+                    if let Some(peripheral_delegate) = self.peripheral_delegate.as_ref() {
+                        peripheral_delegate.0.set_advertising(AdvertisingMode::On);
+                    }
                     self.advertising_reconcile_at =
                         tokio::time::Instant::now() + RADIO_LIVENESS_INTERVAL;
                     continue;
@@ -968,13 +1187,21 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
             session: CentralPeerSession::new(address, control_tx, completion_tx, data_inbound_tx),
         };
         crate::diagnostic_log::debug!("bluetooth: dialing {token:02x?} over LE (central role)");
-        let peripheral_for_admission = SendPeripheralDelegate(self.peripheral_delegate.0.clone());
+        let peripheral_for_admission = self
+            .peripheral_delegate
+            .as_ref()
+            .map(|delegate| SendPeripheralDelegate(delegate.0.clone()));
         self.queue.exec_async(move || {
-            let target_has_inbound_session = peripheral_for_admission.has_inbound_session(peer_id);
+            let target_has_inbound_session = peripheral_for_admission
+                .as_ref()
+                .is_some_and(|delegate| delegate.has_inbound_session(peer_id));
             begin_dial(command, target_has_inbound_session, restored_connection);
         });
         let send_peripheral = peripheral;
-        let send_peripheral_manager = SendPeripheralDelegate(self.peripheral_delegate.0.clone());
+        let send_peripheral_manager = self
+            .peripheral_delegate
+            .as_ref()
+            .map(|delegate| SendPeripheralDelegate(delegate.0.clone()));
         let delegate = SendCentralDelegate(self.central_delegate.0.clone());
         let queue = self.queue.clone();
         self.dials.spawn(async move {
@@ -1039,11 +1266,59 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
             let delegate = delegate;
             delegate.0.reap_closed_sessions(&central.0);
         });
-        self.peripheral_delegate.0.clear_closed_peer(address);
+        if let Some(peripheral_delegate) = self.peripheral_delegate.as_ref() {
+            peripheral_delegate.0.clear_closed_peer(address);
+        }
     }
 }
 
-impl Drop for MacosBleBackend {
+macro_rules! impl_public_backend {
+    ($backend:ty) => {
+        impl BleBackend<{ MAX_PEERS }> for $backend {
+            type Error = MacosBleError;
+            type Link = GattLink;
+
+            async fn set_radio_mode(&mut self, mode: RadioMode) -> Result<(), MacosBleError> {
+                self.backend.set_radio_mode(mode).await
+            }
+
+            async fn set_advertising(
+                &mut self,
+                mode: AdvertisingMode,
+            ) -> Result<(), MacosBleError> {
+                self.backend.set_advertising(mode).await
+            }
+
+            async fn set_scanning(&mut self, mode: ScanningMode) -> Result<(), MacosBleError> {
+                self.backend.set_scanning(mode).await
+            }
+
+            async fn local_capabilities(
+                &mut self,
+                configured: LinkCapabilities,
+            ) -> Result<LinkCapabilities, MacosBleError> {
+                self.backend.local_capabilities(configured).await
+            }
+
+            async fn next_event(&mut self) -> BleEvent<GattLink> {
+                self.backend.next_event().await
+            }
+
+            async fn dial(&mut self, address: BleAddress) -> DialOutcome {
+                self.backend.dial(address).await
+            }
+
+            async fn on_link_closed(&mut self, address: BleAddress) {
+                self.backend.on_link_closed(address).await;
+            }
+        }
+    };
+}
+
+impl_public_backend!(MacosBleBackend);
+impl_public_backend!(CentralOnlyMacosBleBackend);
+
+impl Drop for CoreBluetoothBackend {
     fn drop(&mut self) {
         // Drop can run from an arbitrary Tokio or CoreBluetooth-adjacent thread. Close callback
         // ingress immediately, abort owned tasks, and enqueue retained cleanup without synchronously
@@ -1054,7 +1329,7 @@ impl Drop for MacosBleBackend {
             &self.queue,
             &self.central,
             &self.central_delegate,
-            &self.peripheral_delegate,
+            self.peripheral_delegate.as_ref(),
             false,
             None,
         );
@@ -1070,7 +1345,7 @@ mod native_thread_tests {
     #[test]
     fn preparation_without_restoration_is_distinct_from_the_platform_default() {
         assert_ne!(
-            ManagerPreparation::WithoutRestoration,
+            ManagerPreparation::WithoutRestoration(CoreBluetoothRole::DualRole),
             ManagerPreparation::PlatformDefault
         );
     }

--- a/prns-ffi/src/bluetooth_auto/macos/backend.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/backend.rs
@@ -255,8 +255,8 @@ impl Drop for NativeThread {
     }
 }
 
-/// Restoration-aware CoreBluetooth managers whose delegates and serial queue already exist, while
-/// radio authorization, service publication, and L2CAP readiness remain asynchronous.
+/// Prepared CoreBluetooth managers whose delegates and serial queue already exist, while radio
+/// authorization, service publication, and L2CAP readiness remain asynchronous.
 pub struct PreparedMacosBleBackend {
     native_thread: NativeThread,
     events: tokio_mpsc::UnboundedReceiver<Event>,
@@ -266,13 +266,50 @@ pub struct PreparedMacosBleBackend {
     handles: Handles,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ManagerPreparation {
+    RestorationAware,
+    ForegroundOnly,
+}
+
+impl ManagerPreparation {
+    const fn uses_state_restoration(self) -> bool {
+        matches!(self, Self::RestorationAware)
+    }
+}
+
 impl MacosBleBackend {
     #[cfg(target_os = "ios")]
     pub const MAX_PEERS: usize = 7;
     #[cfg(target_os = "macos")]
     pub const MAX_PEERS: usize = 8;
 
+    /// Creates CoreBluetooth managers with the existing iOS restoration identifiers.
+    ///
+    /// Applications using this path are responsible for the matching background modes and
+    /// restoration lifecycle. Use [`Self::prepare_foreground`] when the owner intentionally has no
+    /// CoreBluetooth state-restoration contract.
     pub async fn prepare(identity: BleIdentity) -> Result<PreparedMacosBleBackend, MacosBleError> {
+        Self::prepare_with(identity, ManagerPreparation::RestorationAware).await
+    }
+
+    /// Creates CoreBluetooth managers without opting into iOS state restoration.
+    ///
+    /// Central and peripheral operation remain available while the application is running, but
+    /// CoreBluetooth will not preserve or restore these managers after process termination.
+    pub async fn prepare_foreground(
+        identity: BleIdentity,
+    ) -> Result<PreparedMacosBleBackend, MacosBleError> {
+        Self::prepare_with(identity, ManagerPreparation::ForegroundOnly).await
+    }
+
+    async fn prepare_with(
+        identity: BleIdentity,
+        manager_preparation: ManagerPreparation,
+    ) -> Result<PreparedMacosBleBackend, MacosBleError> {
+        let uses_state_restoration = manager_preparation.uses_state_restoration();
+        #[cfg(not(target_os = "ios"))]
+        let _ = uses_state_restoration;
         let (events_tx, events_rx) = tokio_mpsc::unbounded_channel::<Event>();
         let (keepalive, shutdown_rx) = sync_mpsc::channel::<()>();
         let (handles_tx, handles_rx) = oneshot::channel::<Handles>();
@@ -297,7 +334,7 @@ impl MacosBleBackend {
                 );
                 let central_proto = ProtocolObject::from_ref(&*central_delegate);
                 #[cfg(target_os = "ios")]
-                let central_options = Some(central_manager_options());
+                let central_options = uses_state_restoration.then(central_manager_options);
                 #[cfg(not(target_os = "ios"))]
                 let central_options: Option<
                     Retained<NSDictionary<NSString, AnyObject>>,
@@ -317,7 +354,7 @@ impl MacosBleBackend {
                     PeripheralDelegate::new(events_tx, queue.clone(), identity);
                 let peripheral_proto = ProtocolObject::from_ref(&*peripheral_delegate);
                 #[cfg(target_os = "ios")]
-                let peripheral_options = Some(peripheral_manager_options());
+                let peripheral_options = uses_state_restoration.then(peripheral_manager_options);
                 #[cfg(not(target_os = "ios"))]
                 let peripheral_options: Option<
                     Retained<NSDictionary<NSString, AnyObject>>,
@@ -666,6 +703,12 @@ impl BleBackend<{ MacosBleBackend::MAX_PEERS }> for MacosBleBackend {
 mod native_thread_tests {
     use super::*;
     use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[test]
+    fn foreground_preparation_does_not_request_state_restoration() {
+        assert!(!ManagerPreparation::ForegroundOnly.uses_state_restoration());
+        assert!(ManagerPreparation::RestorationAware.uses_state_restoration());
+    }
 
     #[test]
     fn dropping_owner_stops_and_joins_native_thread() {

--- a/prns-ffi/src/bluetooth_auto/macos/backend.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/backend.rs
@@ -737,6 +737,7 @@ mod native_thread_tests {
     use super::*;
     use std::sync::atomic::{AtomicBool, Ordering};
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn foreground_preparation_is_distinct_from_the_platform_default() {
         assert_ne!(

--- a/prns-ffi/src/bluetooth_auto/macos/central.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/central.rs
@@ -29,9 +29,8 @@ use super::gatt_write::{
 };
 use super::{
     cbuuid_eq, columba_identity_uuid, columba_rx_uuid, columba_tx_uuid, control_uuid,
-    core_bluetooth_peer_id, data_uuid, service_uuid, try_bounded_ingress, BoundedIngress,
-    CoreBluetoothPeerId, MacosBleError, ManagerSignalSender, PeripheralTable, RestoredPeripherals,
-    SendCharacteristicRef, SendPeripheral, Sighting,
+    core_bluetooth_peer_id, data_uuid, service_uuid, CoreBluetoothPeerId, MacosBleError,
+    ManagerSignalSender, SendCentralManager, SendCharacteristicRef, SendPeripheral, Sighting,
 };
 
 pub(super) fn is_system_connected(
@@ -66,7 +65,16 @@ pub(super) struct DialChars {
 pub(super) enum DialCompletion {
     Ready(DialChars),
     Failed,
-    Rejected,
+    Rejected(DialRejection),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum DialRejection {
+    YieldToSystemConnection,
+    YieldToInboundSession,
+    RestoredConnectionUnavailable,
+    ExistingCentralSession,
+    RadioOff,
 }
 
 pub(super) const CENTRAL_CONTROL_INBOUND_CAPACITY: usize = 8;
@@ -115,6 +123,405 @@ impl RestoredCallbackBuffer {
         self.controls.clear();
         self.data.clear();
         self.charged_data_bytes = 0;
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum RestoredAdmission {
+    Admitted,
+    Updated,
+    AlreadyOwned,
+    Full,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RestoredPhase {
+    Queued,
+    Offered,
+    Claimed,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CentralPeripheralState {
+    Observed,
+    Restored,
+    Dialing,
+    Active,
+}
+
+struct CentralPeripheral<P> {
+    peer_id: CoreBluetoothPeerId,
+    address: BleAddress,
+    peripheral: P,
+    rssi: Option<i8>,
+    state: CentralPeripheralState,
+    pending_sighting: bool,
+}
+
+struct RestoredPeer {
+    peer_id: CoreBluetoothPeerId,
+    phase: RestoredPhase,
+    callbacks: RestoredCallbackBuffer,
+}
+
+pub(super) enum CentralDialCandidate<P> {
+    Ready {
+        peer_id: CoreBluetoothPeerId,
+        peripheral: P,
+        rssi: Option<i8>,
+        restored: bool,
+    },
+    Busy,
+    Missing,
+}
+
+pub(super) enum RestoredBufferResult<T> {
+    Buffered,
+    Overflowed,
+    AlreadyFailed,
+    NotRestored(T),
+}
+
+/// Bounded central-role ownership confined to CoreBluetooth's serial queue. The async backend
+/// requests handoffs through that queue instead of locking this state from callback threads.
+///
+/// Restored peers retain their admission slot while queued, offered, and claimed, so popping a
+/// synthetic sighting never creates an unaccounted callback buffer. Candidate entries use a
+/// larger, independently supplied capacity and evict only advisory observations; live, dialing,
+/// and restored peers are never evicted.
+pub(super) struct CentralPeerRegistry<P> {
+    peripheral_capacity: usize,
+    restored_capacity: usize,
+    peripherals: VecDeque<CentralPeripheral<P>>,
+    restored: VecDeque<RestoredPeer>,
+}
+
+impl<P> CentralPeerRegistry<P> {
+    pub(super) fn new(peripheral_capacity: usize, restored_capacity: usize) -> Self {
+        Self {
+            peripheral_capacity,
+            restored_capacity,
+            peripherals: VecDeque::new(),
+            restored: VecDeque::new(),
+        }
+    }
+
+    pub(super) fn admit_restored(
+        &mut self,
+        peer_id: CoreBluetoothPeerId,
+        peripheral: P,
+    ) -> RestoredAdmission {
+        if let Some(restored) = self
+            .restored
+            .iter()
+            .find(|restored| restored.peer_id == peer_id)
+        {
+            if restored.phase != RestoredPhase::Queued {
+                return RestoredAdmission::AlreadyOwned;
+            }
+            if let Some(entry) = self
+                .peripherals
+                .iter_mut()
+                .find(|entry| entry.peer_id == peer_id)
+            {
+                entry.peripheral = peripheral;
+                entry.rssi = None;
+                return RestoredAdmission::Updated;
+            }
+            return RestoredAdmission::Full;
+        }
+        if self.restored.len() >= self.restored_capacity {
+            return RestoredAdmission::Full;
+        }
+
+        if let Some(position) = self
+            .peripherals
+            .iter()
+            .position(|entry| entry.peer_id == peer_id)
+        {
+            if self.peripherals[position].state != CentralPeripheralState::Observed {
+                return RestoredAdmission::AlreadyOwned;
+            }
+            self.peripherals.remove(position);
+        }
+
+        let address = peer_id.address();
+        if let Some(position) = self
+            .peripherals
+            .iter()
+            .position(|entry| entry.address == address)
+        {
+            if self.peripherals[position].state != CentralPeripheralState::Observed {
+                return RestoredAdmission::Full;
+            }
+            self.peripherals.remove(position);
+        }
+        if !self.make_peripheral_room() {
+            return RestoredAdmission::Full;
+        }
+
+        self.peripherals.push_back(CentralPeripheral {
+            peer_id,
+            address,
+            peripheral,
+            rssi: None,
+            state: CentralPeripheralState::Restored,
+            pending_sighting: false,
+        });
+        self.restored.push_back(RestoredPeer {
+            peer_id,
+            phase: RestoredPhase::Queued,
+            callbacks: RestoredCallbackBuffer::default(),
+        });
+        RestoredAdmission::Admitted
+    }
+
+    /// Updates the most recent handle and signal for one synthetic address. Address collisions are
+    /// deterministic: an advisory observation replaces an older advisory observation, while a
+    /// restored, dialing, or active owner rejects the colliding newcomer.
+    pub(super) fn observe(
+        &mut self,
+        peer_id: CoreBluetoothPeerId,
+        peripheral: P,
+        rssi: Option<i8>,
+    ) -> bool {
+        if let Some(position) = self
+            .peripherals
+            .iter()
+            .position(|entry| entry.peer_id == peer_id)
+        {
+            if self.peripherals[position].state != CentralPeripheralState::Observed {
+                return false;
+            }
+            self.peripherals.remove(position);
+        }
+
+        let address = peer_id.address();
+        if let Some(position) = self
+            .peripherals
+            .iter()
+            .position(|entry| entry.address == address)
+        {
+            if self.peripherals[position].state != CentralPeripheralState::Observed {
+                return false;
+            }
+            self.peripherals.remove(position);
+        }
+        if !self.make_peripheral_room() {
+            return false;
+        }
+        self.peripherals.push_back(CentralPeripheral {
+            peer_id,
+            address,
+            peripheral,
+            rssi,
+            state: CentralPeripheralState::Observed,
+            pending_sighting: true,
+        });
+        true
+    }
+
+    fn make_peripheral_room(&mut self) -> bool {
+        if self.peripheral_capacity == 0 {
+            return false;
+        }
+        if self.peripherals.len() < self.peripheral_capacity {
+            return true;
+        }
+        let Some(position) = self
+            .peripherals
+            .iter()
+            .position(|entry| entry.state == CentralPeripheralState::Observed)
+        else {
+            return false;
+        };
+        self.peripherals.remove(position);
+        true
+    }
+
+    pub(super) fn offer_restored(&mut self) -> Option<CoreBluetoothPeerId> {
+        let peer = self
+            .restored
+            .iter_mut()
+            .find(|peer| peer.phase == RestoredPhase::Queued)?;
+        peer.phase = RestoredPhase::Offered;
+        Some(peer.peer_id)
+    }
+
+    pub(super) fn claim(&mut self, address: BleAddress) -> CentralDialCandidate<P>
+    where
+        P: Clone,
+    {
+        let Some(position) = self
+            .peripherals
+            .iter()
+            .position(|entry| entry.address == address)
+        else {
+            return CentralDialCandidate::Missing;
+        };
+        let peer_id = self.peripherals[position].peer_id;
+        let restored = match self.peripherals[position].state {
+            CentralPeripheralState::Observed => false,
+            CentralPeripheralState::Restored => {
+                let Some(restored) = self
+                    .restored
+                    .iter_mut()
+                    .find(|restored| restored.peer_id == peer_id)
+                else {
+                    return CentralDialCandidate::Busy;
+                };
+                if restored.phase != RestoredPhase::Offered {
+                    return CentralDialCandidate::Busy;
+                }
+                restored.phase = RestoredPhase::Claimed;
+                true
+            }
+            CentralPeripheralState::Dialing | CentralPeripheralState::Active => {
+                return CentralDialCandidate::Busy;
+            }
+        };
+        self.peripherals[position].state = CentralPeripheralState::Dialing;
+        self.peripherals[position].pending_sighting = false;
+        CentralDialCandidate::Ready {
+            peer_id,
+            peripheral: self.peripherals[position].peripheral.clone(),
+            rssi: self.peripherals[position].rssi,
+            restored,
+        }
+    }
+
+    pub(super) fn begin_session(
+        &mut self,
+        peer_id: CoreBluetoothPeerId,
+    ) -> Result<Option<RestoredCallbackBuffer>, ()> {
+        let Some(peripheral) = self
+            .peripherals
+            .iter_mut()
+            .find(|entry| entry.peer_id == peer_id)
+        else {
+            return Err(());
+        };
+        if peripheral.state != CentralPeripheralState::Dialing {
+            return Err(());
+        }
+        peripheral.state = CentralPeripheralState::Active;
+        let Some(position) = self
+            .restored
+            .iter()
+            .position(|peer| peer.peer_id == peer_id)
+        else {
+            return Ok(None);
+        };
+        if self.restored[position].phase != RestoredPhase::Claimed {
+            peripheral.state = CentralPeripheralState::Dialing;
+            return Err(());
+        }
+        let restored = self.restored.remove(position).ok_or(())?;
+        Ok(Some(restored.callbacks))
+    }
+
+    pub(super) fn mark_active(&mut self, peer_id: CoreBluetoothPeerId) {
+        if let Some(entry) = self
+            .peripherals
+            .iter_mut()
+            .find(|entry| entry.peer_id == peer_id)
+        {
+            entry.state = CentralPeripheralState::Active;
+        }
+    }
+
+    pub(super) fn remove_peer(&mut self, peer_id: CoreBluetoothPeerId) -> Option<P> {
+        let peripheral = self
+            .peripherals
+            .iter()
+            .position(|entry| entry.peer_id == peer_id)
+            .and_then(|position| self.peripherals.remove(position))
+            .map(|entry| entry.peripheral);
+        self.restored.retain(|peer| peer.peer_id != peer_id);
+        peripheral
+    }
+
+    /// Remove all registry state and return only peripherals for which this backend owns a
+    /// restored, dialing, or active CoreBluetooth connection. Advisory observations are dropped
+    /// without cancellation because no connection was started for them.
+    pub(super) fn drain_owned(&mut self) -> Vec<P> {
+        self.restored.clear();
+        self.peripherals
+            .drain(..)
+            .filter_map(|entry| {
+                (entry.state != CentralPeripheralState::Observed).then_some(entry.peripheral)
+            })
+            .collect()
+    }
+
+    pub(super) fn pop_sighting(&mut self) -> (Option<Sighting>, bool) {
+        let sighting = self
+            .peripherals
+            .iter_mut()
+            .find(|entry| entry.pending_sighting)
+            .map(|entry| {
+                entry.pending_sighting = false;
+                Sighting {
+                    address: entry.address,
+                    rssi: entry.rssi,
+                }
+            });
+        let more = self.peripherals.iter().any(|entry| entry.pending_sighting);
+        (sighting, more)
+    }
+
+    pub(super) fn buffer_restored_data(
+        &mut self,
+        peer_id: CoreBluetoothPeerId,
+        data: Box<[u8]>,
+    ) -> RestoredBufferResult<Box<[u8]>> {
+        let Some(restored) = self
+            .restored
+            .iter_mut()
+            .find(|restored| restored.peer_id == peer_id)
+        else {
+            return RestoredBufferResult::NotRestored(data);
+        };
+        let was_failed = restored.callbacks.failed;
+        if restored.callbacks.buffer_data(data) {
+            RestoredBufferResult::Buffered
+        } else if was_failed {
+            RestoredBufferResult::AlreadyFailed
+        } else {
+            RestoredBufferResult::Overflowed
+        }
+    }
+
+    pub(super) fn buffer_restored_control(
+        &mut self,
+        peer_id: CoreBluetoothPeerId,
+        control: Control,
+    ) -> RestoredBufferResult<Control> {
+        let Some(restored) = self
+            .restored
+            .iter_mut()
+            .find(|restored| restored.peer_id == peer_id)
+        else {
+            return RestoredBufferResult::NotRestored(control);
+        };
+        let was_failed = restored.callbacks.failed;
+        if restored.callbacks.buffer_control(control) {
+            RestoredBufferResult::Buffered
+        } else if was_failed {
+            RestoredBufferResult::AlreadyFailed
+        } else {
+            RestoredBufferResult::Overflowed
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn peripheral_len(&self) -> usize {
+        self.peripherals.len()
+    }
+
+    #[cfg(test)]
+    pub(super) fn restored_len(&self) -> usize {
+        self.restored.len()
     }
 }
 
@@ -258,6 +665,13 @@ impl CentralPeerSession {
         true
     }
 
+    pub(super) fn enqueue_control(
+        &self,
+        control: Control,
+    ) -> Result<(), tokio_mpsc::error::TrySendError<Control>> {
+        self.control_tx.try_send(control)
+    }
+
     fn complete_columba(
         &mut self,
         write: GattWriteTarget,
@@ -286,9 +700,9 @@ impl CentralPeerSession {
         }
     }
 
-    pub(super) fn reject(mut self) {
+    pub(super) fn reject(mut self, rejection: DialRejection) {
         if let Some(completion_tx) = self.completion_tx.take() {
-            let _ = completion_tx.send(DialCompletion::Rejected);
+            let _ = completion_tx.send(DialCompletion::Rejected(rejection));
         }
     }
 
@@ -338,6 +752,15 @@ impl CentralPeerSession {
     }
 }
 
+pub(super) fn closed_central_session_ids(
+    sessions: &HashMap<CoreBluetoothPeerId, CentralPeerSession>,
+) -> Vec<CoreBluetoothPeerId> {
+    sessions
+        .iter()
+        .filter_map(|(peer_id, session)| session.data_receiver_closed().then_some(*peer_id))
+        .collect()
+}
+
 pub(super) struct DialCommand {
     pub(super) central: Retained<CBCentralManager>,
     pub(super) delegate: Retained<CentralDelegate>,
@@ -351,11 +774,11 @@ unsafe impl Send for DialCommand {}
 
 pub(super) struct CentralDelegateIvars {
     manager_signals: ManagerSignalSender,
-    sightings: tokio_mpsc::Sender<Sighting>,
-    peripherals: PeripheralTable,
-    restored: RestoredPeripherals,
+    sighting_wake: tokio_mpsc::Sender<()>,
+    manager: RefCell<Option<SendCentralManager>>,
+    radio_enabled: Arc<AtomicBool>,
+    registry: RefCell<CentralPeerRegistry<SendPeripheral>>,
     scan_activity: Arc<AtomicBool>,
-    pending_restored_callbacks: RefCell<HashMap<CoreBluetoothPeerId, RestoredCallbackBuffer>>,
     sessions: RefCell<HashMap<CoreBluetoothPeerId, CentralPeerSession>>,
     discovery_guard: RefCell<DiscoveryGuard>,
 }
@@ -370,6 +793,7 @@ define_class!(
     unsafe impl CBCentralManagerDelegate for CentralDelegate {
         #[unsafe(method(centralManagerDidUpdateState:))]
         fn did_update_state(&self, central: &CBCentralManager) {
+            *self.ivars().manager.borrow_mut() = Some(SendCentralManager(central.retain()));
             // SAFETY: CoreBluetooth supplied this live manager to its delegate on the configured
             // serial dispatch queue.
             if unsafe { central.state() } == CBManagerState::PoweredOn {
@@ -380,9 +804,11 @@ define_class!(
         #[unsafe(method(centralManager:willRestoreState:))]
         fn will_restore_state(
             &self,
-            _central: &CBCentralManager,
+            central: &CBCentralManager,
             dict: &NSDictionary<NSString, AnyObject>,
         ) {
+            *self.ivars().manager.borrow_mut() = Some(SendCentralManager(central.retain()));
+            self.reap_closed_sessions(central);
             // SAFETY: CoreBluetooth exports this NSString constant with process lifetime.
             let key: &NSString = unsafe { CBCentralManagerRestoredStatePeripheralsKey };
             let Some(restored) = dict.objectForKey(key) else {
@@ -392,18 +818,53 @@ define_class!(
             // CBPeripheral objects; `restored` retains the array for the duration of the borrow.
             let peripherals: &NSArray<CBPeripheral> =
                 unsafe { &*(Retained::as_ptr(&restored) as *const NSArray<CBPeripheral>) };
+            if !self.ivars().radio_enabled.load(Ordering::Acquire) {
+                for peripheral in peripherals.iter() {
+                    let peer_id = core_bluetooth_peer_id(&peripheral);
+                    // Remove any earlier exact owner before cancellation so the queued shutdown
+                    // drain cannot repeat this cancellation.
+                    self.ivars().registry.borrow_mut().remove_peer(peer_id);
+                    // SAFETY: CoreBluetooth supplied the restored peripheral and manager together
+                    // on their serial queue. A logically disabled backend adopts no restored link.
+                    unsafe {
+                        peripheral.setDelegate(None);
+                        central.cancelPeripheralConnection(&peripheral);
+                    }
+                }
+                return;
+            }
             for peripheral in peripherals.iter() {
                 let peer_id = core_bluetooth_peer_id(&peripheral);
                 let address = peer_id.address();
+                let admission = self
+                    .ivars()
+                    .registry
+                    .borrow_mut()
+                    .admit_restored(peer_id, SendPeripheral(peripheral.retain()));
+                match admission {
+                    RestoredAdmission::Admitted | RestoredAdmission::Updated => {}
+                    RestoredAdmission::AlreadyOwned => {
+                        crate::diagnostic_log::debug!(
+                            "bluetooth: ignoring duplicate restoration for already-owned peripheral {:02x?}",
+                            address.octets()
+                        );
+                        continue;
+                    }
+                    RestoredAdmission::Full => {
+                        crate::diagnostic_log::warn!(
+                            "bluetooth: rejecting restored peripheral {:02x?} — restored-peer capacity is full",
+                            address.octets()
+                        );
+                        // SAFETY: CoreBluetooth supplied both live objects on the manager's serial
+                        // queue; the registry's mutable borrow ended before this framework call.
+                        unsafe { central.cancelPeripheralConnection(&peripheral) };
+                        continue;
+                    }
+                }
                 crate::diagnostic_log::debug!(
                     "bluetooth: restored peripheral {:02x?} from a background relaunch — re-adopting",
                     address.octets()
                 );
-                self.ivars()
-                    .pending_restored_callbacks
-                    .borrow_mut()
-                    .entry(peer_id)
-                    .or_default();
                 // CoreBluetooth may deliver the value notification that caused this relaunch as
                 // soon as the restoration delegate method returns. Install the peripheral
                 // delegate now and buffer those values until the Host admits this central-role
@@ -413,13 +874,11 @@ define_class!(
                 unsafe {
                     peripheral.setDelegate(Some(ProtocolObject::from_ref(self)));
                 }
-                if let Ok(mut map) = self.ivars().peripherals.lock() {
-                    map.insert(peer_id, (SendPeripheral(peripheral.retain()), None));
-                }
-                if let Ok(mut queue) = self.ivars().restored.lock() {
-                    queue.push_back(peer_id);
-                }
             }
+            // Wake the async backend without waiting for queue capacity. The capacity-one signal
+            // is only advisory; restored ownership remains in the queue-confined registry until
+            // the backend offers and claims it.
+            let _ = self.ivars().sighting_wake.try_send(());
         }
 
         #[unsafe(method(centralManager:didDiscoverPeripheral:advertisementData:RSSI:))]
@@ -430,9 +889,13 @@ define_class!(
             advertisement_data: &NSDictionary<NSString, AnyObject>,
             rssi: &NSNumber,
         ) {
+            if !self.ivars().radio_enabled.load(Ordering::Acquire) {
+                return;
+            }
             self.ivars().scan_activity.store(true, Ordering::Relaxed);
             let peer_id = core_bluetooth_peer_id(peripheral);
             let now = Instant::now();
+            self.reap_closed_sessions_at(central, now);
             let strength = advertisement_candidate_strength(advertisement_data);
             if cfg!(target_os = "macos")
                 && !self
@@ -493,22 +956,27 @@ define_class!(
             } else {
                 i8::try_from(dbm).ok()
             };
-            let address = peer_id.address();
-            if let Ok(mut map) = self.ivars().peripherals.lock() {
-                map.insert(peer_id, (SendPeripheral(peripheral.retain()), rssi));
+            let observed = self.ivars().registry.borrow_mut().observe(
+                peer_id,
+                SendPeripheral(peripheral.retain()),
+                rssi,
+            );
+            if !observed {
+                return;
             }
-            match try_bounded_ingress(&self.ivars().sightings, Sighting { address, rssi }) {
-                BoundedIngress::Accepted => {}
-                BoundedIngress::Full(_) => crate::diagnostic_log::debug!(
-                    "bluetooth: dropping advisory sighting for {:02x?} — sighting queue is full",
-                    address.octets()
-                ),
-                BoundedIngress::Closed(_) => {}
-            }
+            let _ = self.ivars().sighting_wake.try_send(());
         }
 
         #[unsafe(method(centralManager:didConnectPeripheral:))]
-        fn did_connect(&self, _central: &CBCentralManager, peripheral: &CBPeripheral) {
+        fn did_connect(&self, central: &CBCentralManager, peripheral: &CBPeripheral) {
+            if !self.ivars().radio_enabled.load(Ordering::Acquire) {
+                // A connect completion can race the queued logical shutdown. Remove the exact
+                // registry owner before cancelling so the later drain cannot cancel it twice; if
+                // shutdown already drained it, this intentionally does nothing.
+                self.cancel_registered_peer(central, core_bluetooth_peer_id(peripheral));
+                return;
+            }
+            self.reap_closed_sessions(central);
             let peer_id = core_bluetooth_peer_id(peripheral);
             if !self.ivars().sessions.borrow().contains_key(&peer_id) {
                 return;
@@ -527,7 +995,7 @@ define_class!(
             error: Option<&NSError>,
         ) {
             crate::diagnostic_log::warn!("bluetooth: dial connect FAILED: {error:?}");
-            self.fail_peer(core_bluetooth_peer_id(peripheral));
+            self.disconnect_peer(core_bluetooth_peer_id(peripheral));
         }
 
         #[unsafe(method(centralManager:didDisconnectPeripheral:error:))]
@@ -545,7 +1013,7 @@ define_class!(
             crate::diagnostic_log::warn!(
                 "bluetooth: central-role peripheral disconnected: {error:?}"
             );
-            self.fail_peer(peer_id);
+            self.disconnect_peer(peer_id);
         }
     }
 
@@ -779,20 +1247,24 @@ define_class!(
                 || cbuuid_eq(&updated_uuid, &columba_tx_uuid())
             {
                 let data = value.to_vec().into_boxed_slice();
-                if let Some(restored) = self
+                let restored = self
                     .ivars()
-                    .pending_restored_callbacks
+                    .registry
                     .borrow_mut()
-                    .get_mut(&peer_id)
-                {
-                    if !restored.buffer_data(data) {
+                    .buffer_restored_data(peer_id, data);
+                let data = match restored {
+                    RestoredBufferResult::Buffered | RestoredBufferResult::AlreadyFailed => {
+                        return;
+                    }
+                    RestoredBufferResult::Overflowed => {
                         crate::diagnostic_log::warn!(
                             "bluetooth: restored GATT notification buffer exceeded for {:02x?}",
                             peer_id.address().octets()
                         );
+                        return;
                     }
-                    return;
-                }
+                    RestoredBufferResult::NotRestored(data) => data,
+                };
                 let enqueue_error = self
                     .ivars()
                     .sessions
@@ -824,22 +1296,34 @@ define_class!(
             let Some(control) = Control::decode(&value.to_vec()) else {
                 return;
             };
-            if let Some(restored) = self
+            let restored = self
                 .ivars()
-                .pending_restored_callbacks
+                .registry
                 .borrow_mut()
-                .get_mut(&peer_id)
-            {
-                if !restored.buffer_control(control) {
+                .buffer_restored_control(peer_id, control);
+            let control = match restored {
+                RestoredBufferResult::Buffered | RestoredBufferResult::AlreadyFailed => return,
+                RestoredBufferResult::Overflowed => {
                     crate::diagnostic_log::warn!(
                         "bluetooth: restored control buffer exceeded for {:02x?}",
                         peer_id.address().octets()
                     );
+                    return;
                 }
-                return;
-            }
-            if let Some(session) = self.ivars().sessions.borrow().get(&peer_id) {
-                let _ = session.control_tx.try_send(control);
+                RestoredBufferResult::NotRestored(control) => control,
+            };
+            let enqueue_error = self
+                .ivars()
+                .sessions
+                .borrow()
+                .get(&peer_id)
+                .and_then(|session| session.enqueue_control(control).err());
+            if let Some(error) = enqueue_error {
+                crate::diagnostic_log::warn!(
+                    "bluetooth: control inbox failed for {:02x?}: {error:?}",
+                    peer_id.address().octets()
+                );
+                self.fail_peer(peer_id);
             }
         }
 
@@ -884,18 +1368,22 @@ define_class!(
 impl CentralDelegate {
     pub(super) fn new(
         manager_signals: ManagerSignalSender,
-        sightings: tokio_mpsc::Sender<Sighting>,
-        peripherals: PeripheralTable,
-        restored: RestoredPeripherals,
+        sighting_wake: tokio_mpsc::Sender<()>,
         scan_activity: Arc<AtomicBool>,
+        radio_enabled: Arc<AtomicBool>,
+        peripheral_capacity: usize,
+        restored_capacity: usize,
     ) -> Retained<Self> {
         let this = Self::alloc().set_ivars(CentralDelegateIvars {
             manager_signals,
-            sightings,
-            peripherals,
-            restored,
+            sighting_wake,
+            manager: RefCell::new(None),
+            radio_enabled,
+            registry: RefCell::new(CentralPeerRegistry::new(
+                peripheral_capacity,
+                restored_capacity,
+            )),
             scan_activity,
-            pending_restored_callbacks: RefCell::new(HashMap::new()),
             sessions: RefCell::new(HashMap::new()),
             discovery_guard: RefCell::new(DiscoveryGuard::default()),
         });
@@ -906,20 +1394,31 @@ impl CentralDelegate {
 
     pub(super) fn begin_session(
         &self,
+        central: &CBCentralManager,
         peer_id: CoreBluetoothPeerId,
         mut session: CentralPeerSession,
     ) -> bool {
-        if self.ivars().sessions.borrow().contains_key(&peer_id) {
-            session.reject();
+        *self.ivars().manager.borrow_mut() = Some(SendCentralManager(central.retain()));
+        if !self.ivars().radio_enabled.load(Ordering::Acquire) {
+            self.cancel_registered_peer(central, peer_id);
+            session.reject(DialRejection::RadioOff);
             return false;
         }
-        if let Some(callbacks) = self
-            .ivars()
-            .pending_restored_callbacks
-            .borrow_mut()
-            .remove(&peer_id)
-        {
+        self.reap_closed_sessions(central);
+        if self.ivars().sessions.borrow().contains_key(&peer_id) {
+            self.ivars().registry.borrow_mut().mark_active(peer_id);
+            session.reject(DialRejection::ExistingCentralSession);
+            return false;
+        }
+        let callbacks = self.ivars().registry.borrow_mut().begin_session(peer_id);
+        let Ok(callbacks) = callbacks else {
+            self.cancel_registered_peer(central, peer_id);
+            session.fail();
+            return false;
+        };
+        if let Some(callbacks) = callbacks {
             if !session.restore_callbacks(callbacks) {
+                self.cancel_registered_peer(central, peer_id);
                 session.fail();
                 return false;
             }
@@ -928,30 +1427,134 @@ impl CentralDelegate {
         true
     }
 
-    pub(super) fn discard_restored_callbacks(&self, peer_id: CoreBluetoothPeerId) {
-        self.ivars()
-            .pending_restored_callbacks
-            .borrow_mut()
-            .remove(&peer_id);
+    /// Queue-confined restored-event handoff for the async backend.
+    pub(super) fn offer_restored(&self) -> Option<CoreBluetoothPeerId> {
+        if !self.ivars().radio_enabled.load(Ordering::Acquire) {
+            return None;
+        }
+        self.ivars().registry.borrow_mut().offer_restored()
     }
 
-    pub(super) fn remove_session(&self, peer_id: CoreBluetoothPeerId) {
-        if let Some(session) = self.ivars().sessions.borrow_mut().remove(&peer_id) {
+    /// Queue-confined sighting handoff for the async backend.
+    pub(super) fn pop_sighting(&self) -> Option<Sighting> {
+        if !self.ivars().radio_enabled.load(Ordering::Acquire) {
+            return None;
+        }
+        let (sighting, more) = self.ivars().registry.borrow_mut().pop_sighting();
+        if more {
+            let _ = self.ivars().sighting_wake.try_send(());
+        }
+        sighting
+    }
+
+    /// Queue-confined dial lookup. Closed sessions are removed before registry admission so a
+    /// dropped link cannot keep either the per-peer entry or aggregate capacity pinned.
+    pub(super) fn claim(
+        &self,
+        central: &CBCentralManager,
+        address: BleAddress,
+    ) -> CentralDialCandidate<SendPeripheral> {
+        if !self.ivars().radio_enabled.load(Ordering::Acquire) {
+            return CentralDialCandidate::Missing;
+        }
+        self.reap_closed_sessions(central);
+        self.ivars().registry.borrow_mut().claim(address)
+    }
+
+    /// Queue-confined logical radio transition. Disabling fails every async session, clears all
+    /// callback/admission state, and cancels each restored, dialing, or active peripheral exactly
+    /// once. Published managers stay alive so a later enable does not rebuild CoreBluetooth state.
+    pub(super) fn set_radio_enabled(&self, central: &CBCentralManager, enabled: bool) {
+        self.ivars().radio_enabled.store(enabled, Ordering::Release);
+        if enabled {
+            return;
+        }
+
+        // SAFETY: the manager and delegate are confined to this serial CoreBluetooth queue.
+        unsafe { central.stopScan() };
+        self.ivars().scan_activity.store(false, Ordering::Relaxed);
+
+        let sessions = core::mem::take(&mut *self.ivars().sessions.borrow_mut());
+        for (_, session) in sessions {
+            session.fail();
+        }
+        let owned = self.ivars().registry.borrow_mut().drain_owned();
+        *self.ivars().discovery_guard.borrow_mut() = DiscoveryGuard::default();
+        for peripheral in owned {
+            // SAFETY: the retained peripheral, manager, and delegate all belong to this serial
+            // queue. Detaching first prevents late characteristic callbacks from reviving work.
+            unsafe {
+                peripheral.0.setDelegate(None);
+                central.cancelPeripheralConnection(&peripheral.0);
+            }
+        }
+    }
+
+    pub(super) fn discard_peer(&self, peer_id: CoreBluetoothPeerId) {
+        self.ivars().registry.borrow_mut().remove_peer(peer_id);
+    }
+
+    fn cancel_registered_peer(&self, central: &CBCentralManager, peer_id: CoreBluetoothPeerId) {
+        let peripheral = self.ivars().registry.borrow_mut().remove_peer(peer_id);
+        let Some(peripheral) = peripheral else {
+            return;
+        };
+        // SAFETY: the manager, retained peripheral, and this delegate are confined to the same
+        // serial CoreBluetooth queue.
+        unsafe { central.cancelPeripheralConnection(&peripheral.0) };
+    }
+
+    fn finish_peer(&self, peer_id: CoreBluetoothPeerId, cancel_connection: bool) {
+        let session = self.ivars().sessions.borrow_mut().remove(&peer_id);
+        let peripheral = self.ivars().registry.borrow_mut().remove_peer(peer_id);
+        if cancel_connection {
+            let central = self
+                .ivars()
+                .manager
+                .borrow()
+                .as_ref()
+                .map(|manager| manager.0.clone());
+            if let (Some(central), Some(peripheral)) = (central, peripheral) {
+                // SAFETY: every caller and both retained framework objects are confined to the
+                // central manager's serial dispatch queue.
+                unsafe { central.cancelPeripheralConnection(&peripheral.0) };
+            }
+        }
+        if let Some(session) = session {
             session.fail();
         }
     }
 
-    pub(super) fn remove_closed_session(&self, peer_id: CoreBluetoothPeerId) -> bool {
-        let link_closed = self
-            .ivars()
-            .sessions
-            .borrow()
-            .get(&peer_id)
-            .is_some_and(CentralPeerSession::data_receiver_closed);
-        if link_closed {
-            self.remove_session(peer_id);
+    fn disconnect_peer(&self, peer_id: CoreBluetoothPeerId) {
+        self.finish_peer(peer_id, false);
+    }
+
+    pub(super) fn reap_closed_sessions(&self, central: &CBCentralManager) {
+        self.reap_closed_sessions_at(central, Instant::now());
+    }
+
+    fn reap_closed_sessions_at(&self, central: &CBCentralManager, now: Instant) {
+        let closed = closed_central_session_ids(&self.ivars().sessions.borrow());
+        for peer_id in closed {
+            if let Some(session) = self.ivars().sessions.borrow_mut().remove(&peer_id) {
+                session.fail();
+            }
+            let peripheral = self.ivars().registry.borrow_mut().remove_peer(peer_id);
+            let Some(peripheral) = peripheral else {
+                continue;
+            };
+            self.ivars()
+                .discovery_guard
+                .borrow_mut()
+                .record_stale_cancellation(peer_id, now);
+            crate::diagnostic_log::debug!(
+                "bluetooth: reaping closed central session for {:02x?}",
+                peer_id.address().octets()
+            );
+            // SAFETY: this method and all callers are confined to the manager's serial dispatch
+            // queue; both retained framework objects remain live through the cancellation call.
+            unsafe { central.cancelPeripheralConnection(&peripheral.0) };
         }
-        link_closed
     }
 
     pub(super) fn submit_write(
@@ -960,6 +1563,10 @@ impl CentralDelegate {
         peer_id: CoreBluetoothPeerId,
         request: GattWriteRequest,
     ) {
+        if !self.ivars().radio_enabled.load(Ordering::Acquire) {
+            request.complete(Err(MacosBleError::Closed));
+            return;
+        }
         let mut sessions = self.ivars().sessions.borrow_mut();
         let Some(session) = sessions.get_mut(&peer_id) else {
             request.complete(Err(MacosBleError::Closed));
@@ -1030,9 +1637,8 @@ impl CentralDelegate {
         issue_unacknowledged_write(peripheral, request);
     }
 
-    fn fail_peer(&self, peer_id: CoreBluetoothPeerId) {
-        self.discard_restored_callbacks(peer_id);
-        self.remove_session(peer_id);
+    pub(super) fn fail_peer(&self, peer_id: CoreBluetoothPeerId) {
+        self.finish_peer(peer_id, true);
     }
 }
 

--- a/prns-ffi/src/bluetooth_auto/macos/central.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/central.rs
@@ -1,11 +1,11 @@
 use core::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
 use objc2::rc::Retained;
-use objc2::runtime::AnyObject;
+use objc2::runtime::{AnyObject, ProtocolObject};
 use objc2::{define_class, msg_send, AllocAnyThread, DefinedClass, Message};
 use objc2_core_bluetooth::{
     CBCentralManager, CBCentralManagerDelegate, CBCentralManagerRestoredStatePeripheralsKey,
@@ -22,7 +22,7 @@ use super::discovery::{
     advertisement_candidate_strength, discover_disposition, DiscoverDisposition, DiscoveryGuard,
     PeripheralLinkState, SessionPresence, StaleCancellation, StaleLinkRecovery,
 };
-use super::gatt_link::GattInboundSender;
+use super::gatt_link::{GattInboundSender, GATT_INBOUND_BUDGET_BYTES};
 use super::gatt_write::{
     write_admission, GattWriteAdmission, GattWriteMode, GattWriteRequest, GattWriteTarget,
     PendingAcknowledgedWrite,
@@ -66,6 +66,55 @@ pub(super) enum DialCompletion {
     Ready(DialChars),
     Failed,
     Rejected,
+}
+
+pub(super) const CENTRAL_CONTROL_INBOUND_CAPACITY: usize = 8;
+
+/// Value notifications received after CoreBluetooth restores a peripheral but before the Host
+/// admits its central-role session. A buffer overflow marks the handoff failed: silently skipping
+/// a control message or framed-data fragment could corrupt the restored protocol stream.
+#[derive(Default)]
+pub(super) struct RestoredCallbackBuffer {
+    controls: VecDeque<Control>,
+    data: VecDeque<Box<[u8]>>,
+    charged_data_bytes: usize,
+    failed: bool,
+}
+
+impl RestoredCallbackBuffer {
+    pub(super) fn buffer_control(&mut self, control: Control) -> bool {
+        if self.failed || self.controls.len() >= CENTRAL_CONTROL_INBOUND_CAPACITY {
+            self.fail();
+            return false;
+        }
+        self.controls.push_back(control);
+        true
+    }
+
+    pub(super) fn buffer_data(&mut self, data: Box<[u8]>) -> bool {
+        if self.failed {
+            return false;
+        }
+        let charge = data.len().max(1);
+        let Some(charged_data_bytes) = self.charged_data_bytes.checked_add(charge) else {
+            self.fail();
+            return false;
+        };
+        if charged_data_bytes > GATT_INBOUND_BUDGET_BYTES {
+            self.fail();
+            return false;
+        }
+        self.charged_data_bytes = charged_data_bytes;
+        self.data.push_back(data);
+        true
+    }
+
+    fn fail(&mut self) {
+        self.failed = true;
+        self.controls.clear();
+        self.data.clear();
+        self.charged_data_bytes = 0;
+    }
 }
 
 enum ColumbaReadiness {
@@ -191,6 +240,23 @@ impl CentralPeerSession {
         }
     }
 
+    pub(super) fn restore_callbacks(&mut self, callbacks: RestoredCallbackBuffer) -> bool {
+        if callbacks.failed {
+            return false;
+        }
+        for control in callbacks.controls {
+            if self.control_tx.try_send(control).is_err() {
+                return false;
+            }
+        }
+        for data in callbacks.data {
+            if self.data_tx.try_send(data).is_err() {
+                return false;
+            }
+        }
+        true
+    }
+
     fn complete_columba(
         &mut self,
         write: GattWriteTarget,
@@ -287,6 +353,7 @@ pub(super) struct CentralDelegateIvars {
     peripherals: PeripheralTable,
     restored: RestoredPeripherals,
     scan_activity: Arc<AtomicBool>,
+    pending_restored_callbacks: RefCell<HashMap<CoreBluetoothPeerId, RestoredCallbackBuffer>>,
     sessions: RefCell<HashMap<CoreBluetoothPeerId, CentralPeerSession>>,
     discovery_guard: RefCell<DiscoveryGuard>,
 }
@@ -330,6 +397,20 @@ define_class!(
                     "bluetooth: restored peripheral {:02x?} from a background relaunch — re-adopting",
                     address.octets()
                 );
+                self.ivars()
+                    .pending_restored_callbacks
+                    .borrow_mut()
+                    .entry(peer_id)
+                    .or_default();
+                // CoreBluetooth may deliver the value notification that caused this relaunch as
+                // soon as the restoration delegate method returns. Install the peripheral
+                // delegate now and buffer those values until the Host admits this central-role
+                // session. Discovery, subscriptions, and identity reads are re-driven afterward.
+                // SAFETY: CoreBluetooth supplied this retained peripheral on the manager's serial
+                // queue, and `self` remains retained as the manager delegate.
+                unsafe {
+                    peripheral.setDelegate(Some(ProtocolObject::from_ref(self)));
+                }
                 if let Ok(mut map) = self.ivars().peripherals.lock() {
                     map.insert(peer_id, (SendPeripheral(peripheral.retain()), None));
                 }
@@ -452,7 +533,9 @@ define_class!(
                 .discovery_guard
                 .borrow_mut()
                 .clear_stale_cancellation(peer_id);
-            crate::diagnostic_log::warn!("bluetooth: dialed peripheral disconnected: {error:?}");
+            crate::diagnostic_log::warn!(
+                "bluetooth: central-role peripheral disconnected: {error:?}"
+            );
             self.fail_peer(peer_id);
         }
     }
@@ -686,17 +769,27 @@ define_class!(
             if cbuuid_eq(&updated_uuid, &data_uuid())
                 || cbuuid_eq(&updated_uuid, &columba_tx_uuid())
             {
-                let enqueue_error =
-                    self.ivars()
-                        .sessions
-                        .borrow()
-                        .get(&peer_id)
-                        .and_then(|session| {
-                            session
-                                .data_tx
-                                .try_send(Box::from(&value.to_vec()[..]))
-                                .err()
-                        });
+                let data = value.to_vec().into_boxed_slice();
+                if let Some(restored) = self
+                    .ivars()
+                    .pending_restored_callbacks
+                    .borrow_mut()
+                    .get_mut(&peer_id)
+                {
+                    if !restored.buffer_data(data) {
+                        crate::diagnostic_log::warn!(
+                            "bluetooth: restored GATT notification buffer exceeded for {:02x?}",
+                            peer_id.address().octets()
+                        );
+                    }
+                    return;
+                }
+                let enqueue_error = self
+                    .ivars()
+                    .sessions
+                    .borrow()
+                    .get(&peer_id)
+                    .and_then(|session| session.data_tx.try_send(data).err());
                 if let Some(error) = enqueue_error {
                     crate::diagnostic_log::warn!(
                         "bluetooth: GATT notification inbox failed for {:02x?}: {error:?}",
@@ -722,6 +815,20 @@ define_class!(
             let Some(control) = Control::decode(&value.to_vec()) else {
                 return;
             };
+            if let Some(restored) = self
+                .ivars()
+                .pending_restored_callbacks
+                .borrow_mut()
+                .get_mut(&peer_id)
+            {
+                if !restored.buffer_control(control) {
+                    crate::diagnostic_log::warn!(
+                        "bluetooth: restored control buffer exceeded for {:02x?}",
+                        peer_id.address().octets()
+                    );
+                }
+                return;
+            }
             if let Some(session) = self.ivars().sessions.borrow().get(&peer_id) {
                 let _ = session.control_tx.try_send(control);
             }
@@ -777,6 +884,7 @@ impl CentralDelegate {
             peripherals,
             restored,
             scan_activity,
+            pending_restored_callbacks: RefCell::new(HashMap::new()),
             sessions: RefCell::new(HashMap::new()),
             discovery_guard: RefCell::new(DiscoveryGuard::default()),
         });
@@ -788,14 +896,32 @@ impl CentralDelegate {
     pub(super) fn begin_session(
         &self,
         peer_id: CoreBluetoothPeerId,
-        session: CentralPeerSession,
+        mut session: CentralPeerSession,
     ) -> bool {
         if self.ivars().sessions.borrow().contains_key(&peer_id) {
             session.reject();
             return false;
         }
+        if let Some(callbacks) = self
+            .ivars()
+            .pending_restored_callbacks
+            .borrow_mut()
+            .remove(&peer_id)
+        {
+            if !session.restore_callbacks(callbacks) {
+                session.fail();
+                return false;
+            }
+        }
         self.ivars().sessions.borrow_mut().insert(peer_id, session);
         true
+    }
+
+    pub(super) fn discard_restored_callbacks(&self, peer_id: CoreBluetoothPeerId) {
+        self.ivars()
+            .pending_restored_callbacks
+            .borrow_mut()
+            .remove(&peer_id);
     }
 
     pub(super) fn remove_session(&self, peer_id: CoreBluetoothPeerId) {
@@ -894,6 +1020,7 @@ impl CentralDelegate {
     }
 
     fn fail_peer(&self, peer_id: CoreBluetoothPeerId) {
+        self.discard_restored_callbacks(peer_id);
         self.remove_session(peer_id);
     }
 }

--- a/prns-ffi/src/bluetooth_auto/macos/central.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/central.rs
@@ -29,8 +29,9 @@ use super::gatt_write::{
 };
 use super::{
     cbuuid_eq, columba_identity_uuid, columba_rx_uuid, columba_tx_uuid, control_uuid,
-    core_bluetooth_peer_id, data_uuid, service_uuid, CoreBluetoothPeerId, Event, MacosBleError,
-    PeripheralTable, RestoredPeripherals, SendCharacteristicRef, SendPeripheral,
+    core_bluetooth_peer_id, data_uuid, service_uuid, try_bounded_ingress, BoundedIngress,
+    CoreBluetoothPeerId, MacosBleError, ManagerSignalSender, PeripheralTable, RestoredPeripherals,
+    SendCharacteristicRef, SendPeripheral, Sighting,
 };
 
 pub(super) fn is_system_connected(
@@ -349,7 +350,8 @@ pub(super) struct DialCommand {
 unsafe impl Send for DialCommand {}
 
 pub(super) struct CentralDelegateIvars {
-    events: tokio_mpsc::UnboundedSender<Event>,
+    manager_signals: ManagerSignalSender,
+    sightings: tokio_mpsc::Sender<Sighting>,
     peripherals: PeripheralTable,
     restored: RestoredPeripherals,
     scan_activity: Arc<AtomicBool>,
@@ -371,7 +373,7 @@ define_class!(
             // SAFETY: CoreBluetooth supplied this live manager to its delegate on the configured
             // serial dispatch queue.
             if unsafe { central.state() } == CBManagerState::PoweredOn {
-                let _ = self.ivars().events.send(Event::CentralPowered);
+                self.ivars().manager_signals.central_powered();
             }
         }
 
@@ -495,7 +497,14 @@ define_class!(
             if let Ok(mut map) = self.ivars().peripherals.lock() {
                 map.insert(peer_id, (SendPeripheral(peripheral.retain()), rssi));
             }
-            let _ = self.ivars().events.send(Event::Sighting { address, rssi });
+            match try_bounded_ingress(&self.ivars().sightings, Sighting { address, rssi }) {
+                BoundedIngress::Accepted => {}
+                BoundedIngress::Full(_) => crate::diagnostic_log::debug!(
+                    "bluetooth: dropping advisory sighting for {:02x?} — sighting queue is full",
+                    address.octets()
+                ),
+                BoundedIngress::Closed(_) => {}
+            }
         }
 
         #[unsafe(method(centralManager:didConnectPeripheral:))]
@@ -874,13 +883,15 @@ define_class!(
 
 impl CentralDelegate {
     pub(super) fn new(
-        events: tokio_mpsc::UnboundedSender<Event>,
+        manager_signals: ManagerSignalSender,
+        sightings: tokio_mpsc::Sender<Sighting>,
         peripherals: PeripheralTable,
         restored: RestoredPeripherals,
         scan_activity: Arc<AtomicBool>,
     ) -> Retained<Self> {
         let this = Self::alloc().set_ivars(CentralDelegateIvars {
-            events,
+            manager_signals,
+            sightings,
             peripherals,
             restored,
             scan_activity,

--- a/prns-ffi/src/bluetooth_auto/macos/central.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/central.rs
@@ -47,6 +47,14 @@ pub(super) fn is_system_connected(
         .any(|peripheral| core_bluetooth_peer_id(&peripheral) == peer_id)
 }
 
+pub(super) fn discover_prns_services(peripheral: &CBPeripheral) {
+    let uuid = service_uuid();
+    let services = NSArray::from_slice(&[&*uuid]);
+    // SAFETY: callers hold a live peripheral on the CoreBluetooth serial dispatch queue, and
+    // `services` is a correctly typed, retained NSArray for the duration of the message.
+    unsafe { peripheral.discoverServices(Some(&services)) };
+}
+
 pub(super) struct DialChars {
     pub(super) peer_protocol: PeerProtocol,
     pub(super) peer_identity: Option<BleIdentity>,
@@ -418,11 +426,7 @@ define_class!(
             crate::diagnostic_log::debug!(
                 "bluetooth: dial connected over LE, discovering Prns service"
             );
-            let uuid = service_uuid();
-            let services = NSArray::from_slice(&[&*uuid]);
-            // SAFETY: `peripheral` is live for this callback and `services` is a correctly typed,
-            // retained NSArray for the duration of the Objective-C message.
-            unsafe { peripheral.discoverServices(Some(&services)) };
+            discover_prns_services(peripheral);
         }
 
         #[unsafe(method(centralManager:didFailToConnectPeripheral:error:))]

--- a/prns-ffi/src/bluetooth_auto/macos/data_plane.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/data_plane.rs
@@ -194,17 +194,10 @@ unsafe extern "C-unwind" fn write_cb(
 pub(super) fn wire_l2cap(
     channel: &CBL2CAPChannel,
     queue: &DispatchRetained<DispatchQueue>,
-) -> Option<(CoreBluetoothPeerId, DataPlane)> {
+) -> Option<DataPlane> {
     // SAFETY: CoreBluetooth supplied a live retained channel, and its accessors return retained
     // objects whose runtime types match the generated bindings.
-    let (peer_id, input, output) = unsafe {
-        let peer = channel.peer()?;
-        (
-            core_bluetooth_peer_id(&peer),
-            channel.inputStream()?,
-            channel.outputStream()?,
-        )
-    };
+    let (input, output) = unsafe { (channel.inputStream()?, channel.outputStream()?) };
     let (inbound_tx, inbound_rx) = tokio_mpsc::channel::<Box<[u8]>>(16);
     let outbound = Arc::new(Mutex::new(Outbound {
         pending: VecDeque::new(),
@@ -238,19 +231,37 @@ pub(super) fn wire_l2cap(
         pump_ref.input.open();
         pump_ref.output.open();
     }
-    Some((
-        peer_id,
-        DataPlane {
-            inbound_rx,
-            outbound,
+    Some(DataPlane {
+        inbound_rx,
+        outbound,
+        queue: queue.clone(),
+        pump_ptr: PumpPtr(pump),
+        pump: Arc::new(PumpHandle {
+            ptr: pump,
             queue: queue.clone(),
-            pump_ptr: PumpPtr(pump),
-            pump: Arc::new(PumpHandle {
-                ptr: pump,
-                queue: queue.clone(),
-            }),
-        },
-    ))
+        }),
+    })
+}
+
+/// Read the exact CoreBluetooth peer identity without touching or opening the channel streams.
+pub(super) fn l2cap_peer_id(channel: &CBL2CAPChannel) -> Option<CoreBluetoothPeerId> {
+    // SAFETY: CoreBluetooth supplied a live channel and retains its peer for the callback.
+    unsafe { channel.peer().map(|peer| core_bluetooth_peer_id(&peer)) }
+}
+
+/// Explicitly close a refused channel. CoreBluetooth has no delegate acknowledgement for an
+/// inbound CoC, so closing both unopened stream halves is the only immediate negative signal.
+pub(super) fn close_l2cap(channel: &CBL2CAPChannel) {
+    // SAFETY: CoreBluetooth supplied a live channel. Closing an unopened or already closed
+    // NSStream is idempotent and does not schedule either stream on a run loop or dispatch queue.
+    unsafe {
+        if let Some(input) = channel.inputStream() {
+            input.close();
+        }
+        if let Some(output) = channel.outputStream() {
+            output.close();
+        }
+    }
 }
 
 pub(super) struct DataPlane {
@@ -259,6 +270,16 @@ pub(super) struct DataPlane {
     pub(super) queue: DispatchRetained<DispatchQueue>,
     pub(super) pump_ptr: PumpPtr,
     pub(super) pump: Arc<PumpHandle>,
+}
+
+impl DataPlane {
+    fn is_closed(&self) -> bool {
+        self.inbound_rx.is_closed()
+            || self
+                .outbound
+                .lock()
+                .map_or(true, |outbound| outbound.closed)
+    }
 }
 
 const MAX_BUFFERED_L2CAP: usize = 4;
@@ -270,25 +291,58 @@ pub(super) struct PendingL2cap {
 }
 
 impl PendingL2cap {
-    pub(super) fn deliver(&mut self, mut data: DataPlane) {
+    pub(super) fn deliver(&mut self, mut data: DataPlane) -> bool {
+        self.reap_closed();
         while let Some(tx) = self.waiters.pop_front() {
             match tx.send(data) {
-                Ok(()) => return,
+                Ok(()) => return true,
                 Err(returned) => data = returned,
             }
         }
-        self.ready.push_back(data);
-        while self.ready.len() > MAX_BUFFERED_L2CAP {
-            self.ready.pop_front();
+        if self.ready.len() >= MAX_BUFFERED_L2CAP {
+            return false;
         }
+        self.ready.push_back(data);
+        true
     }
 
-    pub(super) fn arm(&mut self, tx: oneshot::Sender<DataPlane>) {
+    pub(super) fn arm(&mut self, tx: oneshot::Sender<DataPlane>) -> bool {
+        self.reap_closed();
+        if tx.is_closed() {
+            return false;
+        }
         match self.ready.pop_front() {
             Some(data) => {
                 let _ = tx.send(data);
+                true
             }
-            None => self.waiters.push_back(tx),
+            None => {
+                self.waiters.retain(|waiter| !waiter.is_closed());
+                if self.waiters.len() >= MAX_BUFFERED_L2CAP {
+                    return false;
+                }
+                self.waiters.push_back(tx);
+                true
+            }
         }
+    }
+
+    pub(super) fn can_deliver(&self) -> bool {
+        self.waiters.iter().any(|waiter| !waiter.is_closed())
+            || self.ready.len() < MAX_BUFFERED_L2CAP
+    }
+
+    pub(super) fn reap_closed(&mut self) {
+        self.waiters.retain(|waiter| !waiter.is_closed());
+        self.ready.retain(|data| !data.is_closed());
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.waiters.is_empty() && self.ready.is_empty()
+    }
+
+    #[cfg(test)]
+    pub(super) fn waiter_len(&self) -> usize {
+        self.waiters.len()
     }
 }

--- a/prns-ffi/src/bluetooth_auto/macos/gatt_link.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/gatt_link.rs
@@ -21,7 +21,7 @@ use super::{
 };
 
 const GATT_WRITE_TIMEOUT: Duration = Duration::from_secs(5);
-const GATT_INBOUND_BUDGET_BYTES: usize = 128 * 1024;
+pub(super) const GATT_INBOUND_BUDGET_BYTES: usize = 128 * 1024;
 
 #[derive(Clone)]
 pub(super) struct GattInboundSender {

--- a/prns-ffi/src/bluetooth_auto/macos/gatt_link.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/gatt_link.rs
@@ -127,7 +127,7 @@ pub(super) enum ControlPlane {
         data_characteristic: Option<GattWriteTarget>,
         central_delegate: SendCentralDelegate,
         queue: DispatchRetained<DispatchQueue>,
-        peripheral_manager: SendPeripheralDelegate,
+        peripheral_manager: Option<SendPeripheralDelegate>,
     },
 }
 
@@ -138,6 +138,23 @@ impl ControlPlane {
             Self::Listener { .. } => FailurePolicy::EndInboundLink,
         }
     }
+}
+
+fn arm_central_l2cap(
+    peripheral_manager: Option<&SendPeripheralDelegate>,
+    peer_id: CoreBluetoothPeerId,
+    completion: oneshot::Sender<DataPlane>,
+) -> bool {
+    let Some(peripheral_manager) = peripheral_manager else {
+        crate::diagnostic_log::warn!(
+            "bluetooth: ignoring L2CAP accept without a local peripheral role; staying on the GATT floor"
+        );
+        return false;
+    };
+    peripheral_manager
+        .0
+        .arm_pending_channel(peer_id, completion);
+    true
 }
 
 enum GattWriter {
@@ -365,7 +382,11 @@ impl BleLink for GattLink {
                         peer_id,
                         peripheral_manager,
                         ..
-                    } => peripheral_manager.0.arm_pending_channel(*peer_id, tx),
+                    } => {
+                        if !arm_central_l2cap(peripheral_manager.as_ref(), *peer_id, tx) {
+                            return Ok(());
+                        }
+                    }
                     ControlPlane::Listener {
                         peer_id, delegate, ..
                     } => delegate.0.arm_pending_channel(*peer_id, tx),
@@ -538,6 +559,13 @@ impl BleSink for GattSink {
 #[cfg(test)]
 mod source_lifecycle_tests {
     use super::*;
+
+    #[test]
+    fn central_only_link_rejects_a_local_l2cap_accept_plan() {
+        let (tx, rx) = oneshot::channel();
+        assert!(!arm_central_l2cap(None, CoreBluetoothPeerId([0; 16]), tx));
+        assert!(rx.blocking_recv().is_err());
+    }
 
     #[tokio::test]
     async fn inbound_l2cap_end_closes_source_while_gatt_floor_is_still_open() {

--- a/prns-ffi/src/bluetooth_auto/macos/l2cap_lifecycle.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/l2cap_lifecycle.rs
@@ -111,8 +111,13 @@ fn spawn_l2cap_lane(
         }
     };
     tokio::spawn(async move {
-        let Ok(data) = pending.await else {
-            return;
+        let data = tokio::select! {
+            biased;
+            _ = frames.closed() => return,
+            data = pending => match data {
+                Ok(data) => data,
+                Err(_) => return,
+            },
         };
         crate::diagnostic_log::debug!(
             "bluetooth: L2CAP fast lane up — data now rides the channel, GATT stays the floor"
@@ -131,18 +136,7 @@ fn spawn_l2cap_lane(
             _pump: pump.clone(),
         });
         let _read_pump = pump;
-        let mut deframer = StreamDeframer::<{ 2 * L2CAP_SDU_LEN }>::new();
-        let mut frame = std::vec![0u8; 2 * L2CAP_SDU_LEN];
-        'read: while let Some(chunk) = inbound_rx.recv().await {
-            if !deframer.absorb(&chunk) {
-                break;
-            }
-            while let Some(len) = deframer.next_frame(&mut frame) {
-                if frames.send(Box::from(&frame[..len])).await.is_err() {
-                    break 'read;
-                }
-            }
-        }
+        receive_l2cap_frames(&mut inbound_rx, &frames).await;
         match end_action {
             EndAction::RetainGattFloor => {
                 // The detached task continues to own the central-role GATT receive floor.
@@ -166,6 +160,32 @@ fn spawn_l2cap_lane(
     PendingLane {
         write_ready,
         link_end,
+    }
+}
+
+async fn receive_l2cap_frames(
+    inbound_rx: &mut tokio_mpsc::Receiver<Box<[u8]>>,
+    frames: &tokio_mpsc::Sender<Box<[u8]>>,
+) {
+    let mut deframer = StreamDeframer::<{ 2 * L2CAP_SDU_LEN }>::new();
+    let mut frame = std::vec![0u8; 2 * L2CAP_SDU_LEN];
+    'read: loop {
+        let chunk = tokio::select! {
+            biased;
+            _ = frames.closed() => break,
+            chunk = inbound_rx.recv() => match chunk {
+                Some(chunk) => chunk,
+                None => break,
+            },
+        };
+        if !deframer.absorb(&chunk) {
+            break;
+        }
+        while let Some(len) = deframer.next_frame(&mut frame) {
+            if frames.send(Box::from(&frame[..len])).await.is_err() {
+                break 'read;
+            }
+        }
     }
 }
 
@@ -217,5 +237,36 @@ mod tests {
         stop_gatt_merge(Some(gatt_merge)).await;
 
         assert!(gatt_tx.is_closed());
+    }
+
+    #[tokio::test]
+    async fn dropped_link_releases_a_fast_lane_that_never_arrived() {
+        let (mut pending_tx, pending_rx) = oneshot::channel::<DataPlane>();
+        let (frames_tx, frames_rx) = tokio_mpsc::channel(1);
+
+        let lane = spawn_l2cap_lane(pending_rx, frames_tx, None, FailurePolicy::RetainGattFloor);
+        drop(lane);
+        drop(frames_rx);
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), pending_tx.closed())
+            .await
+            .expect("the detached lane must release its pending receiver with the link");
+    }
+
+    #[tokio::test]
+    async fn dropped_link_stops_an_idle_delivered_fast_lane() {
+        let (inbound_tx, mut inbound_rx) = tokio_mpsc::channel::<Box<[u8]>>(1);
+        let (frames_tx, frames_rx) = tokio_mpsc::channel(1);
+
+        let lane = tokio::spawn(async move {
+            receive_l2cap_frames(&mut inbound_rx, &frames_tx).await;
+        });
+        drop(frames_rx);
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), lane)
+            .await
+            .expect("the delivered lane must stop when its owning link is dropped")
+            .expect("the delivered lane task must not panic");
+        assert!(inbound_tx.is_closed());
     }
 }

--- a/prns-ffi/src/bluetooth_auto/macos/mod.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/mod.rs
@@ -36,7 +36,10 @@ use prns_core::interfaces::bluetooth_auto::{
 use central::CentralDelegate;
 use peripheral::PeripheralDelegate;
 
-pub use backend::{MacosBleBackend, PreparedMacosBleBackend};
+pub use backend::{
+    CentralOnlyMacosBleBackend, MacosBleBackend, PreparedCentralOnlyMacosBleBackend,
+    PreparedMacosBleBackend,
+};
 pub use gatt_link::{GattSink, GattSource};
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
@@ -67,6 +70,36 @@ const PERIPHERAL_RESTORE_IDENTIFIER: &str = "com.personal.prns.ble.peripheral";
 pub struct CoreBluetoothRestorationIdentifiers {
     central: String,
     peripheral: String,
+}
+
+/// Stable, application-owned identifier for the CoreBluetooth central manager used by a
+/// central-only Bluetooth Auto backend.
+///
+/// This identifier opts only the central manager into CoreBluetooth state preservation and
+/// restoration. The containing application is responsible for declaring the `bluetooth-central`
+/// background mode and recreating the manager with this exact identifier when iOS relaunches it.
+/// No peripheral restoration identifier is accepted because central-only preparation does not
+/// create a `CBPeripheralManager`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg(any(test, target_os = "ios"))]
+pub struct CoreBluetoothCentralRestorationIdentifier(String);
+
+#[cfg(any(test, target_os = "ios"))]
+impl CoreBluetoothCentralRestorationIdentifier {
+    pub fn new(
+        identifier: impl Into<String>,
+    ) -> Result<Self, CoreBluetoothRestorationIdentifiersError> {
+        let identifier = identifier.into();
+        if identifier.is_empty() {
+            return Err(CoreBluetoothRestorationIdentifiersError::EmptyCentral);
+        }
+        Ok(Self(identifier))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 #[cfg(any(test, target_os = "ios"))]

--- a/prns-ffi/src/bluetooth_auto/macos/mod.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/mod.rs
@@ -284,7 +284,7 @@ impl SendPeripheralDelegate {
     }
 }
 
-enum Event {
+enum Event<L = GattLink> {
     CentralPowered,
     GattServicePublished,
     GattServicePublishFailed,
@@ -296,7 +296,7 @@ enum Event {
         address: BleAddress,
         rssi: Option<i8>,
     },
-    Inbound(GattLink),
+    Inbound(L),
 }
 
 #[derive(Debug)]

--- a/prns-ffi/src/bluetooth_auto/macos/mod.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/mod.rs
@@ -25,6 +25,7 @@ use objc2_core_bluetooth::{
     CBPeripheralManager, CBUUID,
 };
 use objc2_foundation::{NSArray, NSData, NSDictionary, NSNumber, NSString};
+use tokio::sync::{mpsc as tokio_mpsc, watch};
 
 use prns_core::interfaces::bluetooth_auto::{
     BleAddress, BleUuid, BLE_SERVICE_UUID, COLUMBA_IDENTITY_UUID, COLUMBA_RX_UUID, COLUMBA_TX_UUID,
@@ -32,7 +33,6 @@ use prns_core::interfaces::bluetooth_auto::{
 };
 
 use central::CentralDelegate;
-use gatt_link::GattLink;
 use peripheral::PeripheralDelegate;
 
 pub use backend::{MacosBleBackend, PreparedMacosBleBackend};
@@ -284,19 +284,90 @@ impl SendPeripheralDelegate {
     }
 }
 
-enum Event<L = GattLink> {
-    CentralPowered,
-    GattServicePublished,
-    GattServicePublishFailed,
-    L2capPublished {
-        psm: u16,
-    },
-    L2capPublishFailed,
-    Sighting {
-        address: BleAddress,
-        rssi: Option<i8>,
-    },
-    Inbound(L),
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum PublicationState {
+    #[default]
+    Waiting,
+    Published,
+    Failed,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum L2capPublicationState {
+    #[default]
+    Waiting,
+    Published(u16),
+    Failed,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct ManagerSignals {
+    central_powered_generation: u64,
+    gatt: PublicationState,
+    l2cap: L2capPublicationState,
+}
+
+#[derive(Clone)]
+struct ManagerSignalSender(watch::Sender<ManagerSignals>);
+
+impl ManagerSignalSender {
+    fn central_powered(&self) {
+        self.0.send_modify(|signals| {
+            signals.central_powered_generation = signals.central_powered_generation.wrapping_add(1);
+        });
+    }
+
+    fn gatt_service_published(&self) {
+        self.0.send_modify(|signals| {
+            if signals.gatt != PublicationState::Failed {
+                signals.gatt = PublicationState::Published;
+            }
+        });
+    }
+
+    fn gatt_service_publish_failed(&self) {
+        self.0
+            .send_modify(|signals| signals.gatt = PublicationState::Failed);
+    }
+
+    fn l2cap_published(&self, psm: u16) {
+        self.0.send_modify(|signals| {
+            if signals.l2cap != L2capPublicationState::Failed {
+                signals.l2cap = L2capPublicationState::Published(psm);
+            }
+        });
+    }
+
+    fn l2cap_publish_failed(&self) {
+        self.0
+            .send_modify(|signals| signals.l2cap = L2capPublicationState::Failed);
+    }
+}
+
+fn manager_signal_channel() -> (ManagerSignalSender, watch::Receiver<ManagerSignals>) {
+    let (sender, receiver) = watch::channel(ManagerSignals::default());
+    (ManagerSignalSender(sender), receiver)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Sighting {
+    address: BleAddress,
+    rssi: Option<i8>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum BoundedIngress<T> {
+    Accepted,
+    Full(T),
+    Closed(T),
+}
+
+fn try_bounded_ingress<T>(sender: &tokio_mpsc::Sender<T>, value: T) -> BoundedIngress<T> {
+    match sender.try_send(value) {
+        Ok(()) => BoundedIngress::Accepted,
+        Err(tokio_mpsc::error::TrySendError::Full(value)) => BoundedIngress::Full(value),
+        Err(tokio_mpsc::error::TrySendError::Closed(value)) => BoundedIngress::Closed(value),
+    }
 }
 
 #[derive(Debug)]

--- a/prns-ffi/src/bluetooth_auto/macos/mod.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/mod.rs
@@ -13,6 +13,9 @@ mod tests;
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
+#[cfg(any(test, target_os = "ios"))]
+use std::fmt;
+
 use objc2::msg_send;
 use objc2::rc::Retained;
 use objc2::runtime::AnyObject;
@@ -49,10 +52,92 @@ impl CoreBluetoothPeerId {
     }
 }
 
-#[cfg(target_os = "ios")]
+#[cfg(any(test, target_os = "ios"))]
 const CENTRAL_RESTORE_IDENTIFIER: &str = "com.personal.prns.ble.central";
-#[cfg(target_os = "ios")]
+#[cfg(any(test, target_os = "ios"))]
 const PERIPHERAL_RESTORE_IDENTIFIER: &str = "com.personal.prns.ble.peripheral";
+
+/// Stable, application-owned identifiers for the two CoreBluetooth managers used by Bluetooth
+/// Auto.
+///
+/// Passing these identifiers opts the caller into CoreBluetooth state preservation and
+/// restoration. The containing application is responsible for declaring the matching central and
+/// peripheral background modes and reinstantiating the managers with the same identifiers when
+/// iOS relaunches it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg(any(test, target_os = "ios"))]
+pub struct CoreBluetoothRestorationIdentifiers {
+    central: String,
+    peripheral: String,
+}
+
+#[cfg(any(test, target_os = "ios"))]
+impl CoreBluetoothRestorationIdentifiers {
+    pub fn new(
+        central: impl Into<String>,
+        peripheral: impl Into<String>,
+    ) -> Result<Self, CoreBluetoothRestorationIdentifiersError> {
+        let central = central.into();
+        if central.is_empty() {
+            return Err(CoreBluetoothRestorationIdentifiersError::EmptyCentral);
+        }
+        let peripheral = peripheral.into();
+        if peripheral.is_empty() {
+            return Err(CoreBluetoothRestorationIdentifiersError::EmptyPeripheral);
+        }
+        if central == peripheral {
+            return Err(CoreBluetoothRestorationIdentifiersError::Duplicate);
+        }
+        Ok(Self {
+            central,
+            peripheral,
+        })
+    }
+
+    #[must_use]
+    pub fn central(&self) -> &str {
+        &self.central
+    }
+
+    #[must_use]
+    pub fn peripheral(&self) -> &str {
+        &self.peripheral
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg(any(test, target_os = "ios"))]
+pub enum CoreBluetoothRestorationIdentifiersError {
+    EmptyCentral,
+    EmptyPeripheral,
+    Duplicate,
+}
+
+#[cfg(any(test, target_os = "ios"))]
+impl fmt::Display for CoreBluetoothRestorationIdentifiersError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyCentral => formatter
+                .write_str("the CoreBluetooth central restoration identifier must not be empty"),
+            Self::EmptyPeripheral => formatter
+                .write_str("the CoreBluetooth peripheral restoration identifier must not be empty"),
+            Self::Duplicate => formatter.write_str(
+                "the CoreBluetooth central and peripheral restoration identifiers must differ",
+            ),
+        }
+    }
+}
+
+#[cfg(any(test, target_os = "ios"))]
+impl std::error::Error for CoreBluetoothRestorationIdentifiersError {}
+
+#[cfg(any(test, target_os = "ios"))]
+fn legacy_restoration_identifiers() -> CoreBluetoothRestorationIdentifiers {
+    CoreBluetoothRestorationIdentifiers {
+        central: CENTRAL_RESTORE_IDENTIFIER.to_owned(),
+        peripheral: PERIPHERAL_RESTORE_IDENTIFIER.to_owned(),
+    }
+}
 
 fn cbuuid(uuid: BleUuid) -> Retained<CBUUID> {
     match uuid {
@@ -121,22 +206,22 @@ fn scan_options() -> Retained<NSDictionary<NSString, AnyObject>> {
 }
 
 #[cfg(target_os = "ios")]
-fn central_manager_options() -> Retained<NSDictionary<NSString, AnyObject>> {
+fn central_manager_options(identifier: &str) -> Retained<NSDictionary<NSString, AnyObject>> {
     use objc2_core_bluetooth::CBCentralManagerOptionRestoreIdentifierKey;
     // SAFETY: CoreBluetooth exports this NSString constant with process lifetime.
     let key: &NSString = unsafe { CBCentralManagerOptionRestoreIdentifierKey };
-    let value = NSString::from_str(CENTRAL_RESTORE_IDENTIFIER);
+    let value = NSString::from_str(identifier);
     let value_ref: &NSString = &value;
     let value_obj: &AnyObject = value_ref;
     NSDictionary::from_slices(&[key], &[value_obj])
 }
 
 #[cfg(target_os = "ios")]
-fn peripheral_manager_options() -> Retained<NSDictionary<NSString, AnyObject>> {
+fn peripheral_manager_options(identifier: &str) -> Retained<NSDictionary<NSString, AnyObject>> {
     use objc2_core_bluetooth::CBPeripheralManagerOptionRestoreIdentifierKey;
     // SAFETY: CoreBluetooth exports this NSString constant with process lifetime.
     let key: &NSString = unsafe { CBPeripheralManagerOptionRestoreIdentifierKey };
-    let value = NSString::from_str(PERIPHERAL_RESTORE_IDENTIFIER);
+    let value = NSString::from_str(identifier);
     let value_ref: &NSString = &value;
     let value_obj: &AnyObject = value_ref;
     NSDictionary::from_slices(&[key], &[value_obj])

--- a/prns-ffi/src/bluetooth_auto/macos/mod.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/mod.rs
@@ -8,10 +8,11 @@ mod l2cap_lifecycle;
 mod peripheral;
 
 #[cfg(test)]
+mod peripheral_tests;
+#[cfg(test)]
+mod radio_lifecycle_tests;
+#[cfg(test)]
 mod tests;
-
-use std::collections::{HashMap, VecDeque};
-use std::sync::{Arc, Mutex};
 
 #[cfg(any(test, target_os = "ios"))]
 use std::fmt;
@@ -37,9 +38,6 @@ use peripheral::PeripheralDelegate;
 
 pub use backend::{MacosBleBackend, PreparedMacosBleBackend};
 pub use gatt_link::{GattSink, GattSource};
-
-type PeripheralTable = Arc<Mutex<HashMap<CoreBluetoothPeerId, (SendPeripheral, Option<i8>)>>>;
-type RestoredPeripherals = Arc<Mutex<VecDeque<CoreBluetoothPeerId>>>;
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 struct CoreBluetoothPeerId([u8; 16]);
@@ -252,6 +250,7 @@ struct SendPeripheralManager(Retained<CBPeripheralManager>);
 // retained Objective-C object is never concurrently messaged by Prns.
 unsafe impl Send for SendPeripheralManager {}
 
+#[derive(Clone)]
 struct SendPeripheral(Retained<CBPeripheral>);
 // SAFETY: this wrapper is only transferred into jobs on the central manager's serial dispatch
 // queue; Prns does not concurrently message the retained peripheral.
@@ -373,6 +372,7 @@ fn try_bounded_ingress<T>(sender: &tokio_mpsc::Sender<T>, value: T) -> BoundedIn
 #[derive(Debug)]
 pub enum MacosBleError {
     PowerOnTimeout,
+    RadioTransitionTimeout,
     Closed,
     ControlTooLarge,
     NotifyFailed,

--- a/prns-ffi/src/bluetooth_auto/macos/peripheral.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/peripheral.rs
@@ -27,8 +27,9 @@ use super::data_plane::{wire_l2cap, DataPlane, PendingL2cap};
 use super::gatt_link::{gatt_inbound_channel, ControlPlane, GattInboundSender, GattLink};
 use super::{
     advertisement_data, cbuuid_eq, columba_identity_uuid, columba_rx_uuid, columba_tx_uuid,
-    control_uuid, core_bluetooth_peer_id, data_uuid, service_uuid, CoreBluetoothPeerId, Event,
-    SendPeripheralDelegate, SendPeripheralManager,
+    control_uuid, core_bluetooth_peer_id, data_uuid, service_uuid, try_bounded_ingress,
+    BoundedIngress, CoreBluetoothPeerId, ManagerSignalSender, SendPeripheralDelegate,
+    SendPeripheralManager,
 };
 
 #[derive(Clone, Copy)]
@@ -96,7 +97,8 @@ impl PeripheralPeerSession {
 }
 
 pub(super) struct PeripheralDelegateIvars {
-    events: tokio_mpsc::UnboundedSender<Event>,
+    manager_signals: ManagerSignalSender,
+    inbound: tokio_mpsc::Sender<GattLink>,
     characteristic: RefCell<Retained<CBMutableCharacteristic>>,
     data_characteristic: RefCell<Retained<CBMutableCharacteristic>>,
     columba_rx_characteristic: RefCell<Retained<CBMutableCharacteristic>>,
@@ -228,7 +230,7 @@ define_class!(
                 crate::diagnostic_log::debug!(
                     "bluetooth: restored the published Prns GATT service from a background relaunch"
                 );
-                let _ = self.ivars().events.send(Event::GattServicePublished);
+                self.ivars().manager_signals.gatt_service_published();
             }
         }
 
@@ -241,13 +243,13 @@ define_class!(
         ) {
             if let Some(error) = error {
                 crate::diagnostic_log::error!("bluetooth: GATT service add FAILED: {error:?}");
-                let _ = self.ivars().events.send(Event::GattServicePublishFailed);
+                self.ivars().manager_signals.gatt_service_publish_failed();
                 return;
             }
             crate::diagnostic_log::debug!(
                 "bluetooth: GATT service added (control characteristic live)"
             );
-            let _ = self.ivars().events.send(Event::GattServicePublished);
+            self.ivars().manager_signals.gatt_service_published();
         }
 
         #[unsafe(method(peripheralManagerDidStartAdvertising:error:))]
@@ -274,10 +276,10 @@ define_class!(
         ) {
             if let Some(error) = error {
                 crate::diagnostic_log::error!("bluetooth: L2CAP publish FAILED: {error:?}");
-                let _ = self.ivars().events.send(Event::L2capPublishFailed);
+                self.ivars().manager_signals.l2cap_publish_failed();
             } else {
                 crate::diagnostic_log::debug!("bluetooth: published L2CAP channel, PSM {psm:#06x}");
-                let _ = self.ivars().events.send(Event::L2capPublished { psm });
+                self.ivars().manager_signals.l2cap_published(psm);
             }
         }
 
@@ -481,7 +483,8 @@ impl PeripheralDelegate {
     }
 
     pub(super) fn new(
-        events: tokio_mpsc::UnboundedSender<Event>,
+        manager_signals: ManagerSignalSender,
+        inbound: tokio_mpsc::Sender<GattLink>,
         queue: DispatchRetained<DispatchQueue>,
         identity: BleIdentity,
     ) -> Retained<Self> {
@@ -546,7 +549,8 @@ impl PeripheralDelegate {
             )
         };
         let this = Self::alloc().set_ivars(PeripheralDelegateIvars {
-            events,
+            manager_signals,
+            inbound,
             characteristic: RefCell::new(characteristic),
             data_characteristic: RefCell::new(data_characteristic),
             columba_rx_characteristic: RefCell::new(columba_rx_characteristic),
@@ -604,7 +608,29 @@ impl PeripheralDelegate {
             data_inbound_rx: Some(data_rx),
             l2cap_pending: None,
         };
-        let _ = self.ivars().events.send(Event::Inbound(link));
+        let rejected = match try_bounded_ingress(&self.ivars().inbound, link) {
+            BoundedIngress::Accepted => return,
+            BoundedIngress::Full(link) => {
+                crate::diagnostic_log::warn!(
+                    "bluetooth: rejecting inbound link from {:02x?} — inbound queue is full",
+                    link.address.octets()
+                );
+                link
+            }
+            BoundedIngress::Closed(link) => {
+                crate::diagnostic_log::debug!(
+                    "bluetooth: rejecting inbound link from {:02x?} — backend is closed",
+                    link.address.octets()
+                );
+                link
+            }
+        };
+        let address = rejected.address;
+        // The session's data sender observes receiver closure only after the rejected link is
+        // dropped. Remove the queue-confined session and any pending L2CAP state immediately
+        // afterward so a rejected ingress can never retain a live peer.
+        drop(rejected);
+        self.clear_closed_peer_on_queue(address);
     }
 
     pub(super) fn notify(
@@ -723,28 +749,31 @@ impl PeripheralDelegate {
         });
     }
 
+    /// Queue-confined: call only from the CoreBluetooth serial dispatch queue.
+    fn clear_closed_peer_on_queue(&self, address: BleAddress) {
+        let mut removed = false;
+        self.ivars()
+            .sessions
+            .borrow_mut()
+            .retain(|peer_id, session| {
+                let remove = peer_id.address() == address && session.data_receiver_closed();
+                removed |= remove;
+                !remove
+            });
+        if removed {
+            self.ivars()
+                .pending_l2cap
+                .borrow_mut()
+                .retain(|peer_id, _| peer_id.address() != address);
+        }
+    }
+
     pub(super) fn clear_closed_peer(&self, address: BleAddress) {
         let queue = self.ivars().queue.clone();
         let this = SendPeripheralDelegate(self.retain());
         queue.exec_async(move || {
             let this = this;
-            let mut removed = false;
-            this.0
-                .ivars()
-                .sessions
-                .borrow_mut()
-                .retain(|peer_id, session| {
-                    let remove = peer_id.address() == address && session.data_receiver_closed();
-                    removed |= remove;
-                    !remove
-                });
-            if removed {
-                this.0
-                    .ivars()
-                    .pending_l2cap
-                    .borrow_mut()
-                    .retain(|peer_id, _| peer_id.address() != address);
-            }
+            this.0.clear_closed_peer_on_queue(address);
         });
     }
 }

--- a/prns-ffi/src/bluetooth_auto/macos/peripheral.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/peripheral.rs
@@ -21,9 +21,11 @@ use tokio::sync::{mpsc as tokio_mpsc, oneshot};
 use prns_core::interfaces::bluetooth_auto::AdvertisingMode;
 use prns_core::interfaces::bluetooth_auto::{
     BleAddress, BleIdentity, Control, PeerProtocol, BLE_HW_MTU, FRAGMENT_HEADER_LEN,
+    HANDSHAKE_SLACK,
 };
 
-use super::data_plane::{wire_l2cap, DataPlane, PendingL2cap};
+use super::backend::central_peripheral_capacity;
+use super::data_plane::{close_l2cap, l2cap_peer_id, wire_l2cap, DataPlane, PendingL2cap};
 use super::gatt_link::{gatt_inbound_channel, ControlPlane, GattInboundSender, GattLink};
 use super::{
     advertisement_data, cbuuid_eq, columba_identity_uuid, columba_rx_uuid, columba_tx_uuid,
@@ -88,6 +90,82 @@ pub(super) fn has_session_for_peer<V>(
     sessions.contains_key(&peer_id)
 }
 
+pub(super) const fn peripheral_session_capacity(max_peers: usize) -> usize {
+    max_peers.saturating_mul(2).saturating_add(HANDSHAKE_SLACK)
+}
+
+pub(super) const fn pending_l2cap_capacity(max_peers: usize) -> usize {
+    central_peripheral_capacity(max_peers).saturating_add(peripheral_session_capacity(max_peers))
+}
+
+pub(super) const fn can_open_inbound(current_sessions: usize, capacity: usize) -> bool {
+    current_sessions < capacity
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum L2capDeliveryAdmission {
+    Existing,
+    Listener,
+    Unknown,
+    Full,
+}
+
+pub(super) fn l2cap_delivery_admission<S, P>(
+    sessions: &HashMap<CoreBluetoothPeerId, S>,
+    pending: &HashMap<CoreBluetoothPeerId, P>,
+    peer_id: CoreBluetoothPeerId,
+    capacity: usize,
+) -> L2capDeliveryAdmission {
+    if pending.contains_key(&peer_id) {
+        L2capDeliveryAdmission::Existing
+    } else if !sessions.contains_key(&peer_id) {
+        L2capDeliveryAdmission::Unknown
+    } else if pending.len() >= capacity {
+        L2capDeliveryAdmission::Full
+    } else {
+        L2capDeliveryAdmission::Listener
+    }
+}
+
+pub(super) fn can_arm_l2cap<P>(
+    pending: &HashMap<CoreBluetoothPeerId, P>,
+    peer_id: CoreBluetoothPeerId,
+    capacity: usize,
+) -> bool {
+    pending.contains_key(&peer_id) || pending.len() < capacity
+}
+
+pub(super) fn reap_closed_sessions<S, P>(
+    sessions: &mut HashMap<CoreBluetoothPeerId, S>,
+    pending: &mut HashMap<CoreBluetoothPeerId, P>,
+    address: Option<BleAddress>,
+    mut is_closed: impl FnMut(&S) -> bool,
+) -> usize {
+    let closed = sessions
+        .iter()
+        .filter_map(|(peer_id, session)| {
+            let address_matches = address.is_none_or(|address| peer_id.address() == address);
+            (address_matches && is_closed(session)).then_some(*peer_id)
+        })
+        .collect::<Vec<_>>();
+    for peer_id in &closed {
+        sessions.remove(peer_id);
+        pending.remove(peer_id);
+    }
+    closed.len()
+}
+
+pub(super) fn reap_stale_pending_l2cap(
+    pending: &mut HashMap<CoreBluetoothPeerId, PendingL2cap>,
+) -> usize {
+    let before = pending.len();
+    pending.retain(|_, state| {
+        state.reap_closed();
+        !state.is_empty()
+    });
+    before.saturating_sub(pending.len())
+}
+
 impl PeripheralPeerSession {
     fn data_receiver_closed(&self) -> bool {
         // The control receiver is handshake-only and closes when a link settles. The data
@@ -106,8 +184,11 @@ pub(super) struct PeripheralDelegateIvars {
     columba_identity_characteristic: RefCell<Retained<CBMutableCharacteristic>>,
     queue: DispatchRetained<DispatchQueue>,
     manager: RefCell<Option<SendPeripheralManager>>,
+    radio_enabled: Arc<AtomicBool>,
     service_registration_requested: RefCell<bool>,
     l2cap_publication_requested: RefCell<bool>,
+    session_capacity: usize,
+    pending_l2cap_capacity: usize,
     sessions: RefCell<HashMap<CoreBluetoothPeerId, PeripheralPeerSession>>,
     pending_l2cap: RefCell<HashMap<CoreBluetoothPeerId, PendingL2cap>>,
 }
@@ -299,19 +380,86 @@ define_class!(
                 );
                 return;
             };
-            let Some((peer_id, data)) = wire_l2cap(channel, &self.ivars().queue) else {
-                crate::diagnostic_log::warn!(
-                    "bluetooth: L2CAP channel exposes no streams — dropping"
+            if !self.ivars().radio_enabled.load(Ordering::Acquire) {
+                crate::diagnostic_log::debug!(
+                    "bluetooth: refusing inbound L2CAP channel while the logical radio is off"
                 );
+                close_l2cap(channel);
+                return;
+            }
+            let Some(peer_id) = l2cap_peer_id(channel) else {
+                crate::diagnostic_log::warn!(
+                    "bluetooth: refusing L2CAP channel with no exact CoreBluetooth peer identity"
+                );
+                close_l2cap(channel);
+                return;
+            };
+            self.reap_closed_state_on_queue();
+            let (admission, pending_count, peer_has_capacity) = {
+                let sessions = self.ivars().sessions.borrow();
+                let pending = self.ivars().pending_l2cap.borrow();
+                (
+                    l2cap_delivery_admission(
+                        &sessions,
+                        &pending,
+                        peer_id,
+                        self.ivars().pending_l2cap_capacity,
+                    ),
+                    pending.len(),
+                    pending.get(&peer_id).is_none_or(PendingL2cap::can_deliver),
+                )
+            };
+            match admission {
+                L2capDeliveryAdmission::Unknown => {
+                    crate::diagnostic_log::warn!(
+                        "bluetooth: refusing L2CAP channel from {:02x?} — no exact peer session or waiter",
+                        peer_id.address().octets()
+                    );
+                    close_l2cap(channel);
+                    return;
+                }
+                L2capDeliveryAdmission::Full => {
+                    crate::diagnostic_log::warn!(
+                        "bluetooth: refusing L2CAP channel from {:02x?} — pending-peer capacity is full ({pending_count}/{})",
+                        peer_id.address().octets(),
+                        self.ivars().pending_l2cap_capacity
+                    );
+                    close_l2cap(channel);
+                    return;
+                }
+                L2capDeliveryAdmission::Existing | L2capDeliveryAdmission::Listener
+                    if !peer_has_capacity =>
+                {
+                    crate::diagnostic_log::warn!(
+                        "bluetooth: refusing L2CAP channel from {:02x?} — this exact peer's pending-channel capacity is full",
+                        peer_id.address().octets()
+                    );
+                    close_l2cap(channel);
+                    return;
+                }
+                L2capDeliveryAdmission::Existing | L2capDeliveryAdmission::Listener => {}
+            }
+            // Stream access, callback registration, and `open` happen only after the exact peer
+            // passed both aggregate and per-peer admission above.
+            let Some(data) = wire_l2cap(channel, &self.ivars().queue) else {
+                crate::diagnostic_log::warn!(
+                    "bluetooth: admitted L2CAP channel exposes no streams — dropping"
+                );
+                close_l2cap(channel);
                 return;
             };
             crate::diagnostic_log::debug!("bluetooth: L2CAP channel opened, data plane up");
-            self.ivars()
-                .pending_l2cap
-                .borrow_mut()
-                .entry(peer_id)
-                .or_default()
-                .deliver(data);
+            let mut pending = self.ivars().pending_l2cap.borrow_mut();
+            let entry = pending.entry(peer_id).or_default();
+            if !entry.deliver(data) {
+                crate::diagnostic_log::warn!(
+                    "bluetooth: dropping L2CAP channel from {:02x?} — exact-peer delivery capacity closed after admission",
+                    peer_id.address().octets()
+                );
+            }
+            if entry.is_empty() {
+                pending.remove(&peer_id);
+            }
         }
 
         #[unsafe(method(peripheralManager:didReceiveWriteRequests:))]
@@ -320,6 +468,19 @@ define_class!(
             peripheral: &CBPeripheralManager,
             requests: &NSArray<CBATTRequest>,
         ) {
+            if !self.ivars().radio_enabled.load(Ordering::Acquire) {
+                for request in requests.iter() {
+                    // SAFETY: every request belongs to this live callback and is answered exactly
+                    // once before returning; disabled state cannot accept new session work.
+                    unsafe {
+                        peripheral.respondToRequest_withResult(
+                            &request,
+                            CBATTError::InsufficientResources,
+                        )
+                    };
+                }
+                return;
+            }
             for request in requests.iter() {
                 // SAFETY: CoreBluetooth supplied this retained request for the duration of the
                 // delegate callback; its optional value has the binding-declared NSData type.
@@ -339,6 +500,7 @@ define_class!(
                 // SAFETY: the live request retains the CBCentral that issued it.
                 let central = unsafe { request.central() };
                 let peer_id = core_bluetooth_peer_id(&central);
+                self.reap_closed_state_on_queue();
                 if cbuuid_eq(&written_uuid, &data_uuid()) {
                     let enqueue_error = self
                         .ivars()
@@ -364,12 +526,12 @@ define_class!(
                     continue;
                 }
                 if cbuuid_eq(&written_uuid, &columba_rx_uuid()) {
-                    let mut enqueue_error = None;
+                    let mut accepted = true;
                     let known = self.ivars().sessions.borrow().contains_key(&peer_id);
                     if !known && bytes.len() == 16 {
                         let mut peer_identity = [0u8; 16];
                         peer_identity.copy_from_slice(&bytes);
-                        self.open_inbound(
+                        accepted = self.open_inbound(
                             &central,
                             peer_id,
                             InboundProfile::Columba(BleIdentity::new(peer_identity)),
@@ -381,16 +543,18 @@ define_class!(
                         .get(&peer_id)
                         .filter(|session| session.protocol == PeerProtocol::Columba)
                     {
-                        enqueue_error = session.data_tx.try_send(Box::from(bytes.as_slice())).err();
+                        if let Err(error) = session.data_tx.try_send(Box::from(bytes.as_slice())) {
+                            crate::diagnostic_log::warn!(
+                                "bluetooth: Columba GATT write inbox failed for {:02x?}: {error:?}",
+                                peer_id.address().octets()
+                            );
+                            accepted = false;
+                        }
                     }
-                    let result = if let Some(error) = enqueue_error {
-                        crate::diagnostic_log::warn!(
-                            "bluetooth: Columba GATT write inbox failed for {:02x?}: {error:?}",
-                            peer_id.address().octets()
-                        );
-                        CBATTError::InsufficientResources
-                    } else {
+                    let result = if accepted {
                         CBATTError::Success
+                    } else {
+                        CBATTError::InsufficientResources
                     };
                     // SAFETY: the request belongs to this live manager callback and is answered
                     // exactly once on this branch.
@@ -398,8 +562,9 @@ define_class!(
                     continue;
                 }
                 if let Some(control) = Control::decode(&bytes) {
+                    let mut accepted = true;
                     if !self.ivars().sessions.borrow().contains_key(&peer_id) {
-                        self.open_inbound(&central, peer_id, InboundProfile::Native);
+                        accepted = self.open_inbound(&central, peer_id, InboundProfile::Native);
                     }
                     if let Some(session) = self
                         .ivars()
@@ -408,7 +573,18 @@ define_class!(
                         .get(&peer_id)
                         .filter(|session| session.protocol == PeerProtocol::Native)
                     {
-                        let _ = session.control_tx.try_send(control);
+                        accepted &= session.control_tx.try_send(control).is_ok();
+                    }
+                    if !accepted {
+                        // SAFETY: the request belongs to this live manager callback and is answered
+                        // exactly once on this branch.
+                        unsafe {
+                            peripheral.respondToRequest_withResult(
+                                &request,
+                                CBATTError::InsufficientResources,
+                            )
+                        };
+                        continue;
                     }
                 }
                 // SAFETY: this is the sole response for this request on the fall-through branch,
@@ -424,7 +600,11 @@ define_class!(
             central: &CBCentral,
             characteristic: &CBCharacteristic,
         ) {
+            if !self.ivars().radio_enabled.load(Ordering::Acquire) {
+                return;
+            }
             let peer_id = core_bluetooth_peer_id(central);
+            self.reap_closed_state_on_queue();
             // SAFETY: the supplied characteristic is live and its UUID is immutable.
             let uuid = unsafe { characteristic.UUID() };
             let protocol = if cbuuid_eq(&uuid, &columba_tx_uuid()) {
@@ -446,6 +626,7 @@ define_class!(
             characteristic: &CBCharacteristic,
         ) {
             let peer_id = core_bluetooth_peer_id(central);
+            self.reap_closed_state_on_queue();
             // SAFETY: the supplied characteristic is live and its UUID is immutable.
             let uuid = unsafe { characteristic.UUID() };
             let unsubscribed_protocol = if cbuuid_eq(&uuid, &control_uuid()) {
@@ -462,8 +643,7 @@ define_class!(
                 .get(&peer_id)
                 .is_some_and(|session| Some(session.protocol) == unsubscribed_protocol);
             if remove {
-                self.ivars().sessions.borrow_mut().remove(&peer_id);
-                self.ivars().pending_l2cap.borrow_mut().remove(&peer_id);
+                self.clear_peer_on_queue(peer_id);
             }
         }
 
@@ -479,6 +659,10 @@ define_class!(
 impl PeripheralDelegate {
     /// Queue-confined: call only from the CoreBluetooth serial dispatch queue.
     pub(super) fn has_inbound_session(&self, peer_id: CoreBluetoothPeerId) -> bool {
+        if !self.ivars().radio_enabled.load(Ordering::Acquire) {
+            return false;
+        }
+        self.reap_closed_state_on_queue();
         has_session_for_peer(&self.ivars().sessions.borrow(), peer_id)
     }
 
@@ -487,6 +671,8 @@ impl PeripheralDelegate {
         inbound: tokio_mpsc::Sender<GattLink>,
         queue: DispatchRetained<DispatchQueue>,
         identity: BleIdentity,
+        radio_enabled: Arc<AtomicBool>,
+        max_peers: usize,
     ) -> Retained<Self> {
         let data_plane_properties = CBCharacteristicProperties::Write
             | CBCharacteristicProperties::WriteWithoutResponse
@@ -558,8 +744,11 @@ impl PeripheralDelegate {
             columba_identity_characteristic: RefCell::new(columba_identity_characteristic),
             queue,
             manager: RefCell::new(None),
+            radio_enabled,
             service_registration_requested: RefCell::new(false),
             l2cap_publication_requested: RefCell::new(false),
+            session_capacity: peripheral_session_capacity(max_peers),
+            pending_l2cap_capacity: pending_l2cap_capacity(max_peers),
             sessions: RefCell::new(HashMap::new()),
             pending_l2cap: RefCell::new(HashMap::new()),
         });
@@ -573,7 +762,20 @@ impl PeripheralDelegate {
         central: &CBCentral,
         peer_id: CoreBluetoothPeerId,
         profile: InboundProfile,
-    ) {
+    ) -> bool {
+        if !self.ivars().radio_enabled.load(Ordering::Acquire) {
+            return false;
+        }
+        self.reap_closed_state_on_queue();
+        let session_count = self.ivars().sessions.borrow().len();
+        if !can_open_inbound(session_count, self.ivars().session_capacity) {
+            crate::diagnostic_log::warn!(
+                "bluetooth: rejecting inbound control link from {:02x?} — peripheral-session capacity is full ({session_count}/{})",
+                peer_id.address().octets(),
+                self.ivars().session_capacity
+            );
+            return false;
+        }
         let (control_tx, control_rx) = tokio_mpsc::channel::<Control>(8);
         let (data_tx, data_rx) = gatt_inbound_channel();
         let protocol = profile.protocol();
@@ -609,7 +811,7 @@ impl PeripheralDelegate {
             l2cap_pending: None,
         };
         let rejected = match try_bounded_ingress(&self.ivars().inbound, link) {
-            BoundedIngress::Accepted => return,
+            BoundedIngress::Accepted => return true,
             BoundedIngress::Full(link) => {
                 crate::diagnostic_log::warn!(
                     "bluetooth: rejecting inbound link from {:02x?} — inbound queue is full",
@@ -625,12 +827,13 @@ impl PeripheralDelegate {
                 link
             }
         };
-        let address = rejected.address;
         // The session's data sender observes receiver closure only after the rejected link is
         // dropped. Remove the queue-confined session and any pending L2CAP state immediately
-        // afterward so a rejected ingress can never retain a live peer.
+        // afterward by exact CoreBluetooth peer ID so a synthetic-address collision cannot tear
+        // down an unrelated peer.
         drop(rejected);
-        self.clear_closed_peer_on_queue(address);
+        self.clear_peer_on_queue(peer_id);
+        false
     }
 
     pub(super) fn notify(
@@ -646,6 +849,10 @@ impl PeripheralDelegate {
         let result = sent.clone();
         queue.exec_sync(move || {
             let this = this;
+            if !this.0.ivars().radio_enabled.load(Ordering::Acquire) {
+                return;
+            }
+            this.0.reap_closed_state_on_queue();
             let Some(manager) = this
                 .0
                 .ivars()
@@ -700,13 +907,30 @@ impl PeripheralDelegate {
         let this = SendPeripheralDelegate(self.retain());
         queue.exec_async(move || {
             let this = this;
-            this.0
-                .ivars()
-                .pending_l2cap
-                .borrow_mut()
-                .entry(peer_id)
-                .or_default()
-                .arm(tx);
+            if !this.0.ivars().radio_enabled.load(Ordering::Acquire) {
+                return;
+            }
+            this.0.reap_closed_state_on_queue();
+            let mut pending = this.0.ivars().pending_l2cap.borrow_mut();
+            if !can_arm_l2cap(&pending, peer_id, this.0.ivars().pending_l2cap_capacity) {
+                crate::diagnostic_log::warn!(
+                    "bluetooth: refusing L2CAP waiter for {:02x?} — pending-peer capacity is full ({}/{})",
+                    peer_id.address().octets(),
+                    pending.len(),
+                    this.0.ivars().pending_l2cap_capacity
+                );
+                return;
+            }
+            let entry = pending.entry(peer_id).or_default();
+            if !entry.arm(tx) {
+                crate::diagnostic_log::warn!(
+                    "bluetooth: refusing L2CAP waiter for {:02x?} — this exact peer's waiter capacity is full",
+                    peer_id.address().octets()
+                );
+            }
+            if entry.is_empty() {
+                pending.remove(&peer_id);
+            }
         });
     }
 
@@ -715,6 +939,9 @@ impl PeripheralDelegate {
         let this = SendPeripheralDelegate(self.retain());
         queue.exec_async(move || {
             let this = this;
+            if mode.is_on() && !this.0.ivars().radio_enabled.load(Ordering::Acquire) {
+                return;
+            }
             let Some(manager) = this
                 .0
                 .ivars()
@@ -749,23 +976,61 @@ impl PeripheralDelegate {
         });
     }
 
+    /// Queue-confined logical radio transition. The published GATT service and L2CAP PSM remain
+    /// available for re-enable, while disabling stops airtime and releases every live session,
+    /// pending waiter, and buffered channel.
+    pub(super) fn set_radio_enabled(&self, enabled: bool) {
+        self.ivars().radio_enabled.store(enabled, Ordering::Release);
+        if enabled {
+            return;
+        }
+        if let Some(manager) = self
+            .ivars()
+            .manager
+            .borrow()
+            .as_ref()
+            .map(|manager| manager.0.clone())
+        {
+            // SAFETY: this method is called only on the peripheral manager's serial queue.
+            unsafe { manager.stopAdvertising() };
+        }
+        self.ivars().sessions.borrow_mut().clear();
+        self.ivars().pending_l2cap.borrow_mut().clear();
+    }
+
     /// Queue-confined: call only from the CoreBluetooth serial dispatch queue.
     fn clear_closed_peer_on_queue(&self, address: BleAddress) {
-        let mut removed = false;
-        self.ivars()
-            .sessions
-            .borrow_mut()
-            .retain(|peer_id, session| {
-                let remove = peer_id.address() == address && session.data_receiver_closed();
-                removed |= remove;
-                !remove
-            });
-        if removed {
-            self.ivars()
-                .pending_l2cap
-                .borrow_mut()
-                .retain(|peer_id, _| peer_id.address() != address);
-        }
+        let mut sessions = self.ivars().sessions.borrow_mut();
+        let mut pending = self.ivars().pending_l2cap.borrow_mut();
+        reap_closed_sessions(
+            &mut sessions,
+            &mut pending,
+            Some(address),
+            PeripheralPeerSession::data_receiver_closed,
+        );
+        // Central-role waiters have no peripheral-role session. Reap only entries whose waiter or
+        // delivered channel is independently known closed; never use the synthetic address as an
+        // identity substitute.
+        reap_stale_pending_l2cap(&mut pending);
+    }
+
+    /// Queue-confined: call only from the CoreBluetooth serial dispatch queue.
+    fn reap_closed_state_on_queue(&self) {
+        let mut sessions = self.ivars().sessions.borrow_mut();
+        let mut pending = self.ivars().pending_l2cap.borrow_mut();
+        reap_closed_sessions(
+            &mut sessions,
+            &mut pending,
+            None,
+            PeripheralPeerSession::data_receiver_closed,
+        );
+        reap_stale_pending_l2cap(&mut pending);
+    }
+
+    /// Queue-confined: remove only the state owned by this exact CoreBluetooth peer.
+    fn clear_peer_on_queue(&self, peer_id: CoreBluetoothPeerId) {
+        self.ivars().sessions.borrow_mut().remove(&peer_id);
+        self.ivars().pending_l2cap.borrow_mut().remove(&peer_id);
     }
 
     pub(super) fn clear_closed_peer(&self, address: BleAddress) {

--- a/prns-ffi/src/bluetooth_auto/macos/peripheral_tests.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/peripheral_tests.rs
@@ -1,0 +1,128 @@
+use std::collections::HashMap;
+
+use tokio::sync::oneshot;
+
+use super::data_plane::{DataPlane, PendingL2cap};
+use super::peripheral::{
+    can_arm_l2cap, can_open_inbound, l2cap_delivery_admission, reap_closed_sessions,
+    reap_stale_pending_l2cap, L2capDeliveryAdmission,
+};
+use super::CoreBluetoothPeerId;
+
+fn peer_id(prefix: u8, suffix: u8) -> CoreBluetoothPeerId {
+    let mut bytes = [prefix; 16];
+    bytes[15] = suffix;
+    CoreBluetoothPeerId(bytes)
+}
+
+#[test]
+fn listener_cleanup_removes_only_closed_exact_peer_ids() {
+    let closed = peer_id(0x5a, 1);
+    let colliding_live = peer_id(0x5a, 2);
+    let unrelated_closed = peer_id(0x6b, 1);
+    assert_eq!(closed.address(), colliding_live.address());
+
+    let mut sessions = HashMap::from([
+        (closed, true),
+        (colliding_live, false),
+        (unrelated_closed, true),
+    ]);
+    let mut pending = HashMap::from([
+        (closed, "closed"),
+        (colliding_live, "live"),
+        (unrelated_closed, "unrelated"),
+    ]);
+
+    assert_eq!(
+        reap_closed_sessions(
+            &mut sessions,
+            &mut pending,
+            Some(closed.address()),
+            |closed| *closed,
+        ),
+        1
+    );
+    assert!(!sessions.contains_key(&closed));
+    assert!(!pending.contains_key(&closed));
+    assert!(sessions.contains_key(&colliding_live));
+    assert!(pending.contains_key(&colliding_live));
+    assert!(sessions.contains_key(&unrelated_closed));
+    assert!(pending.contains_key(&unrelated_closed));
+}
+
+#[test]
+fn global_reap_reclaims_session_capacity_across_disable_cycles() {
+    let mut sessions = HashMap::new();
+    let mut pending = HashMap::new();
+
+    for suffix in 0..8 {
+        let peer_id = peer_id(suffix, suffix);
+        sessions.insert(peer_id, true);
+        pending.insert(peer_id, ());
+        assert!(!can_open_inbound(sessions.len(), 1));
+        assert_eq!(
+            reap_closed_sessions(&mut sessions, &mut pending, None, |closed| *closed),
+            1
+        );
+        assert!(can_open_inbound(sessions.len(), 1));
+        assert!(pending.is_empty());
+    }
+}
+
+#[test]
+fn stale_l2cap_waiters_are_reaped_before_map_admission() {
+    let stale_peer = peer_id(1, 1);
+    let next_peer = peer_id(2, 2);
+    let (tx, rx) = oneshot::channel::<DataPlane>();
+    let mut stale = PendingL2cap::default();
+    assert!(stale.arm(tx));
+    drop(rx);
+
+    let mut pending = HashMap::from([(stale_peer, stale)]);
+    assert!(!can_arm_l2cap(&pending, next_peer, 1));
+    assert_eq!(reap_stale_pending_l2cap(&mut pending), 1);
+    assert!(can_arm_l2cap(&pending, next_peer, 1));
+}
+
+#[test]
+fn closed_waiters_reclaim_exact_peer_waiter_capacity() {
+    let mut pending = PendingL2cap::default();
+    let mut receivers = Vec::new();
+    for _ in 0..4 {
+        let (tx, rx) = oneshot::channel::<DataPlane>();
+        assert!(pending.arm(tx));
+        receivers.push(rx);
+    }
+    let (overflow_tx, overflow_rx) = oneshot::channel::<DataPlane>();
+    assert!(!pending.arm(overflow_tx));
+    assert!(overflow_rx.blocking_recv().is_err());
+
+    drop(receivers);
+    let (replacement_tx, _replacement_rx) = oneshot::channel::<DataPlane>();
+    assert!(pending.arm(replacement_tx));
+    assert_eq!(pending.waiter_len(), 1);
+}
+
+#[test]
+fn l2cap_admission_uses_full_peer_id_not_synthetic_address() {
+    let listener = peer_id(0x5a, 1);
+    let armed_collision = peer_id(0x5a, 2);
+    let unknown_collision = peer_id(0x5a, 3);
+    assert_eq!(listener.address(), armed_collision.address());
+    assert_eq!(listener.address(), unknown_collision.address());
+
+    let sessions = HashMap::from([(listener, ())]);
+    let pending = HashMap::from([(armed_collision, ())]);
+    assert_eq!(
+        l2cap_delivery_admission(&sessions, &pending, armed_collision, 1),
+        L2capDeliveryAdmission::Existing
+    );
+    assert_eq!(
+        l2cap_delivery_admission(&sessions, &pending, listener, 1),
+        L2capDeliveryAdmission::Full
+    );
+    assert_eq!(
+        l2cap_delivery_admission(&sessions, &pending, unknown_collision, 2),
+        L2capDeliveryAdmission::Unknown
+    );
+}

--- a/prns-ffi/src/bluetooth_auto/macos/radio_lifecycle_tests.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/radio_lifecycle_tests.rs
@@ -1,0 +1,74 @@
+use super::backend::BoundedRecentSet;
+use super::central::{CentralDialCandidate, CentralPeerRegistry, RestoredAdmission};
+use super::CoreBluetoothPeerId;
+
+fn peer_id(prefix: u8, suffix: u8) -> CoreBluetoothPeerId {
+    let mut bytes = [prefix; 16];
+    bytes[15] = suffix;
+    CoreBluetoothPeerId(bytes)
+}
+
+fn claim(registry: &mut CentralPeerRegistry<u8>, peer_id: CoreBluetoothPeerId, expected: u8) {
+    match registry.claim(peer_id.address()) {
+        CentralDialCandidate::Ready {
+            peer_id: claimed,
+            peripheral,
+            restored,
+            ..
+        } => {
+            assert!(claimed == peer_id);
+            assert_eq!(peripheral, expected);
+            assert!(!restored);
+        }
+        CentralDialCandidate::Busy | CentralDialCandidate::Missing => {
+            panic!("expected a ready dial candidate")
+        }
+    }
+}
+
+#[test]
+fn radio_shutdown_drains_only_connections_owned_by_the_central_registry() {
+    let observed = peer_id(0x10, 1);
+    let dialing = peer_id(0x20, 1);
+    let active = peer_id(0x30, 1);
+    let restored = peer_id(0x40, 1);
+    let mut registry = CentralPeerRegistry::new(4, 1);
+
+    assert!(registry.observe(observed, 10, None));
+    assert!(registry.observe(dialing, 20, None));
+    claim(&mut registry, dialing, 20);
+    assert!(registry.observe(active, 30, None));
+    claim(&mut registry, active, 30);
+    assert!(matches!(registry.begin_session(active), Ok(None)));
+    assert_eq!(
+        registry.admit_restored(restored, 40),
+        RestoredAdmission::Admitted
+    );
+
+    let mut owned = registry.drain_owned();
+    owned.sort_unstable();
+    assert_eq!(owned, vec![20, 30, 40]);
+    assert_eq!(registry.peripheral_len(), 0);
+    assert_eq!(registry.restored_len(), 0);
+}
+
+#[test]
+fn repeated_radio_shutdown_reclaims_registry_and_recent_set_capacity() {
+    let mut registry = CentralPeerRegistry::new(1, 1);
+    let mut seen = BoundedRecentSet::new(1);
+
+    for cycle in 0..8 {
+        let peer_id = peer_id(cycle, cycle);
+        assert_eq!(
+            registry.admit_restored(peer_id, cycle),
+            RestoredAdmission::Admitted
+        );
+        assert!(seen.insert(peer_id.address()));
+
+        assert_eq!(registry.drain_owned(), vec![cycle]);
+        seen.clear();
+        assert_eq!(registry.peripheral_len(), 0);
+        assert_eq!(registry.restored_len(), 0);
+        assert_eq!(seen.len(), 0);
+    }
+}

--- a/prns-ffi/src/bluetooth_auto/macos/tests.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/tests.rs
@@ -3,16 +3,20 @@ use std::time::{Duration, Instant};
 
 use objc2_core_bluetooth::CBCharacteristicProperties;
 use prns_core::interfaces::bluetooth_auto::{
-    AdvertisingMode, BleBackend, BleIdentity, Control, ScanningMode,
+    AdvertisingMode, BleBackend, BleIdentity, Control, RadioMode, ScanningMode,
 };
 use tokio::sync::{mpsc, oneshot};
 
 use super::backend::{
-    dial_admission, manager_readiness, scan_lease, scan_op, DialAdmission, ScanLease, ScanOp,
+    central_peripheral_capacity, dial_admission, manager_readiness, scan_lease, scan_op,
+    BoundedRecentSet, DialAdmission, ScanLease, ScanOp,
 };
 use super::central::{
-    CentralPeerSession, RestoredCallbackBuffer, CENTRAL_CONTROL_INBOUND_CAPACITY,
+    closed_central_session_ids, CentralDialCandidate, CentralPeerRegistry, CentralPeerSession,
+    RestoredAdmission, RestoredBufferResult, RestoredCallbackBuffer,
+    CENTRAL_CONTROL_INBOUND_CAPACITY,
 };
+use super::data_plane::{DataPlane, PendingL2cap};
 use super::discovery::{
     candidate_strength, discover_disposition, CandidateStrength, DiscoverDisposition,
     DiscoveryGuard, PeripheralLinkState, SessionPresence, StaleCancellation, StaleLinkRecovery,
@@ -23,7 +27,11 @@ use super::gatt_link::{
 };
 use super::gatt_write::{write_admission, GattWriteAdmission, GattWriteMode, GattWritePlan};
 use super::legacy_restoration_identifiers;
-use super::peripheral::{advertising_op, has_session_for_peer, AdvertisingOp};
+use super::peripheral::{
+    advertising_op, can_arm_l2cap, can_open_inbound, has_session_for_peer,
+    l2cap_delivery_admission, pending_l2cap_capacity, peripheral_session_capacity, AdvertisingOp,
+    L2capDeliveryAdmission,
+};
 use super::MacosBleError;
 use super::{
     manager_signal_channel, try_bounded_ingress, BoundedIngress, CoreBluetoothPeerId,
@@ -34,6 +42,12 @@ use super::{CoreBluetoothRestorationIdentifiers, CoreBluetoothRestorationIdentif
 fn peer_id(value: u16) -> CoreBluetoothPeerId {
     let mut bytes = [0; 16];
     bytes[..2].copy_from_slice(&value.to_le_bytes());
+    CoreBluetoothPeerId(bytes)
+}
+
+fn colliding_peer_id(suffix: u8) -> CoreBluetoothPeerId {
+    let mut bytes = [0x5a; 16];
+    bytes[15] = suffix;
     CoreBluetoothPeerId(bytes)
 }
 
@@ -261,6 +275,248 @@ fn bounded_ingress_separates_inbound_and_sighting_pressure() {
 }
 
 #[test]
+fn next_sighting_history_is_lru_bounded() {
+    let mut seen = BoundedRecentSet::new(2);
+    assert!(seen.insert([1; 6]));
+    assert!(seen.insert([2; 6]));
+    assert!(!seen.insert([1; 6]));
+    assert!(seen.insert([3; 6]));
+    assert_eq!(seen.len(), 2);
+    assert!(seen.insert([2; 6]));
+    assert_eq!(seen.len(), 2);
+    assert_eq!(seen.pop_front(), Some([3; 6]));
+    assert_eq!(seen.pop_front(), Some([2; 6]));
+}
+
+#[test]
+fn central_registry_holds_restored_capacity_through_offer_and_claim() {
+    let first = peer_id(1);
+    let second = peer_id(2);
+    let third = peer_id(3);
+    let mut registry = CentralPeerRegistry::new(3, 2);
+
+    assert_eq!(
+        registry.admit_restored(first, 10_u16),
+        RestoredAdmission::Admitted
+    );
+    assert_eq!(
+        registry.admit_restored(second, 20),
+        RestoredAdmission::Admitted
+    );
+    assert_eq!(
+        registry.admit_restored(first, 11),
+        RestoredAdmission::Updated
+    );
+    assert_eq!(registry.peripheral_len(), 2);
+    assert_eq!(registry.restored_len(), 2);
+    assert_eq!(registry.admit_restored(third, 30), RestoredAdmission::Full);
+
+    assert!(registry.offer_restored() == Some(first));
+    assert_eq!(
+        registry.admit_restored(first, 12),
+        RestoredAdmission::AlreadyOwned
+    );
+    assert_eq!(registry.admit_restored(third, 30), RestoredAdmission::Full);
+    assert!(matches!(
+        registry.claim(first.address()),
+        CentralDialCandidate::Ready {
+            peer_id,
+            peripheral: 11,
+            restored: true,
+            ..
+        } if peer_id == first
+    ));
+    assert_eq!(
+        registry.admit_restored(first, 13),
+        RestoredAdmission::AlreadyOwned
+    );
+    assert_eq!(registry.admit_restored(third, 30), RestoredAdmission::Full);
+
+    assert!(matches!(registry.begin_session(first), Ok(Some(_))));
+    assert_eq!(registry.restored_len(), 1);
+    assert_eq!(
+        registry.admit_restored(third, 30),
+        RestoredAdmission::Admitted
+    );
+    assert_eq!(registry.remove_peer(first), Some(11));
+    assert_eq!(registry.remove_peer(first), None);
+    assert_eq!(registry.peripheral_len(), 2);
+}
+
+#[tokio::test]
+async fn central_registry_transfers_callbacks_once_and_releases_restored_capacity() {
+    let first = peer_id(1);
+    let second = peer_id(2);
+    let control = Control::decode(&[0x03, 0x01]).expect("valid close control");
+    let mut registry = CentralPeerRegistry::new(2, 1);
+
+    assert_eq!(
+        registry.admit_restored(first, 10_u16),
+        RestoredAdmission::Admitted
+    );
+    assert!(matches!(
+        registry.buffer_restored_control(first, control),
+        RestoredBufferResult::Buffered
+    ));
+    assert!(registry.offer_restored() == Some(first));
+    assert!(matches!(
+        registry.buffer_restored_data(first, Box::from(&[1, 2][..])),
+        RestoredBufferResult::Buffered
+    ));
+    assert!(matches!(
+        registry.claim(first.address()),
+        CentralDialCandidate::Ready {
+            peripheral: 10,
+            restored: true,
+            ..
+        }
+    ));
+    assert!(matches!(
+        registry.buffer_restored_data(first, Box::from(&[3][..])),
+        RestoredBufferResult::Buffered
+    ));
+
+    let callbacks = registry
+        .begin_session(first)
+        .expect("the claimed peer begins")
+        .expect("the restored peer transfers its callback buffer");
+    assert_eq!(registry.restored_len(), 0);
+    assert!(matches!(
+        registry.buffer_restored_control(first, control),
+        RestoredBufferResult::NotRestored(_)
+    ));
+    assert_eq!(
+        registry.admit_restored(second, 20),
+        RestoredAdmission::Admitted
+    );
+
+    let (control_tx, mut control_rx) = mpsc::channel(CENTRAL_CONTROL_INBOUND_CAPACITY);
+    let (completion_tx, _completion_rx) = oneshot::channel();
+    let (data_tx, mut data_rx) = gatt_inbound_channel();
+    let mut session = CentralPeerSession::new(first.address(), control_tx, completion_tx, data_tx);
+    assert!(session.restore_callbacks(callbacks));
+    assert_eq!(control_rx.try_recv(), Ok(control));
+    assert_eq!(&*data_rx.recv().await.unwrap(), &[1, 2]);
+    assert_eq!(&*data_rx.recv().await.unwrap(), &[3]);
+}
+
+#[test]
+fn central_registry_evicts_only_observations_and_deduplicates_synthetic_addresses() {
+    let first = peer_id(1);
+    let second = peer_id(2);
+    let third = peer_id(3);
+    let fourth = peer_id(4);
+    let fifth = peer_id(5);
+    let mut registry = CentralPeerRegistry::new(2, 0);
+
+    assert!(registry.observe(first, 10_u16, Some(-80)));
+    assert!(registry.observe(second, 20, Some(-70)));
+    assert!(registry.observe(first, 11, Some(-60)));
+    assert!(registry.observe(third, 30, Some(-50)));
+    assert_eq!(
+        registry.pop_sighting(),
+        (
+            Some(Sighting {
+                address: first.address(),
+                rssi: Some(-60),
+            }),
+            true,
+        )
+    );
+    assert_eq!(
+        registry.pop_sighting(),
+        (
+            Some(Sighting {
+                address: third.address(),
+                rssi: Some(-50),
+            }),
+            false,
+        )
+    );
+    assert_eq!(registry.pop_sighting(), (None, false));
+    assert!(matches!(
+        registry.claim(second.address()),
+        CentralDialCandidate::Missing
+    ));
+    assert!(matches!(
+        registry.claim(first.address()),
+        CentralDialCandidate::Ready { peripheral: 11, .. }
+    ));
+    assert!(registry.observe(fourth, 40, None));
+    assert!(matches!(
+        registry.claim(fourth.address()),
+        CentralDialCandidate::Ready { .. }
+    ));
+    assert!(!registry.observe(fifth, 50, None));
+    assert_eq!(registry.peripheral_len(), 2);
+
+    let original = colliding_peer_id(1);
+    let replacement = colliding_peer_id(2);
+    let mut collision = CentralPeerRegistry::new(2, 0);
+    assert!(collision.observe(original, 1_u8, None));
+    assert!(collision.observe(replacement, 2, None));
+    assert!(matches!(
+        collision.claim(original.address()),
+        CentralDialCandidate::Ready {
+            peer_id,
+            peripheral: 2,
+            ..
+        } if peer_id == replacement
+    ));
+    assert!(!collision.observe(original, 3, None));
+}
+
+#[test]
+fn peripheral_role_maps_have_explicit_aggregate_caps_and_preserve_central_l2cap() {
+    assert_eq!(central_peripheral_capacity(8), 32);
+    assert_eq!(peripheral_session_capacity(8), 20);
+    assert_eq!(pending_l2cap_capacity(8), 52);
+    assert!(can_open_inbound(19, 20));
+    assert!(!can_open_inbound(20, 20));
+
+    let central = peer_id(1);
+    let listener = peer_id(2);
+    let unknown = peer_id(3);
+    let full_listener = peer_id(4);
+    let sessions = HashMap::from([(listener, ()), (full_listener, ())]);
+    let pending = HashMap::from([(central, ())]);
+    assert_eq!(
+        l2cap_delivery_admission(&sessions, &pending, central, 1),
+        L2capDeliveryAdmission::Existing
+    );
+    assert_eq!(
+        l2cap_delivery_admission(&sessions, &HashMap::<_, ()>::new(), listener, 1),
+        L2capDeliveryAdmission::Listener
+    );
+    assert_eq!(
+        l2cap_delivery_admission(&sessions, &pending, unknown, 2),
+        L2capDeliveryAdmission::Unknown
+    );
+    assert_eq!(
+        l2cap_delivery_admission(&sessions, &pending, full_listener, 1),
+        L2capDeliveryAdmission::Full
+    );
+    assert!(can_arm_l2cap(&pending, central, 1));
+    assert!(!can_arm_l2cap(&pending, unknown, 1));
+}
+
+#[test]
+fn pending_l2cap_bounds_waiters_per_peer() {
+    let mut pending = PendingL2cap::default();
+    let mut receivers = Vec::new();
+    for _ in 0..4 {
+        let (tx, rx) = oneshot::channel::<DataPlane>();
+        assert!(pending.arm(tx));
+        receivers.push(rx);
+    }
+    let (overflow, overflow_rx) = oneshot::channel::<DataPlane>();
+    assert!(!pending.arm(overflow));
+    assert_eq!(pending.waiter_len(), 4);
+    assert!(overflow_rx.blocking_recv().is_err());
+    drop(receivers);
+}
+
+#[test]
 fn bounded_ingress_returns_rejected_payload_when_receiver_is_closed() {
     let (sender, receiver) = mpsc::channel(1);
     drop(receiver);
@@ -296,14 +552,14 @@ fn dial_admission_is_scoped_to_the_target_peer() {
     let inbound_sessions = HashMap::from([(inbound_peer, ())]);
 
     assert_eq!(
-        dial_admission(true, false, false),
+        dial_admission(true, false, None),
         DialAdmission::YieldToSystemConnection
     );
     assert_eq!(
         dial_admission(
             false,
             has_session_for_peer(&inbound_sessions, inbound_peer),
-            false,
+            None,
         ),
         DialAdmission::YieldToInboundSession
     );
@@ -311,28 +567,44 @@ fn dial_admission_is_scoped_to_the_target_peer() {
         dial_admission(
             false,
             has_session_for_peer(&inbound_sessions, unrelated_peer),
-            false,
+            None,
         ),
         DialAdmission::AttachCentralSession
     );
 }
 
 #[test]
-fn dial_admission_resumes_only_restored_system_connections() {
+fn restored_dial_admission_uses_the_exact_peripheral_state() {
     assert_eq!(
-        dial_admission(true, false, true),
+        dial_admission(false, false, Some(PeripheralLinkState::Connected)),
         DialAdmission::ResumeRestoredSession
     );
     assert_eq!(
-        dial_admission(false, false, true),
+        dial_admission(false, false, Some(PeripheralLinkState::Connecting)),
+        DialAdmission::AwaitRestoredConnection
+    );
+    assert_eq!(
+        dial_admission(false, false, Some(PeripheralLinkState::Disconnected)),
         DialAdmission::AttachCentralSession
     );
     assert_eq!(
-        dial_admission(true, true, true),
+        dial_admission(false, false, Some(PeripheralLinkState::Disconnecting)),
+        DialAdmission::RejectRestoredConnection
+    );
+    assert_eq!(
+        dial_admission(false, false, Some(PeripheralLinkState::Unknown)),
+        DialAdmission::RejectRestoredConnection
+    );
+    assert_eq!(
+        dial_admission(true, false, Some(PeripheralLinkState::Connecting)),
+        DialAdmission::AwaitRestoredConnection
+    );
+    assert_eq!(
+        dial_admission(false, true, Some(PeripheralLinkState::Connected),),
         DialAdmission::YieldToInboundSession
     );
     assert_eq!(
-        dial_admission(true, true, false),
+        dial_admission(true, true, None),
         DialAdmission::YieldToInboundSession
     );
 }
@@ -369,6 +641,7 @@ fn role_cleanup_only_selects_a_session_after_its_data_receiver_closes() {
     let (control_tx, _control_rx) = mpsc::channel::<Control>(1);
     let (completion_tx, _completion_rx) = oneshot::channel();
     let (data_tx, data_rx) = gatt_inbound_channel();
+    let closed_peer = peer_id(1);
     let session = CentralPeerSession::new(
         prns_core::interfaces::bluetooth_auto::BleAddress::new([1; 6]),
         control_tx,
@@ -379,6 +652,19 @@ fn role_cleanup_only_selects_a_session_after_its_data_receiver_closes() {
     assert!(!session.data_receiver_closed());
     drop(data_rx);
     assert!(session.data_receiver_closed());
+
+    let (open_control_tx, _open_control_rx) = mpsc::channel::<Control>(1);
+    let (open_completion_tx, _open_completion_rx) = oneshot::channel();
+    let (open_data_tx, _open_data_rx) = gatt_inbound_channel();
+    let open_peer = peer_id(2);
+    let open_session = CentralPeerSession::new(
+        open_peer.address(),
+        open_control_tx,
+        open_completion_tx,
+        open_data_tx,
+    );
+    let sessions = HashMap::from([(closed_peer, session), (open_peer, open_session)]);
+    assert!(closed_central_session_ids(&sessions) == vec![closed_peer]);
 }
 
 #[tokio::test]
@@ -424,6 +710,34 @@ fn restored_callback_overflow_fails_instead_of_skipping_protocol_input() {
 
     let mut data = RestoredCallbackBuffer::default();
     assert!(!data.buffer_data(vec![0; GATT_INBOUND_BUDGET_BYTES + 1].into_boxed_slice()));
+}
+
+#[test]
+fn active_control_inbox_reports_full_and_closed_instead_of_dropping_input() {
+    let control = Control::decode(&[0x03, 0x01]).expect("valid close control");
+    let (control_tx, control_rx) = mpsc::channel(CENTRAL_CONTROL_INBOUND_CAPACITY);
+    let (completion_tx, _completion_rx) = oneshot::channel();
+    let (data_tx, _data_rx) = gatt_inbound_channel();
+    let session = CentralPeerSession::new(
+        prns_core::interfaces::bluetooth_auto::BleAddress::new([1; 6]),
+        control_tx,
+        completion_tx,
+        data_tx,
+    );
+
+    for _ in 0..CENTRAL_CONTROL_INBOUND_CAPACITY {
+        assert!(session.enqueue_control(control).is_ok());
+    }
+    assert!(matches!(
+        session.enqueue_control(control),
+        Err(mpsc::error::TrySendError::Full(_))
+    ));
+
+    drop(control_rx);
+    assert!(matches!(
+        session.enqueue_control(control),
+        Err(mpsc::error::TrySendError::Closed(_))
+    ));
 }
 
 #[tokio::test]
@@ -578,4 +892,28 @@ async fn the_node_publishes_then_accepts_explicit_radio_modes() {
     )
     .await
     .expect("scanning should start");
+    <MacosBleBackend as BleBackend<{ MacosBleBackend::MAX_PEERS }>>::set_radio_mode(
+        &mut backend,
+        RadioMode::Off,
+    )
+    .await
+    .expect("logical radio shutdown should complete");
+    <MacosBleBackend as BleBackend<{ MacosBleBackend::MAX_PEERS }>>::set_radio_mode(
+        &mut backend,
+        RadioMode::On,
+    )
+    .await
+    .expect("logical radio re-enable should complete");
+    <MacosBleBackend as BleBackend<{ MacosBleBackend::MAX_PEERS }>>::set_advertising(
+        &mut backend,
+        AdvertisingMode::On,
+    )
+    .await
+    .expect("advertising should restart after re-enable");
+    <MacosBleBackend as BleBackend<{ MacosBleBackend::MAX_PEERS }>>::set_scanning(
+        &mut backend,
+        ScanningMode::On,
+    )
+    .await
+    .expect("scanning should restart after re-enable");
 }

--- a/prns-ffi/src/bluetooth_auto/macos/tests.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/tests.rs
@@ -10,13 +10,16 @@ use tokio::sync::{mpsc, oneshot};
 use super::backend::{
     dial_admission, scan_lease, scan_op, DialAdmission, ScanLease, ScanOp, StartupReadiness,
 };
-use super::central::CentralPeerSession;
+use super::central::{
+    CentralPeerSession, RestoredCallbackBuffer, CENTRAL_CONTROL_INBOUND_CAPACITY,
+};
 use super::discovery::{
     candidate_strength, discover_disposition, CandidateStrength, DiscoverDisposition,
     DiscoveryGuard, PeripheralLinkState, SessionPresence, StaleCancellation, StaleLinkRecovery,
 };
 use super::gatt_link::{
     gatt_inbound_channel, gatt_inbound_channel_with_budget, GattInboundSendError,
+    GATT_INBOUND_BUDGET_BYTES,
 };
 use super::gatt_write::{write_admission, GattWriteAdmission, GattWriteMode, GattWritePlan};
 use super::legacy_restoration_identifiers;
@@ -290,6 +293,51 @@ fn role_cleanup_only_selects_a_session_after_its_data_receiver_closes() {
     assert!(!session.data_receiver_closed());
     drop(data_rx);
     assert!(session.data_receiver_closed());
+}
+
+#[tokio::test]
+async fn restored_value_callbacks_are_handed_to_the_admitted_session() {
+    let control = Control::decode(&[0x03, 0x01]).expect("valid close control");
+    let mut callbacks = RestoredCallbackBuffer::default();
+    assert!(callbacks.buffer_control(control));
+    assert!(callbacks.buffer_data(Box::from(&[1, 2, 3][..])));
+
+    let (control_tx, mut control_rx) = mpsc::channel(CENTRAL_CONTROL_INBOUND_CAPACITY);
+    let (completion_tx, _completion_rx) = oneshot::channel();
+    let (data_tx, mut data_rx) = gatt_inbound_channel();
+    let mut session = CentralPeerSession::new(
+        prns_core::interfaces::bluetooth_auto::BleAddress::new([1; 6]),
+        control_tx,
+        completion_tx,
+        data_tx,
+    );
+
+    assert!(session.restore_callbacks(callbacks));
+    assert_eq!(control_rx.try_recv(), Ok(control));
+    assert_eq!(&*data_rx.recv().await.unwrap(), &[1, 2, 3]);
+}
+
+#[test]
+fn restored_callback_overflow_fails_instead_of_skipping_protocol_input() {
+    let control = Control::decode(&[0x03, 0x01]).expect("valid close control");
+    let mut controls = RestoredCallbackBuffer::default();
+    for _ in 0..CENTRAL_CONTROL_INBOUND_CAPACITY {
+        assert!(controls.buffer_control(control));
+    }
+    assert!(!controls.buffer_control(control));
+    let (control_tx, _control_rx) = mpsc::channel(CENTRAL_CONTROL_INBOUND_CAPACITY);
+    let (completion_tx, _completion_rx) = oneshot::channel();
+    let (data_tx, _data_rx) = gatt_inbound_channel();
+    let mut session = CentralPeerSession::new(
+        prns_core::interfaces::bluetooth_auto::BleAddress::new([1; 6]),
+        control_tx,
+        completion_tx,
+        data_tx,
+    );
+    assert!(!session.restore_callbacks(controls));
+
+    let mut data = RestoredCallbackBuffer::default();
+    assert!(!data.buffer_data(vec![0; GATT_INBOUND_BUDGET_BYTES + 1].into_boxed_slice()));
 }
 
 #[tokio::test]

--- a/prns-ffi/src/bluetooth_auto/macos/tests.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/tests.rs
@@ -692,6 +692,42 @@ fn scan_op_starts_restarts_and_stops_without_spurious_work() {
 }
 
 #[test]
+fn scan_decision_labels_distinguish_work_from_already_satisfied_requests() {
+    let cases = [
+        (true, false, false, "bluetooth: scan decision start"),
+        (true, false, true, "bluetooth: scan decision start"),
+        (
+            true,
+            true,
+            false,
+            "bluetooth: scan decision already scanning",
+        ),
+        (true, true, true, "bluetooth: scan decision restart"),
+        (false, true, false, "bluetooth: scan decision stop"),
+        (false, true, true, "bluetooth: scan decision stop"),
+        (
+            false,
+            false,
+            false,
+            "bluetooth: scan decision already stopped",
+        ),
+        (
+            false,
+            false,
+            true,
+            "bluetooth: scan decision already stopped",
+        ),
+    ];
+    for (enabled, is_scanning, restart, expected) in cases {
+        assert_eq!(
+            scan_op(enabled, is_scanning, restart).diagnostic_label(enabled),
+            expected,
+            "enabled={enabled}, is_scanning={is_scanning}, restart={restart}",
+        );
+    }
+}
+
+#[test]
 fn scan_lease_restarts_only_an_enabled_scan_without_observed_activity() {
     assert_eq!(scan_lease(false, false), ScanLease::Inactive);
     assert_eq!(scan_lease(false, true), ScanLease::Inactive);

--- a/prns-ffi/src/bluetooth_auto/macos/tests.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/tests.rs
@@ -3,13 +3,15 @@ use std::time::{Duration, Instant};
 
 use objc2_core_bluetooth::CBCharacteristicProperties;
 use prns_core::interfaces::bluetooth_auto::{
-    AdvertisingMode, BleBackend, BleIdentity, Control, RadioMode, ScanningMode,
+    AdvertisingMode, BleBackend, BleIdentity, Control, LinkCapabilities, Psm, RadioMode,
+    ScanningMode,
 };
 use tokio::sync::{mpsc, oneshot};
 
 use super::backend::{
-    central_peripheral_capacity, dial_admission, manager_readiness, scan_lease, scan_op,
-    BoundedRecentSet, DialAdmission, ScanLease, ScanOp,
+    central_peripheral_capacity, dial_admission, manager_readiness, role_capabilities, scan_lease,
+    scan_op, take_inbound_event, BoundedRecentSet, CoreBluetoothRole, DialAdmission, ScanLease,
+    ScanOp,
 };
 use super::central::{
     closed_central_session_ids, CentralDialCandidate, CentralPeerRegistry, CentralPeerSession,
@@ -37,7 +39,10 @@ use super::{
     manager_signal_channel, try_bounded_ingress, BoundedIngress, CoreBluetoothPeerId,
     MacosBleBackend, Sighting,
 };
-use super::{CoreBluetoothRestorationIdentifiers, CoreBluetoothRestorationIdentifiersError};
+use super::{
+    CoreBluetoothCentralRestorationIdentifier, CoreBluetoothRestorationIdentifiers,
+    CoreBluetoothRestorationIdentifiersError,
+};
 
 fn peer_id(value: u16) -> CoreBluetoothPeerId {
     let mut bytes = [0; 16];
@@ -70,6 +75,18 @@ fn restoration_identifiers_are_nonempty_and_distinct(
     let identifiers = CoreBluetoothRestorationIdentifiers::new("central", "peripheral")?;
     assert_eq!(identifiers.central(), "central");
     assert_eq!(identifiers.peripheral(), "peripheral");
+    Ok(())
+}
+
+#[test]
+fn central_restoration_identifier_is_nonempty_and_singular(
+) -> Result<(), CoreBluetoothRestorationIdentifiersError> {
+    assert_eq!(
+        CoreBluetoothCentralRestorationIdentifier::new(""),
+        Err(CoreBluetoothRestorationIdentifiersError::EmptyCentral)
+    );
+    let identifier = CoreBluetoothCentralRestorationIdentifier::new("central-only")?;
+    assert_eq!(identifier.as_str(), "central-only");
     Ok(())
 }
 
@@ -211,18 +228,72 @@ fn discovery_guard_bounds_service_misses_and_stale_cancellation_retries() {
 fn startup_requires_central_gatt_and_l2cap_readiness() {
     let (signals, current) = manager_signal_channel();
     signals.l2cap_published(0x0081);
-    assert_eq!(manager_readiness(*current.borrow()).unwrap(), None);
+    assert_eq!(
+        manager_readiness(CoreBluetoothRole::DualRole, *current.borrow()).unwrap(),
+        None
+    );
 
     signals.central_powered();
-    assert_eq!(manager_readiness(*current.borrow()).unwrap(), None);
+    assert_eq!(
+        manager_readiness(CoreBluetoothRole::DualRole, *current.borrow()).unwrap(),
+        None
+    );
 
     signals.gatt_service_published();
     assert_eq!(
-        manager_readiness(*current.borrow())
+        manager_readiness(CoreBluetoothRole::DualRole, *current.borrow())
             .unwrap()
-            .map(|psm| psm.get()),
+            .and_then(|readiness| readiness.local_psm.map(Psm::get)),
         Some(0x0081)
     );
+}
+
+#[test]
+fn central_only_readiness_requires_only_central_power_and_has_no_local_psm() {
+    let (signals, current) = manager_signal_channel();
+    assert_eq!(
+        manager_readiness(CoreBluetoothRole::CentralOnly, *current.borrow()).unwrap(),
+        None
+    );
+
+    signals.gatt_service_publish_failed();
+    signals.l2cap_publish_failed();
+    signals.central_powered();
+    let readiness = manager_readiness(CoreBluetoothRole::CentralOnly, *current.borrow())
+        .unwrap()
+        .expect("central power is sufficient for central-only readiness");
+    assert_eq!(readiness.central_powered_generation, 1);
+    assert_eq!(readiness.local_psm, None);
+}
+
+#[test]
+fn central_only_capabilities_clear_any_configured_local_psm() {
+    let configured = LinkCapabilities {
+        l2cap: Psm::new(0x0081),
+        link_mtu: 244,
+    };
+    assert_eq!(
+        role_capabilities(CoreBluetoothRole::CentralOnly, configured),
+        LinkCapabilities {
+            l2cap: None,
+            link_mtu: 244,
+        }
+    );
+    assert_eq!(
+        role_capabilities(CoreBluetoothRole::DualRole, configured),
+        configured
+    );
+}
+
+#[test]
+fn closed_inbound_ingress_is_disabled_without_blocking_other_events() {
+    let mut inbound_open = true;
+    assert_eq!(take_inbound_event::<u8>(None, &mut inbound_open), None);
+    assert!(!inbound_open);
+
+    let mut inbound_open = true;
+    assert_eq!(take_inbound_event(Some(7_u8), &mut inbound_open), Some(7));
+    assert!(inbound_open);
 }
 
 #[test]
@@ -265,9 +336,9 @@ fn bounded_ingress_separates_inbound_and_sighting_pressure() {
     manager_signals.gatt_service_published();
     manager_signals.l2cap_published(0x0081);
     assert_eq!(
-        manager_readiness(*manager_current.borrow())
+        manager_readiness(CoreBluetoothRole::DualRole, *manager_current.borrow())
             .unwrap()
-            .map(|psm| psm.get()),
+            .and_then(|readiness| readiness.local_psm.map(Psm::get)),
         Some(0x0081)
     );
     assert_eq!(inbound_rx.try_recv(), Ok(1));
@@ -532,7 +603,7 @@ fn manager_failures_are_sticky_and_fatal() {
     gatt_signals.gatt_service_publish_failed();
     gatt_signals.gatt_service_published();
     assert!(matches!(
-        manager_readiness(*gatt_current.borrow()),
+        manager_readiness(CoreBluetoothRole::DualRole, *gatt_current.borrow()),
         Err(MacosBleError::PublishFailed)
     ));
 
@@ -540,7 +611,7 @@ fn manager_failures_are_sticky_and_fatal() {
     l2cap_signals.l2cap_publish_failed();
     l2cap_signals.l2cap_published(0x0081);
     assert!(matches!(
-        manager_readiness(*l2cap_current.borrow()),
+        manager_readiness(CoreBluetoothRole::DualRole, *l2cap_current.borrow()),
         Err(MacosBleError::PublishFailed)
     ));
 }

--- a/prns-ffi/src/bluetooth_auto/macos/tests.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/tests.rs
@@ -19,14 +19,45 @@ use super::gatt_link::{
     gatt_inbound_channel, gatt_inbound_channel_with_budget, GattInboundSendError,
 };
 use super::gatt_write::{write_admission, GattWriteAdmission, GattWriteMode, GattWritePlan};
+use super::legacy_restoration_identifiers;
 use super::peripheral::{advertising_op, has_session_for_peer, AdvertisingOp};
 use super::MacosBleError;
 use super::{CoreBluetoothPeerId, MacosBleBackend};
+use super::{CoreBluetoothRestorationIdentifiers, CoreBluetoothRestorationIdentifiersError};
 
 fn peer_id(value: u16) -> CoreBluetoothPeerId {
     let mut bytes = [0; 16];
     bytes[..2].copy_from_slice(&value.to_le_bytes());
     CoreBluetoothPeerId(bytes)
+}
+
+#[test]
+fn restoration_identifiers_are_nonempty_and_distinct(
+) -> Result<(), CoreBluetoothRestorationIdentifiersError> {
+    assert_eq!(
+        CoreBluetoothRestorationIdentifiers::new("", "peripheral"),
+        Err(CoreBluetoothRestorationIdentifiersError::EmptyCentral)
+    );
+    assert_eq!(
+        CoreBluetoothRestorationIdentifiers::new("central", ""),
+        Err(CoreBluetoothRestorationIdentifiersError::EmptyPeripheral)
+    );
+    assert_eq!(
+        CoreBluetoothRestorationIdentifiers::new("shared", "shared"),
+        Err(CoreBluetoothRestorationIdentifiersError::Duplicate)
+    );
+
+    let identifiers = CoreBluetoothRestorationIdentifiers::new("central", "peripheral")?;
+    assert_eq!(identifiers.central(), "central");
+    assert_eq!(identifiers.peripheral(), "peripheral");
+    Ok(())
+}
+
+#[test]
+fn legacy_preparation_keeps_personal_hopspot_identifiers() {
+    let identifiers = legacy_restoration_identifiers();
+    assert_eq!(identifiers.central(), "com.personal.prns.ble.central");
+    assert_eq!(identifiers.peripheral(), "com.personal.prns.ble.peripheral");
 }
 
 #[test]

--- a/prns-ffi/src/bluetooth_auto/macos/tests.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/tests.rs
@@ -8,7 +8,8 @@ use prns_core::interfaces::bluetooth_auto::{
 use tokio::sync::{mpsc, oneshot};
 
 use super::backend::{
-    dial_admission, scan_lease, scan_op, DialAdmission, ScanLease, ScanOp, StartupReadiness,
+    dial_admission, pop_unseen_startup_sighting, scan_lease, scan_op, stage_startup_event,
+    DialAdmission, ScanLease, ScanOp, StartupBacklog, StartupProgress, StartupReadiness,
 };
 use super::central::{
     CentralPeerSession, RestoredCallbackBuffer, CENTRAL_CONTROL_INBOUND_CAPACITY,
@@ -24,6 +25,7 @@ use super::gatt_link::{
 use super::gatt_write::{write_admission, GattWriteAdmission, GattWriteMode, GattWritePlan};
 use super::legacy_restoration_identifiers;
 use super::peripheral::{advertising_op, has_session_for_peer, AdvertisingOp};
+use super::Event;
 use super::MacosBleError;
 use super::{CoreBluetoothPeerId, MacosBleBackend};
 use super::{CoreBluetoothRestorationIdentifiers, CoreBluetoothRestorationIdentifiersError};
@@ -201,6 +203,167 @@ fn startup_requires_central_gatt_and_l2cap_readiness() {
 
     readiness.note_gatt_service_published();
     assert_eq!(readiness.ready_psm().map(|psm| psm.get()), Some(0x0081));
+}
+
+#[test]
+fn startup_preserves_operational_events_until_final_readiness() {
+    let first = prns_core::interfaces::bluetooth_auto::BleAddress::new([1; 6]);
+    let mut readiness = StartupReadiness::default();
+    let mut backlog = StartupBacklog::<u8>::default();
+
+    assert!(matches!(
+        stage_startup_event(&mut readiness, &mut backlog, Event::Inbound(7), 2, 4,),
+        Ok(StartupProgress::Waiting)
+    ));
+    assert!(matches!(
+        stage_startup_event(
+            &mut readiness,
+            &mut backlog,
+            Event::Sighting {
+                address: first,
+                rssi: Some(-80),
+            },
+            2,
+            4,
+        ),
+        Ok(StartupProgress::Waiting)
+    ));
+    for event in [Event::<u8>::CentralPowered, Event::GattServicePublished] {
+        assert!(matches!(
+            stage_startup_event(&mut readiness, &mut backlog, event, 2, 4),
+            Ok(StartupProgress::Waiting)
+        ));
+    }
+    assert!(matches!(
+        stage_startup_event(
+            &mut readiness,
+            &mut backlog,
+            Event::Sighting {
+                address: first,
+                rssi: Some(-62),
+            },
+            2,
+            4,
+        ),
+        Ok(StartupProgress::Waiting)
+    ));
+    assert!(matches!(
+        stage_startup_event(
+            &mut readiness,
+            &mut backlog,
+            Event::L2capPublished { psm: 0x0081 },
+            2,
+            4,
+        ),
+        Ok(StartupProgress::Ready(psm)) if psm.get() == 0x0081
+    ));
+
+    assert_eq!(backlog.pop_inbound(), Some(7));
+    assert_eq!(backlog.pop_sighting(), Some((first, Some(-62))));
+}
+
+#[test]
+fn startup_backlog_bounds_inbound_and_evicts_least_recent_sighting() {
+    let first = prns_core::interfaces::bluetooth_auto::BleAddress::new([1; 6]);
+    let second = prns_core::interfaces::bluetooth_auto::BleAddress::new([2; 6]);
+    let third = prns_core::interfaces::bluetooth_auto::BleAddress::new([3; 6]);
+    let mut readiness = StartupReadiness::default();
+    let mut backlog = StartupBacklog::default();
+
+    for link in [1, 2] {
+        assert!(matches!(
+            stage_startup_event(&mut readiness, &mut backlog, Event::Inbound(link), 2, 2,),
+            Ok(StartupProgress::Waiting)
+        ));
+    }
+    assert!(matches!(
+        stage_startup_event(&mut readiness, &mut backlog, Event::Inbound(3), 2, 2,),
+        Ok(StartupProgress::InboundOverflow(3))
+    ));
+
+    for (address, rssi) in [(first, -80), (second, -70), (first, -60)] {
+        assert!(matches!(
+            stage_startup_event(
+                &mut readiness,
+                &mut backlog,
+                Event::Sighting {
+                    address,
+                    rssi: Some(rssi),
+                },
+                2,
+                2,
+            ),
+            Ok(StartupProgress::Waiting)
+        ));
+    }
+    assert!(matches!(
+        stage_startup_event(
+            &mut readiness,
+            &mut backlog,
+            Event::Sighting {
+                address: third,
+                rssi: Some(-50),
+            },
+            2,
+            2,
+        ),
+        Ok(StartupProgress::SightingEvicted { address, rssi })
+            if address == second && rssi == Some(-70)
+    ));
+    assert_eq!(backlog.pop_inbound(), Some(1));
+    assert_eq!(backlog.pop_inbound(), Some(2));
+    assert_eq!(backlog.pop_sighting(), Some((first, Some(-60))));
+    assert_eq!(backlog.pop_sighting(), Some((third, Some(-50))));
+}
+
+#[test]
+fn startup_sighting_api_skips_addresses_already_reported() {
+    let already_seen = prns_core::interfaces::bluetooth_auto::BleAddress::new([1; 6]);
+    let next = prns_core::interfaces::bluetooth_auto::BleAddress::new([2; 6]);
+    let mut readiness = StartupReadiness::default();
+    let mut backlog = StartupBacklog::<u8>::default();
+
+    for address in [already_seen, next] {
+        assert!(matches!(
+            stage_startup_event(
+                &mut readiness,
+                &mut backlog,
+                Event::Sighting {
+                    address,
+                    rssi: Some(-60),
+                },
+                2,
+                4,
+            ),
+            Ok(StartupProgress::Waiting)
+        ));
+    }
+
+    let mut seen = std::collections::HashSet::from([*already_seen.octets()]);
+    assert_eq!(
+        pop_unseen_startup_sighting(&mut backlog, &mut seen),
+        Some(next)
+    );
+    assert_eq!(pop_unseen_startup_sighting(&mut backlog, &mut seen), None);
+}
+
+#[test]
+fn startup_publish_failures_remain_fatal() {
+    for event in [
+        Event::<u8>::GattServicePublishFailed,
+        Event::L2capPublishFailed,
+    ] {
+        assert!(matches!(
+            stage_startup_event(
+                &mut StartupReadiness::default(),
+                &mut StartupBacklog::default(),
+                event,
+                2,
+                4,
+            ),
+            Err(MacosBleError::PublishFailed)
+        ));
+    }
 }
 
 #[test]

--- a/prns-ffi/src/bluetooth_auto/macos/tests.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/tests.rs
@@ -207,19 +207,44 @@ fn dial_admission_is_scoped_to_the_target_peer() {
     let inbound_sessions = HashMap::from([(inbound_peer, ())]);
 
     assert_eq!(
-        dial_admission(true, false),
+        dial_admission(true, false, false),
         DialAdmission::YieldToSystemConnection
     );
     assert_eq!(
-        dial_admission(false, has_session_for_peer(&inbound_sessions, inbound_peer)),
+        dial_admission(
+            false,
+            has_session_for_peer(&inbound_sessions, inbound_peer),
+            false,
+        ),
         DialAdmission::YieldToInboundSession
     );
     assert_eq!(
         dial_admission(
             false,
-            has_session_for_peer(&inbound_sessions, unrelated_peer)
+            has_session_for_peer(&inbound_sessions, unrelated_peer),
+            false,
         ),
         DialAdmission::AttachCentralSession
+    );
+}
+
+#[test]
+fn dial_admission_resumes_only_restored_system_connections() {
+    assert_eq!(
+        dial_admission(true, false, true),
+        DialAdmission::ResumeRestoredSession
+    );
+    assert_eq!(
+        dial_admission(false, false, true),
+        DialAdmission::AttachCentralSession
+    );
+    assert_eq!(
+        dial_admission(true, true, true),
+        DialAdmission::YieldToInboundSession
+    );
+    assert_eq!(
+        dial_admission(true, true, false),
+        DialAdmission::YieldToInboundSession
     );
 }
 

--- a/prns-ffi/src/bluetooth_auto/macos/tests.rs
+++ b/prns-ffi/src/bluetooth_auto/macos/tests.rs
@@ -8,8 +8,7 @@ use prns_core::interfaces::bluetooth_auto::{
 use tokio::sync::{mpsc, oneshot};
 
 use super::backend::{
-    dial_admission, pop_unseen_startup_sighting, scan_lease, scan_op, stage_startup_event,
-    DialAdmission, ScanLease, ScanOp, StartupBacklog, StartupProgress, StartupReadiness,
+    dial_admission, manager_readiness, scan_lease, scan_op, DialAdmission, ScanLease, ScanOp,
 };
 use super::central::{
     CentralPeerSession, RestoredCallbackBuffer, CENTRAL_CONTROL_INBOUND_CAPACITY,
@@ -25,9 +24,11 @@ use super::gatt_link::{
 use super::gatt_write::{write_admission, GattWriteAdmission, GattWriteMode, GattWritePlan};
 use super::legacy_restoration_identifiers;
 use super::peripheral::{advertising_op, has_session_for_peer, AdvertisingOp};
-use super::Event;
 use super::MacosBleError;
-use super::{CoreBluetoothPeerId, MacosBleBackend};
+use super::{
+    manager_signal_channel, try_bounded_ingress, BoundedIngress, CoreBluetoothPeerId,
+    MacosBleBackend, Sighting,
+};
 use super::{CoreBluetoothRestorationIdentifiers, CoreBluetoothRestorationIdentifiersError};
 
 fn peer_id(value: u16) -> CoreBluetoothPeerId {
@@ -194,176 +195,98 @@ fn discovery_guard_bounds_service_misses_and_stale_cancellation_retries() {
 
 #[test]
 fn startup_requires_central_gatt_and_l2cap_readiness() {
-    let mut readiness = StartupReadiness::default();
-    readiness.note_l2cap_published(0x0081).unwrap();
-    assert_eq!(readiness.ready_psm(), None);
+    let (signals, current) = manager_signal_channel();
+    signals.l2cap_published(0x0081);
+    assert_eq!(manager_readiness(*current.borrow()).unwrap(), None);
 
-    readiness.note_central_powered();
-    assert_eq!(readiness.ready_psm(), None);
+    signals.central_powered();
+    assert_eq!(manager_readiness(*current.borrow()).unwrap(), None);
 
-    readiness.note_gatt_service_published();
-    assert_eq!(readiness.ready_psm().map(|psm| psm.get()), Some(0x0081));
-}
-
-#[test]
-fn startup_preserves_operational_events_until_final_readiness() {
-    let first = prns_core::interfaces::bluetooth_auto::BleAddress::new([1; 6]);
-    let mut readiness = StartupReadiness::default();
-    let mut backlog = StartupBacklog::<u8>::default();
-
-    assert!(matches!(
-        stage_startup_event(&mut readiness, &mut backlog, Event::Inbound(7), 2, 4,),
-        Ok(StartupProgress::Waiting)
-    ));
-    assert!(matches!(
-        stage_startup_event(
-            &mut readiness,
-            &mut backlog,
-            Event::Sighting {
-                address: first,
-                rssi: Some(-80),
-            },
-            2,
-            4,
-        ),
-        Ok(StartupProgress::Waiting)
-    ));
-    for event in [Event::<u8>::CentralPowered, Event::GattServicePublished] {
-        assert!(matches!(
-            stage_startup_event(&mut readiness, &mut backlog, event, 2, 4),
-            Ok(StartupProgress::Waiting)
-        ));
-    }
-    assert!(matches!(
-        stage_startup_event(
-            &mut readiness,
-            &mut backlog,
-            Event::Sighting {
-                address: first,
-                rssi: Some(-62),
-            },
-            2,
-            4,
-        ),
-        Ok(StartupProgress::Waiting)
-    ));
-    assert!(matches!(
-        stage_startup_event(
-            &mut readiness,
-            &mut backlog,
-            Event::L2capPublished { psm: 0x0081 },
-            2,
-            4,
-        ),
-        Ok(StartupProgress::Ready(psm)) if psm.get() == 0x0081
-    ));
-
-    assert_eq!(backlog.pop_inbound(), Some(7));
-    assert_eq!(backlog.pop_sighting(), Some((first, Some(-62))));
-}
-
-#[test]
-fn startup_backlog_bounds_inbound_and_evicts_least_recent_sighting() {
-    let first = prns_core::interfaces::bluetooth_auto::BleAddress::new([1; 6]);
-    let second = prns_core::interfaces::bluetooth_auto::BleAddress::new([2; 6]);
-    let third = prns_core::interfaces::bluetooth_auto::BleAddress::new([3; 6]);
-    let mut readiness = StartupReadiness::default();
-    let mut backlog = StartupBacklog::default();
-
-    for link in [1, 2] {
-        assert!(matches!(
-            stage_startup_event(&mut readiness, &mut backlog, Event::Inbound(link), 2, 2,),
-            Ok(StartupProgress::Waiting)
-        ));
-    }
-    assert!(matches!(
-        stage_startup_event(&mut readiness, &mut backlog, Event::Inbound(3), 2, 2,),
-        Ok(StartupProgress::InboundOverflow(3))
-    ));
-
-    for (address, rssi) in [(first, -80), (second, -70), (first, -60)] {
-        assert!(matches!(
-            stage_startup_event(
-                &mut readiness,
-                &mut backlog,
-                Event::Sighting {
-                    address,
-                    rssi: Some(rssi),
-                },
-                2,
-                2,
-            ),
-            Ok(StartupProgress::Waiting)
-        ));
-    }
-    assert!(matches!(
-        stage_startup_event(
-            &mut readiness,
-            &mut backlog,
-            Event::Sighting {
-                address: third,
-                rssi: Some(-50),
-            },
-            2,
-            2,
-        ),
-        Ok(StartupProgress::SightingEvicted { address, rssi })
-            if address == second && rssi == Some(-70)
-    ));
-    assert_eq!(backlog.pop_inbound(), Some(1));
-    assert_eq!(backlog.pop_inbound(), Some(2));
-    assert_eq!(backlog.pop_sighting(), Some((first, Some(-60))));
-    assert_eq!(backlog.pop_sighting(), Some((third, Some(-50))));
-}
-
-#[test]
-fn startup_sighting_api_skips_addresses_already_reported() {
-    let already_seen = prns_core::interfaces::bluetooth_auto::BleAddress::new([1; 6]);
-    let next = prns_core::interfaces::bluetooth_auto::BleAddress::new([2; 6]);
-    let mut readiness = StartupReadiness::default();
-    let mut backlog = StartupBacklog::<u8>::default();
-
-    for address in [already_seen, next] {
-        assert!(matches!(
-            stage_startup_event(
-                &mut readiness,
-                &mut backlog,
-                Event::Sighting {
-                    address,
-                    rssi: Some(-60),
-                },
-                2,
-                4,
-            ),
-            Ok(StartupProgress::Waiting)
-        ));
-    }
-
-    let mut seen = std::collections::HashSet::from([*already_seen.octets()]);
+    signals.gatt_service_published();
     assert_eq!(
-        pop_unseen_startup_sighting(&mut backlog, &mut seen),
-        Some(next)
+        manager_readiness(*current.borrow())
+            .unwrap()
+            .map(|psm| psm.get()),
+        Some(0x0081)
     );
-    assert_eq!(pop_unseen_startup_sighting(&mut backlog, &mut seen), None);
 }
 
 #[test]
-fn startup_publish_failures_remain_fatal() {
-    for event in [
-        Event::<u8>::GattServicePublishFailed,
-        Event::L2capPublishFailed,
-    ] {
-        assert!(matches!(
-            stage_startup_event(
-                &mut StartupReadiness::default(),
-                &mut StartupBacklog::default(),
-                event,
-                2,
-                4,
-            ),
-            Err(MacosBleError::PublishFailed)
-        ));
-    }
+fn bounded_ingress_separates_inbound_and_sighting_pressure() {
+    let (inbound_tx, mut inbound_rx) = mpsc::channel(1);
+    let (sighting_tx, mut sighting_rx) = mpsc::channel(1);
+    let (manager_signals, manager_current) = manager_signal_channel();
+    let address = prns_core::interfaces::bluetooth_auto::BleAddress::new([1; 6]);
+    let sighting = Sighting {
+        address,
+        rssi: Some(-62),
+    };
+
+    assert_eq!(
+        try_bounded_ingress(&inbound_tx, 1_u8),
+        BoundedIngress::Accepted
+    );
+    assert_eq!(
+        try_bounded_ingress(&sighting_tx, sighting),
+        BoundedIngress::Accepted
+    );
+    assert_eq!(
+        try_bounded_ingress(&inbound_tx, 2_u8),
+        BoundedIngress::Full(2)
+    );
+    assert_eq!(
+        try_bounded_ingress(
+            &sighting_tx,
+            Sighting {
+                address,
+                rssi: Some(-50),
+            }
+        ),
+        BoundedIngress::Full(Sighting {
+            address,
+            rssi: Some(-50),
+        })
+    );
+    manager_signals.central_powered();
+    manager_signals.gatt_service_published();
+    manager_signals.l2cap_published(0x0081);
+    assert_eq!(
+        manager_readiness(*manager_current.borrow())
+            .unwrap()
+            .map(|psm| psm.get()),
+        Some(0x0081)
+    );
+    assert_eq!(inbound_rx.try_recv(), Ok(1));
+    assert_eq!(sighting_rx.try_recv(), Ok(sighting));
+}
+
+#[test]
+fn bounded_ingress_returns_rejected_payload_when_receiver_is_closed() {
+    let (sender, receiver) = mpsc::channel(1);
+    drop(receiver);
+    assert_eq!(
+        try_bounded_ingress(&sender, 7_u8),
+        BoundedIngress::Closed(7)
+    );
+}
+
+#[test]
+fn manager_failures_are_sticky_and_fatal() {
+    let (gatt_signals, gatt_current) = manager_signal_channel();
+    gatt_signals.gatt_service_publish_failed();
+    gatt_signals.gatt_service_published();
+    assert!(matches!(
+        manager_readiness(*gatt_current.borrow()),
+        Err(MacosBleError::PublishFailed)
+    ));
+
+    let (l2cap_signals, l2cap_current) = manager_signal_channel();
+    l2cap_signals.l2cap_publish_failed();
+    l2cap_signals.l2cap_published(0x0081);
+    assert!(matches!(
+        manager_readiness(*l2cap_current.borrow()),
+        Err(MacosBleError::PublishFailed)
+    ));
 }
 
 #[test]

--- a/prns-interfaces/impls/tokio/src/bluetooth_auto/host.rs
+++ b/prns-interfaces/impls/tokio/src/bluetooth_auto/host.rs
@@ -76,16 +76,16 @@ impl AutoBle {
         ))
     }
 
-    /// Creates foreground-only CoreBluetooth managers immediately while leaving radio
-    /// authorization and service readiness to the attached asynchronous supervisor.
+    /// Creates CoreBluetooth managers without state restoration while leaving radio authorization
+    /// and service readiness to the attached asynchronous supervisor.
     ///
     /// This path does not opt into CoreBluetooth state restoration. The selected preparation mode
     /// is retained for every later readiness retry.
     #[cfg(any(target_os = "macos", target_os = "ios"))]
-    pub async fn prepare_foreground(
+    pub async fn prepare_without_restoration(
         identity: BleIdentity,
     ) -> Result<PreparedAutoBle, prns_ffi::bluetooth_auto::macos::MacosBleError> {
-        let manager_preparation = AppleManagerPreparation::ForegroundOnly;
+        let manager_preparation = AppleManagerPreparation::WithoutRestoration;
         let backend = manager_preparation.prepare(identity).await?;
         Ok(PreparedAutoBle::new(
             identity,
@@ -120,12 +120,12 @@ impl AutoBle {
         )
     }
 
-    /// Produces a failed-but-supervised foreground-only Bluetooth LE attachment when native
-    /// manager preparation itself cannot be started. The core node and every other transport
-    /// remain available, and retries never opt into state restoration.
+    /// Produces a failed-but-supervised Bluetooth LE attachment without state restoration when
+    /// native manager preparation itself cannot be started. The core node and every other
+    /// transport remain available, and retries never opt into state restoration.
     #[cfg(any(target_os = "macos", target_os = "ios"))]
-    pub fn unavailable_foreground(identity: BleIdentity) -> PreparedAutoBle {
-        PreparedAutoBle::new(identity, AppleManagerPreparation::ForegroundOnly, None)
+    pub fn unavailable_without_restoration(identity: BleIdentity) -> PreparedAutoBle {
+        PreparedAutoBle::new(identity, AppleManagerPreparation::WithoutRestoration, None)
     }
 }
 
@@ -135,7 +135,7 @@ enum AppleManagerPreparation {
     LegacyRestorationAware,
     #[cfg(target_os = "ios")]
     RestorationAware(CoreBluetoothRestorationIdentifiers),
-    ForegroundOnly,
+    WithoutRestoration,
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -155,7 +155,9 @@ impl AppleManagerPreparation {
             Self::RestorationAware(identifiers) => {
                 MacosBleBackend::prepare_with_restoration(identity, identifiers.clone()).await
             }
-            Self::ForegroundOnly => MacosBleBackend::prepare_foreground(identity).await,
+            Self::WithoutRestoration => {
+                MacosBleBackend::prepare_without_restoration(identity).await
+            }
         }
     }
 }
@@ -682,12 +684,12 @@ mod tests {
     #[test]
     fn unavailable_preparation_retains_the_selected_retry_mode() {
         let identity = BleIdentity::new([0x30; 16]);
-        let foreground = AutoBle::unavailable_foreground(identity);
+        let without_restoration = AutoBle::unavailable_without_restoration(identity);
         assert_eq!(
-            foreground.manager_preparation,
-            AppleManagerPreparation::ForegroundOnly
+            without_restoration.manager_preparation,
+            AppleManagerPreparation::WithoutRestoration
         );
-        assert!(foreground.backend.is_none());
+        assert!(without_restoration.backend.is_none());
 
         let restoration_aware = AutoBle::unavailable(identity);
         assert_eq!(

--- a/prns-interfaces/impls/tokio/src/bluetooth_auto/host.rs
+++ b/prns-interfaces/impls/tokio/src/bluetooth_auto/host.rs
@@ -8,6 +8,11 @@ use prns_runtime::runtime::{Attachable, Fleet, InterfaceSupervisor, PrnsNodeHand
 
 use super::BluetoothAutoStatus;
 
+#[cfg(target_os = "ios")]
+pub use prns_ffi::bluetooth_auto::macos::{
+    CoreBluetoothRestorationIdentifiers, CoreBluetoothRestorationIdentifiersError,
+};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AutoBle {
     identity: BleIdentity,
@@ -44,7 +49,25 @@ impl AutoBle {
     pub async fn prepare(
         identity: BleIdentity,
     ) -> Result<PreparedAutoBle, prns_ffi::bluetooth_auto::macos::MacosBleError> {
-        let manager_preparation = AppleManagerPreparation::RestorationAware;
+        let manager_preparation = AppleManagerPreparation::LegacyRestorationAware;
+        let backend = manager_preparation.prepare(identity).await?;
+        Ok(PreparedAutoBle::new(
+            identity,
+            manager_preparation,
+            Some(backend),
+        ))
+    }
+
+    /// Creates restoration-aware CoreBluetooth managers using identifiers supplied by the
+    /// application that owns their lifecycle.
+    ///
+    /// The selected identifiers are retained for every later readiness retry.
+    #[cfg(target_os = "ios")]
+    pub async fn prepare_with_restoration(
+        identity: BleIdentity,
+        identifiers: CoreBluetoothRestorationIdentifiers,
+    ) -> Result<PreparedAutoBle, prns_ffi::bluetooth_auto::macos::MacosBleError> {
+        let manager_preparation = AppleManagerPreparation::RestorationAware(identifiers);
         let backend = manager_preparation.prepare(identity).await?;
         Ok(PreparedAutoBle::new(
             identity,
@@ -76,7 +99,25 @@ impl AutoBle {
     /// core node and every other transport remain available.
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     pub fn unavailable(identity: BleIdentity) -> PreparedAutoBle {
-        PreparedAutoBle::new(identity, AppleManagerPreparation::RestorationAware, None)
+        PreparedAutoBle::new(
+            identity,
+            AppleManagerPreparation::LegacyRestorationAware,
+            None,
+        )
+    }
+
+    /// Produces a failed-but-supervised restoration-aware Bluetooth LE attachment when native
+    /// manager preparation itself cannot be started. Retries reuse the caller's identifiers.
+    #[cfg(target_os = "ios")]
+    pub fn unavailable_with_restoration(
+        identity: BleIdentity,
+        identifiers: CoreBluetoothRestorationIdentifiers,
+    ) -> PreparedAutoBle {
+        PreparedAutoBle::new(
+            identity,
+            AppleManagerPreparation::RestorationAware(identifiers),
+            None,
+        )
     }
 
     /// Produces a failed-but-supervised foreground-only Bluetooth LE attachment when native
@@ -89,16 +130,18 @@ impl AutoBle {
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 enum AppleManagerPreparation {
-    RestorationAware,
+    LegacyRestorationAware,
+    #[cfg(target_os = "ios")]
+    RestorationAware(CoreBluetoothRestorationIdentifiers),
     ForegroundOnly,
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 impl AppleManagerPreparation {
     async fn prepare(
-        self,
+        &self,
         identity: BleIdentity,
     ) -> Result<
         prns_ffi::bluetooth_auto::macos::PreparedMacosBleBackend,
@@ -107,7 +150,11 @@ impl AppleManagerPreparation {
         use prns_ffi::bluetooth_auto::macos::MacosBleBackend;
 
         match self {
-            Self::RestorationAware => MacosBleBackend::prepare(identity).await,
+            Self::LegacyRestorationAware => MacosBleBackend::prepare(identity).await,
+            #[cfg(target_os = "ios")]
+            Self::RestorationAware(identifiers) => {
+                MacosBleBackend::prepare_with_restoration(identity, identifiers.clone()).await
+            }
             Self::ForegroundOnly => MacosBleBackend::prepare_foreground(identity).await,
         }
     }
@@ -645,7 +692,7 @@ mod tests {
         let restoration_aware = AutoBle::unavailable(identity);
         assert_eq!(
             restoration_aware.manager_preparation,
-            AppleManagerPreparation::RestorationAware
+            AppleManagerPreparation::LegacyRestorationAware
         );
         assert!(restoration_aware.backend.is_none());
     }

--- a/prns-interfaces/impls/tokio/src/bluetooth_auto/host.rs
+++ b/prns-interfaces/impls/tokio/src/bluetooth_auto/host.rs
@@ -10,7 +10,8 @@ use super::BluetoothAutoStatus;
 
 #[cfg(target_os = "ios")]
 pub use prns_ffi::bluetooth_auto::macos::{
-    CoreBluetoothRestorationIdentifiers, CoreBluetoothRestorationIdentifiersError,
+    CoreBluetoothCentralRestorationIdentifier, CoreBluetoothRestorationIdentifiers,
+    CoreBluetoothRestorationIdentifiersError,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -76,6 +77,25 @@ impl AutoBle {
         ))
     }
 
+    /// Creates only the restoration-aware CoreBluetooth central manager.
+    ///
+    /// The selected identifier is retained for every later readiness retry. The containing
+    /// application must declare the `bluetooth-central` background mode and recreate the manager
+    /// with this exact identifier on an iOS restoration launch. No peripheral manager is created.
+    #[cfg(target_os = "ios")]
+    pub async fn prepare_central_only_with_restoration(
+        identity: BleIdentity,
+        identifier: CoreBluetoothCentralRestorationIdentifier,
+    ) -> Result<PreparedAutoBle, prns_ffi::bluetooth_auto::macos::MacosBleError> {
+        let manager_preparation = AppleManagerPreparation::CentralOnlyRestorationAware(identifier);
+        let backend = manager_preparation.prepare(identity).await?;
+        Ok(PreparedAutoBle::new(
+            identity,
+            manager_preparation,
+            Some(backend),
+        ))
+    }
+
     /// Creates CoreBluetooth managers without state restoration while leaving radio authorization
     /// and service readiness to the attached asynchronous supervisor.
     ///
@@ -86,6 +106,20 @@ impl AutoBle {
         identity: BleIdentity,
     ) -> Result<PreparedAutoBle, prns_ffi::bluetooth_auto::macos::MacosBleError> {
         let manager_preparation = AppleManagerPreparation::WithoutRestoration;
+        let backend = manager_preparation.prepare(identity).await?;
+        Ok(PreparedAutoBle::new(
+            identity,
+            manager_preparation,
+            Some(backend),
+        ))
+    }
+
+    /// Creates only a CoreBluetooth central manager without state restoration.
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    pub async fn prepare_central_only_without_restoration(
+        identity: BleIdentity,
+    ) -> Result<PreparedAutoBle, prns_ffi::bluetooth_auto::macos::MacosBleError> {
+        let manager_preparation = AppleManagerPreparation::CentralOnlyWithoutRestoration;
         let backend = manager_preparation.prepare(identity).await?;
         Ok(PreparedAutoBle::new(
             identity,
@@ -120,12 +154,37 @@ impl AutoBle {
         )
     }
 
+    /// Produces a failed-but-supervised central-only attachment whose retries reuse the caller's
+    /// central restoration identifier.
+    #[cfg(target_os = "ios")]
+    pub fn unavailable_central_only_with_restoration(
+        identity: BleIdentity,
+        identifier: CoreBluetoothCentralRestorationIdentifier,
+    ) -> PreparedAutoBle {
+        PreparedAutoBle::new(
+            identity,
+            AppleManagerPreparation::CentralOnlyRestorationAware(identifier),
+            None,
+        )
+    }
+
     /// Produces a failed-but-supervised Bluetooth LE attachment without state restoration when
     /// native manager preparation itself cannot be started. The core node and every other
     /// transport remain available, and retries never opt into state restoration.
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     pub fn unavailable_without_restoration(identity: BleIdentity) -> PreparedAutoBle {
         PreparedAutoBle::new(identity, AppleManagerPreparation::WithoutRestoration, None)
+    }
+
+    /// Produces a failed-but-supervised central-only attachment whose retries remain outside the
+    /// CoreBluetooth restoration contract.
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    pub fn unavailable_central_only_without_restoration(identity: BleIdentity) -> PreparedAutoBle {
+        PreparedAutoBle::new(
+            identity,
+            AppleManagerPreparation::CentralOnlyWithoutRestoration,
+            None,
+        )
     }
 }
 
@@ -135,7 +194,22 @@ enum AppleManagerPreparation {
     LegacyRestorationAware,
     #[cfg(target_os = "ios")]
     RestorationAware(CoreBluetoothRestorationIdentifiers),
+    #[cfg(target_os = "ios")]
+    CentralOnlyRestorationAware(CoreBluetoothCentralRestorationIdentifier),
     WithoutRestoration,
+    CentralOnlyWithoutRestoration,
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+enum PreparedAppleBackend {
+    DualRole(prns_ffi::bluetooth_auto::macos::PreparedMacosBleBackend),
+    CentralOnly(prns_ffi::bluetooth_auto::macos::PreparedCentralOnlyMacosBleBackend),
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+enum ReadyAppleBackend {
+    DualRole(prns_ffi::bluetooth_auto::macos::MacosBleBackend),
+    CentralOnly(prns_ffi::bluetooth_auto::macos::CentralOnlyMacosBleBackend),
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -143,22 +217,63 @@ impl AppleManagerPreparation {
     async fn prepare(
         &self,
         identity: BleIdentity,
-    ) -> Result<
-        prns_ffi::bluetooth_auto::macos::PreparedMacosBleBackend,
-        prns_ffi::bluetooth_auto::macos::MacosBleError,
-    > {
-        use prns_ffi::bluetooth_auto::macos::MacosBleBackend;
+    ) -> Result<PreparedAppleBackend, prns_ffi::bluetooth_auto::macos::MacosBleError> {
+        use prns_ffi::bluetooth_auto::macos::{CentralOnlyMacosBleBackend, MacosBleBackend};
 
         match self {
-            Self::LegacyRestorationAware => MacosBleBackend::prepare(identity).await,
+            Self::LegacyRestorationAware => MacosBleBackend::prepare(identity)
+                .await
+                .map(PreparedAppleBackend::DualRole),
             #[cfg(target_os = "ios")]
             Self::RestorationAware(identifiers) => {
-                MacosBleBackend::prepare_with_restoration(identity, identifiers.clone()).await
+                MacosBleBackend::prepare_with_restoration(identity, identifiers.clone())
+                    .await
+                    .map(PreparedAppleBackend::DualRole)
             }
-            Self::WithoutRestoration => {
-                MacosBleBackend::prepare_without_restoration(identity).await
+            #[cfg(target_os = "ios")]
+            Self::CentralOnlyRestorationAware(identifier) => {
+                CentralOnlyMacosBleBackend::prepare_with_restoration(identity, identifier.clone())
+                    .await
+                    .map(PreparedAppleBackend::CentralOnly)
+            }
+            Self::WithoutRestoration => MacosBleBackend::prepare_without_restoration(identity)
+                .await
+                .map(PreparedAppleBackend::DualRole),
+            Self::CentralOnlyWithoutRestoration => {
+                CentralOnlyMacosBleBackend::prepare_without_restoration(identity)
+                    .await
+                    .map(PreparedAppleBackend::CentralOnly)
             }
         }
+    }
+}
+
+#[cfg(all(test, any(target_os = "macos", target_os = "ios")))]
+mod apple_manager_preparation_tests {
+    use super::*;
+
+    #[test]
+    fn unavailable_central_only_preparation_retains_its_role_for_retry() {
+        let identity = BleIdentity::new([0; 16]);
+        let prepared = AutoBle::unavailable_central_only_without_restoration(identity);
+        assert_eq!(
+            prepared.manager_preparation,
+            AppleManagerPreparation::CentralOnlyWithoutRestoration
+        );
+    }
+
+    #[cfg(target_os = "ios")]
+    #[test]
+    fn unavailable_central_only_preparation_retains_its_restoration_identifier() {
+        let identity = BleIdentity::new([0; 16]);
+        let identifier = CoreBluetoothCentralRestorationIdentifier::new("central-only")
+            .expect("the fixture identifier is valid");
+        let prepared =
+            AutoBle::unavailable_central_only_with_restoration(identity, identifier.clone());
+        assert_eq!(
+            prepared.manager_preparation,
+            AppleManagerPreparation::CentralOnlyRestorationAware(identifier)
+        );
     }
 }
 
@@ -167,7 +282,7 @@ impl PreparedAutoBle {
     fn new(
         identity: BleIdentity,
         manager_preparation: AppleManagerPreparation,
-        backend: Option<prns_ffi::bluetooth_auto::macos::PreparedMacosBleBackend>,
+        backend: Option<PreparedAppleBackend>,
     ) -> Self {
         Self {
             identity,
@@ -195,7 +310,7 @@ pub struct PreparedAutoBle {
     policy: EffectiveInterfacePolicy,
     status: BluetoothAutoStatus,
     manager_preparation: AppleManagerPreparation,
-    backend: Option<prns_ffi::bluetooth_auto::macos::PreparedMacosBleBackend>,
+    backend: Option<PreparedAppleBackend>,
 }
 
 /// Canonical name for a prepared Apple-platform Bluetooth LE auto-interface.
@@ -312,7 +427,7 @@ struct PreparedPlatformBluetooth {
     policy: EffectiveInterfacePolicy,
     status: BluetoothAutoStatus,
     manager_preparation: AppleManagerPreparation,
-    backend: Option<prns_ffi::bluetooth_auto::macos::PreparedMacosBleBackend>,
+    backend: Option<PreparedAppleBackend>,
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -360,10 +475,10 @@ async fn run_prepared_platform_bluetooth(
     status: BluetoothAutoStatus,
     policy: EffectiveInterfacePolicy,
     manager_preparation: AppleManagerPreparation,
-    backend: Option<prns_ffi::bluetooth_auto::macos::PreparedMacosBleBackend>,
+    backend: Option<PreparedAppleBackend>,
 ) {
     use super::BluetoothAuto;
-    use prns_ffi::bluetooth_auto::macos::MacosBleBackend;
+    use prns_ffi::bluetooth_auto::macos::{CentralOnlyMacosBleBackend, MacosBleBackend};
     use prns_runtime::interfaces::bluetooth_auto::{
         AppleHost, Endpoint, LinkCapabilities, BLE_HW_MTU,
     };
@@ -386,8 +501,16 @@ async fn run_prepared_platform_bluetooth(
             },
         };
 
-        match candidate.ready().await {
-            Ok(backend) => {
+        let ready = match candidate {
+            PreparedAppleBackend::DualRole(backend) => {
+                backend.ready().await.map(ReadyAppleBackend::DualRole)
+            }
+            PreparedAppleBackend::CentralOnly(backend) => {
+                backend.ready().await.map(ReadyAppleBackend::CentralOnly)
+            }
+        };
+        match ready {
+            Ok(ReadyAppleBackend::DualRole(backend)) => {
                 status.clear_failure();
                 let psm = backend.psm();
                 #[cfg(target_os = "macos")]
@@ -412,6 +535,30 @@ async fn run_prepared_platform_bluetooth(
                 crate::diagnostic_log::info!(
                     "bluetooth: supervising prepared CoreBluetooth backend, local psm {:#06x}",
                     psm.get()
+                );
+                bluetooth.run(fleet).await;
+                return;
+            }
+            Ok(ReadyAppleBackend::CentralOnly(backend)) => {
+                status.clear_failure();
+                #[cfg(target_os = "macos")]
+                let endpoint = Endpoint::CoreBluetooth(AppleHost::MacOs);
+                #[cfg(target_os = "ios")]
+                let endpoint = Endpoint::CoreBluetooth(AppleHost::Ios);
+                let bluetooth =
+                    BluetoothAuto::<_, { CentralOnlyMacosBleBackend::MAX_PEERS }>::with_status(
+                        backend,
+                        ble_identity,
+                        endpoint,
+                        LinkCapabilities {
+                            l2cap: None,
+                            link_mtu: BLE_HW_MTU as u16,
+                        },
+                        status,
+                    )
+                    .with_policy(policy);
+                crate::diagnostic_log::info!(
+                    "bluetooth: supervising prepared central-only CoreBluetooth backend; no local peripheral or L2CAP capability"
                 );
                 bluetooth.run(fleet).await;
                 return;

--- a/prns-interfaces/impls/tokio/src/bluetooth_auto/host.rs
+++ b/prns-interfaces/impls/tokio/src/bluetooth_auto/host.rs
@@ -44,30 +44,91 @@ impl AutoBle {
     pub async fn prepare(
         identity: BleIdentity,
     ) -> Result<PreparedAutoBle, prns_ffi::bluetooth_auto::macos::MacosBleError> {
-        let backend = prns_ffi::bluetooth_auto::macos::MacosBleBackend::prepare(identity).await?;
-        Ok(PreparedAutoBle {
+        let manager_preparation = AppleManagerPreparation::RestorationAware;
+        let backend = manager_preparation.prepare(identity).await?;
+        Ok(PreparedAutoBle::new(
             identity,
-            policy: prns_runtime::interfaces::bluetooth_auto::defaults_for_bitrate(
-                prns_runtime::interfaces::bluetooth_auto::BLE_BITRATE_GUESS_BPS,
-            )
-            .configured(ConfiguredInterfacePolicy::default()),
-            status: BluetoothAutoStatus::new(),
-            backend: Some(backend),
-        })
+            manager_preparation,
+            Some(backend),
+        ))
+    }
+
+    /// Creates foreground-only CoreBluetooth managers immediately while leaving radio
+    /// authorization and service readiness to the attached asynchronous supervisor.
+    ///
+    /// This path does not opt into CoreBluetooth state restoration. The selected preparation mode
+    /// is retained for every later readiness retry.
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    pub async fn prepare_foreground(
+        identity: BleIdentity,
+    ) -> Result<PreparedAutoBle, prns_ffi::bluetooth_auto::macos::MacosBleError> {
+        let manager_preparation = AppleManagerPreparation::ForegroundOnly;
+        let backend = manager_preparation.prepare(identity).await?;
+        Ok(PreparedAutoBle::new(
+            identity,
+            manager_preparation,
+            Some(backend),
+        ))
     }
 
     /// Produces a failed-but-supervised Bluetooth LE attachment when native manager preparation itself
-    /// cannot be started. The core node and every other transport remain available.
+    /// cannot be started. Retries retain the restoration-aware behavior of [`Self::prepare`]. The
+    /// core node and every other transport remain available.
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     pub fn unavailable(identity: BleIdentity) -> PreparedAutoBle {
-        PreparedAutoBle {
+        PreparedAutoBle::new(identity, AppleManagerPreparation::RestorationAware, None)
+    }
+
+    /// Produces a failed-but-supervised foreground-only Bluetooth LE attachment when native
+    /// manager preparation itself cannot be started. The core node and every other transport
+    /// remain available, and retries never opt into state restoration.
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    pub fn unavailable_foreground(identity: BleIdentity) -> PreparedAutoBle {
+        PreparedAutoBle::new(identity, AppleManagerPreparation::ForegroundOnly, None)
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AppleManagerPreparation {
+    RestorationAware,
+    ForegroundOnly,
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+impl AppleManagerPreparation {
+    async fn prepare(
+        self,
+        identity: BleIdentity,
+    ) -> Result<
+        prns_ffi::bluetooth_auto::macos::PreparedMacosBleBackend,
+        prns_ffi::bluetooth_auto::macos::MacosBleError,
+    > {
+        use prns_ffi::bluetooth_auto::macos::MacosBleBackend;
+
+        match self {
+            Self::RestorationAware => MacosBleBackend::prepare(identity).await,
+            Self::ForegroundOnly => MacosBleBackend::prepare_foreground(identity).await,
+        }
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+impl PreparedAutoBle {
+    fn new(
+        identity: BleIdentity,
+        manager_preparation: AppleManagerPreparation,
+        backend: Option<prns_ffi::bluetooth_auto::macos::PreparedMacosBleBackend>,
+    ) -> Self {
+        Self {
             identity,
             policy: prns_runtime::interfaces::bluetooth_auto::defaults_for_bitrate(
                 prns_runtime::interfaces::bluetooth_auto::BLE_BITRATE_GUESS_BPS,
             )
             .configured(ConfiguredInterfacePolicy::default()),
             status: BluetoothAutoStatus::new(),
-            backend: None,
+            manager_preparation,
+            backend,
         }
     }
 }
@@ -84,6 +145,7 @@ pub struct PreparedAutoBle {
     identity: BleIdentity,
     policy: EffectiveInterfacePolicy,
     status: BluetoothAutoStatus,
+    manager_preparation: AppleManagerPreparation,
     backend: Option<prns_ffi::bluetooth_auto::macos::PreparedMacosBleBackend>,
 }
 
@@ -167,6 +229,7 @@ impl Attachable for PreparedAutoBle {
             identity: self.identity,
             policy: self.policy,
             status: self.status,
+            manager_preparation: self.manager_preparation,
             backend: self.backend,
         });
         AttachedBle { status }
@@ -184,6 +247,7 @@ impl Attachable for PreparedAutoBle {
                 identity: self.identity,
                 policy: self.policy,
                 status: self.status,
+                manager_preparation: self.manager_preparation,
                 backend: self.backend,
             },
             ifac,
@@ -198,6 +262,7 @@ struct PreparedPlatformBluetooth {
     identity: BleIdentity,
     policy: EffectiveInterfacePolicy,
     status: BluetoothAutoStatus,
+    manager_preparation: AppleManagerPreparation,
     backend: Option<prns_ffi::bluetooth_auto::macos::PreparedMacosBleBackend>,
 }
 
@@ -232,6 +297,7 @@ impl InterfaceSupervisor for PreparedPlatformBluetooth {
             self.identity,
             self.status,
             self.policy,
+            self.manager_preparation,
             self.backend,
         )
         .await;
@@ -244,6 +310,7 @@ async fn run_prepared_platform_bluetooth(
     ble_identity: BleIdentity,
     status: BluetoothAutoStatus,
     policy: EffectiveInterfacePolicy,
+    manager_preparation: AppleManagerPreparation,
     backend: Option<prns_ffi::bluetooth_auto::macos::PreparedMacosBleBackend>,
 ) {
     use super::BluetoothAuto;
@@ -256,7 +323,7 @@ async fn run_prepared_platform_bluetooth(
     loop {
         let candidate = match prepared.take() {
             Some(backend) => backend,
-            None => match MacosBleBackend::prepare(ble_identity).await {
+            None => match manager_preparation.prepare(ble_identity).await {
                 Ok(backend) => backend,
                 Err(error) => {
                     status.mark_failed(Some("Bluetooth native manager unavailable"));
@@ -563,6 +630,25 @@ mod tests {
         ManuallyAttached, NoPersistence, PreConfiguredDestination, PrnsNode, PrnsNodeRecipe,
     };
     use prns_runtime::storage::GrowableHeap;
+
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[test]
+    fn unavailable_preparation_retains_the_selected_retry_mode() {
+        let identity = BleIdentity::new([0x30; 16]);
+        let foreground = AutoBle::unavailable_foreground(identity);
+        assert_eq!(
+            foreground.manager_preparation,
+            AppleManagerPreparation::ForegroundOnly
+        );
+        assert!(foreground.backend.is_none());
+
+        let restoration_aware = AutoBle::unavailable(identity);
+        assert_eq!(
+            restoration_aware.manager_preparation,
+            AppleManagerPreparation::RestorationAware
+        );
+        assert!(restoration_aware.backend.is_none());
+    }
 
     #[test]
     fn auto_ble_registers_before_platform_backend_initialization() {

--- a/prns-interfaces/impls/tokio/src/bluetooth_auto/mod.rs
+++ b/prns-interfaces/impls/tokio/src/bluetooth_auto/mod.rs
@@ -7,6 +7,8 @@ pub use host::{
     AttachedBle, AttachedBluetoothLe, AutoBle, AutoBluetoothLe, ConfiguredAutoBle,
     ConfiguredAutoBluetoothLe,
 };
+#[cfg(target_os = "ios")]
+pub use host::{CoreBluetoothRestorationIdentifiers, CoreBluetoothRestorationIdentifiersError};
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 pub use host::{PreparedAutoBle, PreparedAutoBluetoothLe};
 #[cfg(target_os = "linux")]

--- a/prns-interfaces/impls/tokio/src/bluetooth_auto/mod.rs
+++ b/prns-interfaces/impls/tokio/src/bluetooth_auto/mod.rs
@@ -8,7 +8,10 @@ pub use host::{
     ConfiguredAutoBluetoothLe,
 };
 #[cfg(target_os = "ios")]
-pub use host::{CoreBluetoothRestorationIdentifiers, CoreBluetoothRestorationIdentifiersError};
+pub use host::{
+    CoreBluetoothCentralRestorationIdentifier, CoreBluetoothRestorationIdentifiers,
+    CoreBluetoothRestorationIdentifiersError,
+};
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 pub use host::{PreparedAutoBle, PreparedAutoBluetoothLe};
 #[cfg(target_os = "linux")]

--- a/prns-interfaces/impls/tokio/src/bluetooth_auto/runtime.rs
+++ b/prns-interfaces/impls/tokio/src/bluetooth_auto/runtime.rs
@@ -1226,6 +1226,100 @@ mod tests {
         }
     }
 
+    #[derive(Debug, PartialEq, Eq)]
+    enum StartupCall {
+        Radio(RadioMode),
+        Capabilities(LinkCapabilities),
+        Advertising(AdvertisingMode),
+        Scanning(ScanningMode),
+        NextEvent,
+    }
+
+    struct RecordingStartupBackend {
+        calls: Vec<StartupCall>,
+        first_event: Option<oneshot::Sender<Vec<StartupCall>>>,
+    }
+
+    impl BleBackend<7> for RecordingStartupBackend {
+        type Error = Closed;
+        type Link = LoopbackLink;
+
+        async fn set_radio_mode(&mut self, mode: RadioMode) -> Result<(), Closed> {
+            self.calls.push(StartupCall::Radio(mode));
+            Ok(())
+        }
+
+        async fn local_capabilities(
+            &mut self,
+            configured: LinkCapabilities,
+        ) -> Result<LinkCapabilities, Closed> {
+            self.calls.push(StartupCall::Capabilities(configured));
+            Ok(configured)
+        }
+
+        async fn set_advertising(&mut self, mode: AdvertisingMode) -> Result<(), Closed> {
+            self.calls.push(StartupCall::Advertising(mode));
+            Ok(())
+        }
+
+        async fn set_scanning(&mut self, mode: ScanningMode) -> Result<(), Closed> {
+            self.calls.push(StartupCall::Scanning(mode));
+            Ok(())
+        }
+
+        async fn next_event(&mut self) -> BleEvent<LoopbackLink> {
+            if let Some(first_event) = self.first_event.take() {
+                self.calls.push(StartupCall::NextEvent);
+                let _ = first_event.send(std::mem::take(&mut self.calls));
+            }
+            std::future::pending().await
+        }
+
+        async fn dial(
+            &mut self,
+            _address: BleAddress,
+        ) -> prns_core::interfaces::bluetooth_auto::DialOutcome {
+            prns_core::interfaces::bluetooth_auto::DialOutcome::UnknownPeer
+        }
+    }
+
+    #[tokio::test]
+    async fn ios_gatt_only_startup_enables_scanning_before_waiting_for_peers() {
+        let (first_event_tx, first_event_rx) = oneshot::channel();
+        let capabilities = LinkCapabilities {
+            l2cap: None,
+            link_mtu: contract::BLE_HW_MTU as u16,
+        };
+        let bluetooth = BluetoothAuto::<_, 7>::new(
+            RecordingStartupBackend {
+                calls: Vec::new(),
+                first_event: Some(first_event_tx),
+            },
+            BleIdentity::new([1; 16]),
+            Endpoint::CoreBluetooth(AppleHost::Ios),
+            capabilities,
+        );
+        let status = bluetooth.status();
+        assert!(status.is_enabled());
+        let (fleet, _detached_fleet) = Fleet::detached(status.id());
+        let calls = tokio::select! {
+            result = tokio::time::timeout(Duration::from_secs(1), first_event_rx) => {
+                result.unwrap().unwrap()
+            }
+            () = bluetooth.run(fleet) => unreachable!("the BLE supervisor runs until cancelled"),
+        };
+        assert_eq!(
+            calls,
+            vec![
+                StartupCall::Radio(RadioMode::On),
+                StartupCall::Capabilities(capabilities),
+                StartupCall::Advertising(AdvertisingMode::On),
+                StartupCall::Scanning(ScanningMode::On),
+                StartupCall::NextEvent,
+            ]
+        );
+    }
+
     #[tokio::test]
     async fn two_nodes_handshake_over_loopback_and_a_frame_crosses() {
         let local_a = LocalPeer {


### PR DESCRIPTION
Add payload-free logs for scan requests, queued execution, the radio gate and CoreBluetooth's start/restart/stop decisions. Connection behavior is unchanged.

The Prns app needs to distinguish a requested scan from one that actually ran or was skipped during startup. Tests also cover the seven-slot GATT-only startup ordering used by iOS.

Depends on #208, #207 and #202; [own changes](https://github.com/evelant/Prns/compare/5750e224199e24f9f7536b65f287e284a91aa8d4...a20dcfd15b09f50a0d83fc66caf82cfc3fc3dd4d). App integration: #197.

Rebased on trunk `c4fd54dfd`. Validation on `a20dcfd15`: 82 FFI tests pass with and without logging (one hardware test ignored per run), 15 Bluetooth-interface tests pass, and strict FFI Clippy and iOS Rust compilation pass. The normal publishing gate passed, including the configured firmware resource matrix, Miri/target-ISA checks and selected SDK lanes. No fresh device qualification is claimed.
