### PR TITLE
Report failures to save pairing grants on the controller

### DIFF
--- a/prns-core/src/engine/command_execution.rs
+++ b/prns-core/src/engine/command_execution.rs
@@ -777,16 +777,26 @@ impl<S: StorageLayout> EngineState<S> {
                     fill_random,
                     sink,
                 );
-                if let Ok(RemoteControlControllerPairingFinalization::Completed {
-                    attempt_id,
-                    ..
-                }) = &result
-                {
-                    sink(EngineReaction::Journaled(
+                match &result {
+                    Ok(RemoteControlControllerPairingFinalization::Completed {
+                        attempt_id,
+                        ..
+                    }) => sink(EngineReaction::Journaled(
                         Journaled::RemoteControlControllerPairingAuthorizationPersisted {
                             attempt_id: *attempt_id,
                         },
-                    ));
+                    )),
+                    Ok(
+                        RemoteControlControllerPairingFinalization::PersistenceFailureRecorded {
+                            attempt_id,
+                            ..
+                        },
+                    ) => sink(EngineReaction::Journaled(
+                        Journaled::RemoteControlControllerPairingAuthorizationPersistenceFailed {
+                            attempt_id: *attempt_id,
+                        },
+                    )),
+                    Err(_) => {}
                 }
                 settle(
                     sink,

--- a/prns-core/src/engine/commands/remote_control_controller_pairing.rs
+++ b/prns-core/src/engine/commands/remote_control_controller_pairing.rs
@@ -922,12 +922,23 @@ mod tests {
         packed
     }
 
-    fn execute(
+    #[derive(Debug, Default, PartialEq, Eq)]
+    struct ControllerPairingAuthorizationPersistenceEvents {
+        persisted: std::vec::Vec<RemoteControlPairingAttemptId>,
+        failed: std::vec::Vec<RemoteControlPairingAttemptId>,
+    }
+
+    fn execute_observing_controller_pairing_persistence(
         engine: &mut EngineState<TestStorageLayout>,
         command: PrnsCommand,
         now: InstantMillis,
-    ) -> (Settlement, WakeSchedules) {
+    ) -> (
+        Settlement,
+        WakeSchedules,
+        ControllerPairingAuthorizationPersistenceEvents,
+    ) {
         let mut settled = None;
+        let mut persistence_events = ControllerPairingAuthorizationPersistenceEvents::default();
         let schedules = engine.ingest_command_into(
             IssuedCommand {
                 id: CommandId(0xC1),
@@ -941,12 +952,30 @@ mod tests {
                     id: CommandId(0xC1),
                     settlement,
                 }) => settled = Some(settlement),
+                EngineReaction::Journaled(
+                    Journaled::RemoteControlControllerPairingAuthorizationPersisted { attempt_id },
+                ) => persistence_events.persisted.push(attempt_id),
+                EngineReaction::Journaled(
+                    Journaled::RemoteControlControllerPairingAuthorizationPersistenceFailed {
+                        attempt_id,
+                    },
+                ) => persistence_events.failed.push(attempt_id),
                 EngineReaction::Journaled(Journaled::CommandSettled { .. })
                 | EngineReaction::Journaled(_)
                 | EngineReaction::Directive(_) => {}
             },
         );
-        (settled.unwrap(), schedules)
+        (settled.unwrap(), schedules, persistence_events)
+    }
+
+    fn execute(
+        engine: &mut EngineState<TestStorageLayout>,
+        command: PrnsCommand,
+        now: InstantMillis,
+    ) -> (Settlement, WakeSchedules) {
+        let (settlement, schedules, _) =
+            execute_observing_controller_pairing_persistence(engine, command, now);
+        (settlement, schedules)
     }
 
     fn dispatch_begin_request(
@@ -1492,8 +1521,12 @@ mod tests {
             persistence: RemoteControlControllerPairingPersistence::Persisted,
         };
 
-        let (settlement, schedules) =
-            execute(&mut engine, command.into_command(), InstantMillis(4_000));
+        let (settlement, schedules, persistence_events) =
+            execute_observing_controller_pairing_persistence(
+                &mut engine,
+                command.into_command(),
+                InstantMillis(4_000),
+            );
         let Settlement::SettleRemoteControlControllerPairingPersistence(Ok(
             RemoteControlControllerPairingFinalization::Completed {
                 attempt_id: completed,
@@ -1514,6 +1547,13 @@ mod tests {
             RemoteControlControllerPairingView::Idle,
         );
         assert_eq!(schedules.remote_control_pairing, WakeSchedule::Idle);
+        assert_eq!(
+            persistence_events,
+            ControllerPairingAuthorizationPersistenceEvents {
+                persisted: std::vec![attempt_id],
+                failed: std::vec![],
+            },
+        );
 
         let (repeated, repeated_schedules) =
             execute(&mut engine, command.into_command(), InstantMillis(4_001));
@@ -1536,15 +1576,16 @@ mod tests {
         let mut engine = engine_with_active_link();
         let (attempt_id, target_identity, permitted_requests) = awaiting_persistence(&mut engine);
 
-        let (settlement, schedules) = execute(
-            &mut engine,
-            SettleRemoteControlControllerPairingPersistence {
-                attempt_id,
-                persistence: RemoteControlControllerPairingPersistence::Failed,
-            }
-            .into_command(),
-            InstantMillis(4_000),
-        );
+        let (settlement, schedules, persistence_events) =
+            execute_observing_controller_pairing_persistence(
+                &mut engine,
+                SettleRemoteControlControllerPairingPersistence {
+                    attempt_id,
+                    persistence: RemoteControlControllerPairingPersistence::Failed,
+                }
+                .into_command(),
+                InstantMillis(4_000),
+            );
         let Settlement::SettleRemoteControlControllerPairingPersistence(Ok(
             RemoteControlControllerPairingFinalization::PersistenceFailureRecorded {
                 attempt_id: failed,
@@ -1565,6 +1606,13 @@ mod tests {
             RemoteControlControllerPairingView::Idle,
         );
         assert_eq!(schedules.remote_control_pairing, WakeSchedule::Idle);
+        assert_eq!(
+            persistence_events,
+            ControllerPairingAuthorizationPersistenceEvents {
+                persisted: std::vec![],
+                failed: std::vec![attempt_id],
+            },
+        );
     }
 
     #[test]

--- a/prns-core/src/engine/reaction.rs
+++ b/prns-core/src/engine/reaction.rs
@@ -465,6 +465,10 @@ pub enum Journaled<'a> {
         attempt_id: crate::remote_control::RemoteControlPairingAttemptId,
     },
 
+    RemoteControlControllerPairingAuthorizationPersistenceFailed {
+        attempt_id: crate::remote_control::RemoteControlPairingAttemptId,
+    },
+
     RemoteControlControllerPairingExpired {
         aborted: crate::remote_control::RemoteControlControllerPairingAborted,
     },

--- a/prns-core/src/remote_control/pairing/exchange/transcript.rs
+++ b/prns-core/src/remote_control/pairing/exchange/transcript.rs
@@ -136,6 +136,15 @@ impl RemoteControlPairingTranscriptDigest {
 pub struct RemoteControlPairingAttemptId(RemoteControlPairingTranscriptDigest);
 
 impl RemoteControlPairingAttemptId {
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn from_test_transcript_digest_bytes(
+        bytes: [u8; PAIRING_TRANSCRIPT_DIGEST_ENCODED_LEN],
+    ) -> Self {
+        Self(RemoteControlPairingTranscriptDigest(bytes))
+    }
+
     #[must_use]
     pub const fn transcript(self) -> RemoteControlPairingTranscriptDigest {
         self.0

--- a/prns-host/impls/native/src/lib.rs
+++ b/prns-host/impls/native/src/lib.rs
@@ -2903,6 +2903,14 @@ fn publish_message(sink: &dyn NativeEventSink, message: Message<'_>) -> bool {
             );
             return true;
         }
+        Message::RemoteControlControllerPairingAuthorizationPersistenceFailed { attempt_id } => {
+            publish_remote_control_diagnostic(
+                sink,
+                "RemoteControlControllerPairingAuthorizationPersistenceFailed",
+                format!("{attempt_id:?}"),
+            );
+            return true;
+        }
         Message::RemoteControlControllerPairingExpired { aborted } => {
             publish_remote_control_diagnostic(
                 sink,

--- a/prns-runtime/core/src/runtime/event.rs
+++ b/prns-runtime/core/src/runtime/event.rs
@@ -58,6 +58,9 @@ pub enum Message<'a> {
     RemoteControlControllerPairingAuthorizationPersisted {
         attempt_id: RemoteControlPairingAttemptId,
     },
+    RemoteControlControllerPairingAuthorizationPersistenceFailed {
+        attempt_id: RemoteControlPairingAttemptId,
+    },
     RemoteControlControllerPairingExpired {
         aborted: RemoteControlControllerPairingAborted,
     },
@@ -249,6 +252,13 @@ impl<'a> From<Journaled<'a>> for PrnsEvent<'a> {
                     Message::RemoteControlControllerPairingAuthorizationPersisted { attempt_id },
                 )
             }
+            Journaled::RemoteControlControllerPairingAuthorizationPersistenceFailed {
+                attempt_id,
+            } => PrnsEvent::Message(
+                Message::RemoteControlControllerPairingAuthorizationPersistenceFailed {
+                    attempt_id,
+                },
+            ),
             Journaled::RemoteControlControllerPairingExpired { aborted } => {
                 PrnsEvent::Message(Message::RemoteControlControllerPairingExpired { aborted })
             }
@@ -492,6 +502,25 @@ mod tests {
                     context: observed,
                 },
             }) if observed == context
+        ));
+    }
+
+    #[test]
+    fn controller_pairing_persistence_failure_is_an_app_facing_message() {
+        let attempt_id =
+            RemoteControlPairingAttemptId::from_test_transcript_digest_bytes([0x83; 32]);
+
+        let event = PrnsEvent::from(
+            Journaled::RemoteControlControllerPairingAuthorizationPersistenceFailed { attempt_id },
+        );
+
+        assert!(matches!(
+            event,
+            PrnsEvent::Message(
+                Message::RemoteControlControllerPairingAuthorizationPersistenceFailed {
+                    attempt_id: observed,
+                },
+            ) if observed == attempt_id
         ));
     }
 }

--- a/prns-runtime/core/src/runtime/observability.rs
+++ b/prns-runtime/core/src/runtime/observability.rs
@@ -295,6 +295,7 @@ impl ReliabilityMetricsSnapshot {
             | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
             | Journaled::RemoteControlControllerPairingPersistenceRequired(_)
             | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }
+            | Journaled::RemoteControlControllerPairingAuthorizationPersistenceFailed { .. }
             | Journaled::RemoteControlControllerPairingExpired { .. }
             | Journaled::RemoteControlControllerPairingLinkClosed { .. }
             | Journaled::RemoteControlTargetPairingExpired { .. }

--- a/prns-runtime/impls/embassy/src/manifold/driver/fixed_topology/tests.rs
+++ b/prns-runtime/impls/embassy/src/manifold/driver/fixed_topology/tests.rs
@@ -147,6 +147,7 @@ fn an_ifac_frame_crosses_the_seam_and_leaves_masked_through_the_peer() {
         | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
         | Journaled::RemoteControlControllerPairingPersistenceRequired(_)
         | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }
+        | Journaled::RemoteControlControllerPairingAuthorizationPersistenceFailed { .. }
         | Journaled::RemoteControlControllerPairingExpired { .. }
         | Journaled::RemoteControlControllerPairingLinkClosed { .. }
         | Journaled::RemoteControlTargetPairingExpired { .. }

--- a/prns-runtime/impls/embassy/src/manifold/driver/pooled_topology/tests.rs
+++ b/prns-runtime/impls/embassy/src/manifold/driver/pooled_topology/tests.rs
@@ -189,6 +189,7 @@ fn a_pooled_ifac_slot_added_at_runtime_opens_inbound_then_frees_on_remove() {
         | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
         | Journaled::RemoteControlControllerPairingPersistenceRequired(_)
         | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }
+        | Journaled::RemoteControlControllerPairingAuthorizationPersistenceFailed { .. }
         | Journaled::RemoteControlControllerPairingExpired { .. }
         | Journaled::RemoteControlControllerPairingLinkClosed { .. }
         | Journaled::RemoteControlTargetPairingExpired { .. }
@@ -331,6 +332,7 @@ fn a_pooled_slot_retagged_at_runtime_carries_traffic_under_the_new_id() {
         | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
         | Journaled::RemoteControlControllerPairingPersistenceRequired(_)
         | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }
+        | Journaled::RemoteControlControllerPairingAuthorizationPersistenceFailed { .. }
         | Journaled::RemoteControlControllerPairingExpired { .. }
         | Journaled::RemoteControlControllerPairingLinkClosed { .. }
         | Journaled::RemoteControlTargetPairingExpired { .. }

--- a/prns-runtime/impls/embassy/src/runtime/embedded_persistence.rs
+++ b/prns-runtime/impls/embassy/src/runtime/embedded_persistence.rs
@@ -500,6 +500,7 @@ where
             | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
             | Journaled::RemoteControlControllerPairingPersistenceRequired(_)
             | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }
+            | Journaled::RemoteControlControllerPairingAuthorizationPersistenceFailed { .. }
             | Journaled::RemoteControlControllerPairingExpired { .. }
             | Journaled::RemoteControlControllerPairingLinkClosed { .. }
             | Journaled::RemoteControlTargetPairingExpired { .. }

--- a/prns-runtime/impls/embassy/src/runtime/node_facade/command_handle/tests.rs
+++ b/prns-runtime/impls/embassy/src/runtime/node_facade/command_handle/tests.rs
@@ -449,6 +449,30 @@ fn an_unclaimed_settlement_moves_to_the_application_route() {
 }
 
 #[test]
+fn controller_pairing_persistence_failure_moves_to_the_application_route() {
+    let commands = Channel::<CriticalSectionRawMutex, IssuedCommand, 1>::new();
+    let completions = Pool::<0>::new();
+    let handle = super::PrnsNodeHandle::new(commands.sender(), &completions);
+    let attempt_id = super::super::test_remote_control_pairing_attempt(0xA4);
+    let mut observed = None;
+
+    let route = handle.route_journaled(
+        Journaled::RemoteControlControllerPairingAuthorizationPersistenceFailed { attempt_id },
+        |journaled| {
+            if let Journaled::RemoteControlControllerPairingAuthorizationPersistenceFailed {
+                attempt_id,
+            } = journaled
+            {
+                observed = Some(attempt_id);
+            }
+        },
+    );
+
+    assert!(matches!(route, JournalRoute::Application));
+    assert_eq!(observed, Some(attempt_id));
+}
+
+#[test]
 fn a_cancelled_request_releases_its_slot_and_routes_late_delivery_to_the_application() {
     let pool = CompletionPool::<CriticalSectionRawMutex, 0, 1, 4>::new();
     let id = CommandId(0);

--- a/prns-runtime/impls/embassy/src/runtime/remote_control_pairing_persistence.rs
+++ b/prns-runtime/impls/embassy/src/runtime/remote_control_pairing_persistence.rs
@@ -231,6 +231,7 @@ impl RemoteControlPairingPersistenceRequired {
             | Journaled::RemoteControlTargetPairingAuthorizationPersisted { .. }
             | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
             | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }
+            | Journaled::RemoteControlControllerPairingAuthorizationPersistenceFailed { .. }
             | Journaled::RemoteControlControllerPairingExpired { .. }
             | Journaled::RemoteControlControllerPairingLinkClosed { .. }
             | Journaled::RemoteControlTargetPairingExpired { .. }

--- a/prns-runtime/impls/tokio/src/manifold/driver/journal_delivery/tests.rs
+++ b/prns-runtime/impls/tokio/src/manifold/driver/journal_delivery/tests.rs
@@ -53,6 +53,26 @@ fn settle_forwards_a_settlement_nobody_awaits() {
     );
 }
 
+#[test]
+fn controller_pairing_persistence_failure_reaches_the_application_lane() {
+    let mut delivery = JournalDelivery::default();
+    let attempt_id =
+        crate::remote_control::RemoteControlPairingAttemptId::from_test_transcript_digest_bytes(
+            [0xA3; 32],
+        );
+
+    let forwarded = delivery.route(
+        Journaled::RemoteControlControllerPairingAuthorizationPersistenceFailed { attempt_id },
+    );
+
+    assert!(matches!(
+        forwarded,
+        Some(Journaled::RemoteControlControllerPairingAuthorizationPersistenceFailed {
+            attempt_id: observed,
+        }) if observed == attempt_id
+    ));
+}
+
 const RES_LINK: LinkId = LinkId::new([0x44; 16]);
 
 fn resource_delivery() -> (JournalDelivery, mpsc::UnboundedReceiver<ResourceInbound>) {

--- a/prns-runtime/impls/tokio/src/manifold/driver/tests/announces.rs
+++ b/prns-runtime/impls/tokio/src/manifold/driver/tests/announces.rs
@@ -69,6 +69,7 @@ async fn a_commanded_announce_fans_to_every_interface_and_settles() {
         | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
         | Journaled::RemoteControlControllerPairingPersistenceRequired(_)
         | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }
+        | Journaled::RemoteControlControllerPairingAuthorizationPersistenceFailed { .. }
         | Journaled::RemoteControlControllerPairingExpired { .. }
         | Journaled::RemoteControlControllerPairingLinkClosed { .. }
         | Journaled::RemoteControlTargetPairingExpired { .. }

--- a/prns-runtime/impls/tokio/src/manifold/driver/tests/routes.rs
+++ b/prns-runtime/impls/tokio/src/manifold/driver/tests/routes.rs
@@ -50,6 +50,7 @@ async fn routing_control_drops_a_live_route_and_journals_the_explicit_removal() 
         | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
         | Journaled::RemoteControlControllerPairingPersistenceRequired(_)
         | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }
+        | Journaled::RemoteControlControllerPairingAuthorizationPersistenceFailed { .. }
         | Journaled::RemoteControlControllerPairingExpired { .. }
         | Journaled::RemoteControlControllerPairingLinkClosed { .. }
         | Journaled::RemoteControlTargetPairingExpired { .. }
@@ -192,6 +193,7 @@ async fn the_manifold_culls_an_expired_route_at_its_deadline() {
         | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
         | Journaled::RemoteControlControllerPairingPersistenceRequired(_)
         | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }
+        | Journaled::RemoteControlControllerPairingAuthorizationPersistenceFailed { .. }
         | Journaled::RemoteControlControllerPairingExpired { .. }
         | Journaled::RemoteControlControllerPairingLinkClosed { .. }
         | Journaled::RemoteControlTargetPairingExpired { .. }

--- a/prns-runtime/impls/tokio/src/manifold/driver/tests/transport.rs
+++ b/prns-runtime/impls/tokio/src/manifold/driver/tests/transport.rs
@@ -71,6 +71,7 @@ async fn a_loopback_frame_crosses_the_seam_and_the_rebroadcast_leaves_through_th
         | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
         | Journaled::RemoteControlControllerPairingPersistenceRequired(_)
         | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }
+        | Journaled::RemoteControlControllerPairingAuthorizationPersistenceFailed { .. }
         | Journaled::RemoteControlControllerPairingExpired { .. }
         | Journaled::RemoteControlControllerPairingLinkClosed { .. }
         | Journaled::RemoteControlTargetPairingExpired { .. }
@@ -437,6 +438,7 @@ async fn a_delivery_answers_with_a_proof_directive_on_the_arrival_lane() {
         | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
         | Journaled::RemoteControlControllerPairingPersistenceRequired(_)
         | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }
+        | Journaled::RemoteControlControllerPairingAuthorizationPersistenceFailed { .. }
         | Journaled::RemoteControlControllerPairingExpired { .. }
         | Journaled::RemoteControlControllerPairingLinkClosed { .. }
         | Journaled::RemoteControlTargetPairingExpired { .. }

--- a/prns-runtime/impls/tokio/src/runtime/remote_control_pairing_persistence.rs
+++ b/prns-runtime/impls/tokio/src/runtime/remote_control_pairing_persistence.rs
@@ -146,6 +146,7 @@ impl RemoteControlPairingPersistenceSender {
             | Journaled::RemoteControlTargetPairingAuthorizationPersisted { .. }
             | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
             | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }
+            | Journaled::RemoteControlControllerPairingAuthorizationPersistenceFailed { .. }
             | Journaled::RemoteControlControllerPairingExpired { .. }
             | Journaled::RemoteControlControllerPairingLinkClosed { .. }
             | Journaled::RemoteControlTargetPairingExpired { .. }

--- a/prns-runtime/impls/tokio/src/runtime/tracing_events.rs
+++ b/prns-runtime/impls/tokio/src/runtime/tracing_events.rs
@@ -26,6 +26,7 @@ fn emit_message(message: &Message<'_>) {
         | Message::RemoteControlControllerPairingConfirmationRequired(_)
         | Message::RemoteControlControllerPairingPersistenceRequired(_)
         | Message::RemoteControlControllerPairingAuthorizationPersisted { .. }
+        | Message::RemoteControlControllerPairingAuthorizationPersistenceFailed { .. }
         | Message::RemoteControlControllerPairingExpired { .. }
         | Message::RemoteControlControllerPairingLinkClosed { .. }
         | Message::RemoteControlTargetPairingExpired { .. }

--- a/prns-wasm/examples/browser-playground/outcomes.ts
+++ b/prns-wasm/examples/browser-playground/outcomes.ts
@@ -151,6 +151,7 @@ export function describeInterfaceCloseFailure(
     HostOperationFailed: ({ operation, detail }) => `${operation}: ${detail}`,
     CloseFailed: ({ causes }) =>
       causes.map(describeCleanupFailure).join("; "),
+    RuntimeRejected: ({ operation, detail }) => `${operation}: ${detail}`,
   });
 }
 

--- a/prns-wasm/scripts/stage-event-smoke.mjs
+++ b/prns-wasm/scripts/stage-event-smoke.mjs
@@ -1,11 +1,19 @@
 import { copyFile, mkdir } from "node:fs/promises";
 
+const generatedCasework = new URL(
+  "../../prns-js/dist/casework.js",
+  import.meta.url,
+);
+const smokeCasework = new URL(
+  "../smoke/dist/prns-js/src/casework.js",
+  import.meta.url,
+);
 const sdkDirectory = new URL(
   "../smoke/dist/prns-wasm/examples/browser-playground/sdk/",
   import.meta.url,
 );
 await mkdir(sdkDirectory, { recursive: true });
-await copyFile(
-  new URL("../smoke/dist/prns-js/src/casework.js", import.meta.url),
-  new URL("index.js", sdkDirectory),
-);
+await Promise.all([
+  copyFile(generatedCasework, smokeCasework),
+  copyFile(generatedCasework, new URL("index.js", sdkDirectory)),
+]);

--- a/prns-wasm/smoke/auto-wifi-smoke.ts
+++ b/prns-wasm/smoke/auto-wifi-smoke.ts
@@ -112,7 +112,30 @@ class MockRuntime extends MockRuntimeBase {
   }
 
   snapshot(): unknown {
-    return { type: "snapshot" };
+    const removed = new Set(
+      this.removed.map((entry) => Array.from(entry.interfaceId).join(",")),
+    );
+    return {
+      type: "snapshot",
+      revision: BigInt(
+        this.registered.length + this.removed.length + this.ingested.length,
+      ),
+      ingestedPackets: this.ingested.length,
+      ingestedCommands: 0,
+      routes: 0,
+      scheduledAnnounces: 0,
+      interfaces: this.registered
+        .map((options, index) => ({
+          id: interfaceId(new Uint8Array([0, 0, 0, 0, 0, 0, 0, index + 1])),
+          kind: options.kind,
+          bitrateBps: options.bitrateBps,
+          hardwareMtu: options.hardwareMtu,
+          routes: 0,
+          links: 0,
+          transportedLinks: 0,
+        }))
+        .filter(({ id }) => !removed.has(Array.from(id).join(","))),
+    };
   }
 }
 

--- a/prns-wasm/smoke/casework-smoke.ts
+++ b/prns-wasm/smoke/casework-smoke.ts
@@ -75,7 +75,7 @@ const { MakeTag } = from<Creation>();
 const missing = MakeTag("Missing");
 assert(missing.tag === "Missing", "from constructs data-less union members");
 
-const into = match_into<number>().from<Creation>(ready, {
+const into = match_into<number>().from(ready as Creation, {
   Ready: ({ value }) => value,
   Missing: () => 0,
 });

--- a/prns-wasm/smoke/event-smoke.ts
+++ b/prns-wasm/smoke/event-smoke.ts
@@ -125,6 +125,7 @@ class MockRuntime extends MockRuntimeBase {
   snapshot(): unknown {
     return {
       type: "snapshot",
+      revision: 0n,
       ingestedPackets: 0,
       ingestedCommands: 0,
       routes: 0,

--- a/prns-wasm/smoke/mock_runtime.ts
+++ b/prns-wasm/smoke/mock_runtime.ts
@@ -324,6 +324,20 @@ export class MockRuntimeBase implements PrnsRuntimeBinding {
     return unexpectedRuntimeCall("sendResourceSegment");
   }
 
+  configureBrowserWork(
+    _execution: Parameters<PrnsRuntimeBinding["configureBrowserWork"]>[0],
+  ): ReturnType<PrnsRuntimeBinding["configureBrowserWork"]> {}
+
+  takeBrowserWork(): ReturnType<PrnsRuntimeBinding["takeBrowserWork"]> {
+    return undefined;
+  }
+
+  completeBrowserWork(
+    _options: Parameters<PrnsRuntimeBinding["completeBrowserWork"]>[0],
+  ): ReturnType<PrnsRuntimeBinding["completeBrowserWork"]> {
+    return unexpectedRuntimeCall("completeBrowserWork");
+  }
+
   setLinkResourceStrategy(
     _options: Parameters<
       PrnsRuntimeBinding["setLinkResourceStrategy"]
@@ -396,6 +410,12 @@ export class MockRuntimeBase implements PrnsRuntimeBinding {
 
   snapshot(): ReturnType<PrnsRuntimeBinding["snapshot"]> {
     return unexpectedRuntimeCall("snapshot");
+  }
+
+  projectionSnapshot(
+    _request: Parameters<PrnsRuntimeBinding["projectionSnapshot"]>[0],
+  ): ReturnType<PrnsRuntimeBinding["projectionSnapshot"]> {
+    return unexpectedRuntimeCall("projectionSnapshot");
   }
 }
 

--- a/prns-wasm/smoke/smoke.ts
+++ b/prns-wasm/smoke/smoke.ts
@@ -371,7 +371,7 @@ function describeInterface(snapshot: InterfaceSnapshot): string {
 }
 
 function describeEvent(event: PrnsEvent): string {
-  return match_into<string>().from<PrnsEvent>(event, {
+  return match_into<string>().from(event, {
     AnnounceHeard: ({ destination, hops, sourceInterface }) =>
       `announce destination=${hex(destination)} hops=${hops} interface=${hex(sourceInterface)}`,
     SingleDelivery: ({ destination, plaintext, sourceInterface }) =>

--- a/prns-wasm/smoke/websocket-smoke.ts
+++ b/prns-wasm/smoke/websocket-smoke.ts
@@ -55,11 +55,14 @@ class MockRuntime extends MockRuntimeBase {
   readonly removed: RuntimeRemoveInterfaceInput[] = [];
   readonly ingests: RuntimeIngestOptions[] = [];
   readonly destinations: RuntimeRegisterSingleDestinationOptions[] = [];
+  readonly events: unknown[] = [];
   outbound: unknown[] = [];
+  outboundDrains = 0;
   routeSnapshots: unknown[] = [];
   destinationIdentities: unknown[] = [];
   registerFailure: Error | undefined;
   #revision = 0;
+  #commandId = 0n;
 
   constructor(identity: IdentitySecretKey) {
     super();
@@ -100,7 +103,15 @@ class MockRuntime extends MockRuntimeBase {
   }
 
   announce(_options: RuntimeAnnounceOptions): bigint {
-    return 1n;
+    const id = ++this.#commandId;
+    this.events.push({
+      type: "commandSettled",
+      id,
+      result: "succeeded",
+      kind: "Announced",
+    });
+    this.#revision += 1;
+    return id;
   }
 
   sendSinglePacket(
@@ -121,10 +132,11 @@ class MockRuntime extends MockRuntimeBase {
   }
 
   drainEvents(): unknown[] {
-    return [];
+    return this.events.splice(0);
   }
 
   drainOutbound(): unknown[] {
+    this.outboundDrains += 1;
     const outbound = this.outbound;
     this.outbound = [];
     return outbound;
@@ -350,6 +362,17 @@ async function main(): Promise<void> {
       target: { type: "interface", interfaceId: session.interfaceId },
       bytes: packetFrame(new Uint8Array([9, 8, 7])),
     });
+    const idleDrains = runtime.outboundDrains;
+    await wait(40);
+    assert(
+      runtime.outboundDrains === idleDrains,
+      "idle runtime output is not polled",
+    );
+    assert(
+      Number(socket.sent.length) === 0,
+      "output waits for a runtime activity boundary",
+    );
+    await advanceRuntime(prns);
     await waitFor(() => socket.sent.length === 1, "outbound frame was sent");
     assertBytes(socket.sent[0], [9, 8, 7], "outbound bytes are exact");
     assert(socket.sentPayloads[0] instanceof Uint8Array, "outbound avoids a buffer copy");
@@ -360,6 +383,7 @@ async function main(): Promise<void> {
       target: { type: "interface", interfaceId: session.interfaceId },
       bytes: packetFrame(new Uint8Array([7, 8, 9])),
     });
+    await advanceRuntime(prns);
     await wait(40);
     assert(socket.sent.length === 1, "buffer pressure pauses outbound frames");
     socket.bufferedAmount = 0;
@@ -396,6 +420,7 @@ async function main(): Promise<void> {
       target: { type: "interface", interfaceId: silentAuto.interfaceId },
       bytes: packetFrame(VALID_PACKET),
     });
+    await advanceRuntime(prns);
     await wait(40);
     assert(
       silentAutoSocket.sent.length === 0,
@@ -422,6 +447,7 @@ async function main(): Promise<void> {
       target: { type: "interface", interfaceId: silentAuto.interfaceId },
       bytes: packetFrame(VALID_PACKET),
     });
+    await advanceRuntime(prns);
     await waitFor(
       () => silentAutoSocket.sent.length === 2,
       "outbound resumes after late KISS evidence",
@@ -449,6 +475,7 @@ async function main(): Promise<void> {
       target: { type: "interface", interfaceId: kissAuto.interfaceId },
       bytes: packetFrame(VALID_PACKET),
     });
+    await advanceRuntime(prns);
     await wait(40);
     assert(
       kissAutoSocket.sent.length === 0,
@@ -548,6 +575,7 @@ async function main(): Promise<void> {
       },
       bytes: packetFrame(new Uint8Array([12, 13])),
     });
+    await advanceRuntime(prns);
     await waitFor(
       () => fanoutSocketA.sent.length === 1 && fanoutSocketB.sent.length === 1,
       "broadcast reaches every WebSocket session",
@@ -560,6 +588,7 @@ async function main(): Promise<void> {
       target: { type: "interface", interfaceId: fanoutB.interfaceId },
       bytes: packetFrame(new Uint8Array([14])),
     });
+    await advanceRuntime(prns);
     await wait(40);
     for (let index = 0; index < 65; index += 1) {
       runtime.outbound.push({
@@ -572,6 +601,7 @@ async function main(): Promise<void> {
         bytes: packetFrame(new Uint8Array([index])),
       });
     }
+    await advanceRuntime(prns);
     await waitFor(() => fanoutSocketA.sent.length === 66, "fast fanout keeps draining");
     fanoutSocketB.bufferedAmount = 0;
     await waitFor(
@@ -644,6 +674,7 @@ async function main(): Promise<void> {
       },
       bytes: packetFrame(new Uint8Array([23])),
     });
+    await advanceRuntime(prns);
     await wait(40);
     assert(
       stableRendezvousSocket.sent.length === 1,
@@ -895,6 +926,16 @@ function fixedIdentityStore(): IdentityStore {
 
 function fixedEntropy(length: number) {
   return Tag("Filled", entropyBytes(new Uint8Array(length).fill(42)));
+}
+
+async function advanceRuntime(prns: Prns): Promise<void> {
+  // The event-driven runtime sleeps until a command or ingress advances it.
+  // Queuing fixture output alone must not wake or poll its outbound consumers.
+  const outcome = await prns.announce(destinationHash(new Uint8Array(16).fill(1)));
+  assert(
+    outcome.tag === "Succeeded" && outcome.data.tag === "Announced",
+    "the public command advances and settles the mock runtime",
+  );
 }
 
 function sendBytes(data: string | ArrayBufferLike | Blob | ArrayBufferView): Uint8Array {

--- a/prns-wasm/src/event_projection.rs
+++ b/prns-wasm/src/event_projection.rs
@@ -116,6 +116,12 @@ pub(crate) fn capture_journaled(journaled: Journaled<'_>) -> CapturedJournal {
                 format!("{attempt_id:?}"),
             )
         }
+        Journaled::RemoteControlControllerPairingAuthorizationPersistenceFailed { attempt_id } => {
+            remote_control_diagnostic(
+                "RemoteControlControllerPairingAuthorizationPersistenceFailed",
+                format!("{attempt_id:?}"),
+            )
+        }
         Journaled::RemoteControlControllerPairingExpired { aborted } => remote_control_diagnostic(
             "RemoteControlControllerPairingExpired",
             format!("{aborted:?}"),


### PR DESCRIPTION
Expose controller-side pairing persistence failure as a runtime event, including the attempt ID, through the Tokio, Embassy, native Host, and WASM event paths. Successful saves and fatal persistence errors retain their existing behavior; the wire format is unchanged. Exhaustive Rust event matches need the new variant.

The Prns app acts as the controller. Its pairing screen needs this terminal signal to stop waiting when its local grant could not be saved.

Depends on #206 for browser smoke fixtures, not protocol behavior. The diff against trunk is cumulative until that PR lands; #211 is independent. [Review only this event change](https://github.com/evelant/Prns/compare/57a079ab29164ad3ae5ec65e5cf6047912cdab0e...prns-app-pairing-persistence-event).

Rebased onto trunk `c4fd54dfd` through #206. Focused checks pass: 34 core controller-pairing tests, three runtime event projection tests, and four Embassy controller-pairing tests. The normal local publishing gate passes, including all 14 firmware profiles. The separate casework smoke limitation is disclosed in #206; physical-device qualification is separate.
