### PR TITLE
Report pairing expiry while the target saves authorization

### DIFF
--- a/prns-core/src/engine/command_execution.rs
+++ b/prns-core/src/engine/command_execution.rs
@@ -699,15 +699,26 @@ impl<S: StorageLayout> EngineState<S> {
                     fill_random,
                     sink,
                 );
-                if let Ok(RemoteControlTargetPairingFinalization::CompletionDispatched {
-                    attempt_id,
-                }) = &result
-                {
-                    sink(EngineReaction::Journaled(
+                match &result {
+                    Ok(RemoteControlTargetPairingFinalization::CompletionDispatched {
+                        attempt_id,
+                    }) => sink(EngineReaction::Journaled(
                         Journaled::RemoteControlTargetPairingAuthorizationPersisted {
                             attempt_id: *attempt_id,
                         },
-                    ));
+                    )),
+                    Ok(RemoteControlTargetPairingFinalization::AuthorizationRollbackRequired {
+                        attempt_id,
+                        ..
+                    }) => sink(EngineReaction::Journaled(
+                        Journaled::RemoteControlTargetPairingExpiredDuringAuthorization {
+                            attempt_id: *attempt_id,
+                        },
+                    )),
+                    Ok(RemoteControlTargetPairingFinalization::AuthorizationFailureRecorded {
+                        ..
+                    })
+                    | Err(_) => {}
                 }
                 settle(
                     sink,

--- a/prns-core/src/engine/reaction.rs
+++ b/prns-core/src/engine/reaction.rs
@@ -453,6 +453,12 @@ pub enum Journaled<'a> {
         attempt_id: crate::remote_control::RemoteControlPairingAttemptId,
     },
 
+    /// The target pairing attempt crossed its deadline after its authorization was durably stored,
+    /// so that authorization must be rolled back instead of completing the pairing exchange.
+    RemoteControlTargetPairingExpiredDuringAuthorization {
+        attempt_id: crate::remote_control::RemoteControlPairingAttemptId,
+    },
+
     RemoteControlControllerPairingConfirmationRequired(
         crate::remote_control::RemoteControlControllerPairingAttemptView<'a>,
     ),

--- a/prns-core/src/engine/remote_control_pairing.rs
+++ b/prns-core/src/engine/remote_control_pairing.rs
@@ -2844,6 +2844,7 @@ mod tests {
         let mut directives = 0usize;
         let mut settlement = None;
         let mut closed = None;
+        let mut expired_during_authorization = None;
         engine.ingest_command_into(
             IssuedCommand {
                 id: CommandId(0xB3),
@@ -2866,6 +2867,9 @@ mod tests {
                 EngineReaction::Journaled(Journaled::LinkClosed { link_id, reason }) => {
                     closed = Some((link_id, reason));
                 }
+                EngineReaction::Journaled(
+                    Journaled::RemoteControlTargetPairingExpiredDuringAuthorization { attempt_id },
+                ) => expired_during_authorization = Some(attempt_id),
                 EngineReaction::Journaled(_) => {}
             },
         );
@@ -2886,6 +2890,7 @@ mod tests {
             closed,
             Some((link_id, crate::engine::LinkClosedReason::LocallyClosed)),
         );
+        assert_eq!(expired_during_authorization, Some(attempt_id));
         assert!(engine.links.phase_for(&link_id).is_none());
         assert_eq!(
             engine.remote_control_target_pairing.view(),

--- a/prns-host/impls/native/src/lib.rs
+++ b/prns-host/impls/native/src/lib.rs
@@ -2879,6 +2879,14 @@ fn publish_message(sink: &dyn NativeEventSink, message: Message<'_>) -> bool {
             );
             return true;
         }
+        Message::RemoteControlTargetPairingExpiredDuringAuthorization { attempt_id } => {
+            publish_remote_control_diagnostic(
+                sink,
+                "RemoteControlTargetPairingExpiredDuringAuthorization",
+                format!("{attempt_id:?}"),
+            );
+            return true;
+        }
         Message::RemoteControlControllerPairingConfirmationRequired(attempt) => {
             publish_remote_control_diagnostic(
                 sink,

--- a/prns-runtime/core/src/runtime/event.rs
+++ b/prns-runtime/core/src/runtime/event.rs
@@ -51,6 +51,11 @@ pub enum Message<'a> {
     RemoteControlTargetPairingAuthorizationPersisted {
         attempt_id: RemoteControlPairingAttemptId,
     },
+    /// The target pairing attempt crossed its deadline after its authorization was persisted, so
+    /// that authorization is being rolled back instead of completing the pairing exchange.
+    RemoteControlTargetPairingExpiredDuringAuthorization {
+        attempt_id: RemoteControlPairingAttemptId,
+    },
     RemoteControlControllerPairingConfirmationRequired(RemoteControlControllerPairingConfirmation),
     RemoteControlControllerPairingPersistenceRequired(
         RemoteControlControllerPairingPersistenceView<'a>,
@@ -233,6 +238,11 @@ impl<'a> From<Journaled<'a>> for PrnsEvent<'a> {
                 PrnsEvent::Message(Message::RemoteControlTargetPairingAuthorizationPersisted {
                     attempt_id,
                 })
+            }
+            Journaled::RemoteControlTargetPairingExpiredDuringAuthorization { attempt_id } => {
+                PrnsEvent::Message(
+                    Message::RemoteControlTargetPairingExpiredDuringAuthorization { attempt_id },
+                )
             }
             Journaled::RemoteControlControllerPairingConfirmationRequired(pairing) => {
                 PrnsEvent::Message(Message::RemoteControlControllerPairingConfirmationRequired(
@@ -434,12 +444,53 @@ impl<'a> From<Journaled<'a>> for PrnsEvent<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::identity::in_memory::InMemoryNodeIdentity;
+    use crate::identity::vault::IdentitySecretKey;
+    use crate::identity::{IdentityPublicKeys, IdentitySigner};
     use crate::remote_control::{
-        RemoteControlControllerPairingAborted, RemoteControlPairingContext,
-        RemoteControlPairingIdentity,
+        RemoteControlControllerIdentity, RemoteControlControllerPairingAborted,
+        RemoteControlPairingAttemptTimeout, RemoteControlPairingBegin, RemoteControlPairingContext,
+        RemoteControlPairingIdentity, RemoteControlPairingInvitationCode,
+        RemoteControlPairingPermissions, RemoteControlPairingPreparedOffer,
+        RemoteControlRequestKind, RemoteControlRequestSet,
     };
     use crate::routing::announce::{AnnounceObservation, AnnounceRateAccounting};
-    use crate::units::HopCount;
+    use crate::units::{DurationMillis, HopCount};
+
+    fn pairing_attempt_id() -> RemoteControlPairingAttemptId {
+        let target_signer = InMemoryNodeIdentity::from_secret_key_bytes(&IdentitySecretKey::new(
+            [0x52; crate::identity::IDENTITY_SECRET_KEY_LEN],
+        ));
+        let controller_signer = InMemoryNodeIdentity::from_secret_key_bytes(
+            &IdentitySecretKey::new([0x31; crate::identity::IDENTITY_SECRET_KEY_LEN]),
+        );
+        let controller = RemoteControlControllerIdentity::new(IdentityPublicKeys {
+            encryption: controller_signer.encryption_public_key(),
+            signing: controller_signer.signing_public_key(),
+        });
+        let context = RemoteControlPairingContext::new(
+            RemoteControlPairingIdentity::new(IdentityHash::new([0x81; 16])).endpoint(),
+            LinkId::new([0x82; 16]),
+        );
+        let begin = RemoteControlPairingBegin::new(
+            controller,
+            context.endpoint(),
+            RemoteControlPairingInvitationCode::from_value(0x1234_ABCD),
+        );
+        let permissions = RemoteControlPairingPermissions::try_from(RemoteControlRequestSet::only(
+            RemoteControlRequestKind::Describe,
+        ))
+        .unwrap();
+        let timeout = RemoteControlPairingAttemptTimeout::try_from(DurationMillis(30_000)).unwrap();
+        let prepared = RemoteControlPairingPreparedOffer::new(
+            &target_signer,
+            context,
+            &begin,
+            permissions,
+            timeout,
+        );
+        prepared.transcript().into()
+    }
 
     #[test]
     fn announce_event_preserves_application_data() {
@@ -492,6 +543,22 @@ mod tests {
                     context: observed,
                 },
             }) if observed == context
+        ));
+    }
+
+    #[test]
+    fn target_pairing_expiry_during_authorization_is_an_app_facing_message() {
+        let attempt_id = pairing_attempt_id();
+
+        let event = PrnsEvent::from(
+            Journaled::RemoteControlTargetPairingExpiredDuringAuthorization { attempt_id },
+        );
+
+        assert!(matches!(
+            event,
+            PrnsEvent::Message(Message::RemoteControlTargetPairingExpiredDuringAuthorization {
+                attempt_id: observed,
+            }) if observed == attempt_id
         ));
     }
 }

--- a/prns-runtime/core/src/runtime/observability.rs
+++ b/prns-runtime/core/src/runtime/observability.rs
@@ -292,6 +292,7 @@ impl ReliabilityMetricsSnapshot {
             | Journaled::RemoteControlTargetPairingControllerCommitted { .. }
             | Journaled::RemoteControlTargetPairingAuthorizationRequired { .. }
             | Journaled::RemoteControlTargetPairingAuthorizationPersisted { .. }
+            | Journaled::RemoteControlTargetPairingExpiredDuringAuthorization { .. }
             | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
             | Journaled::RemoteControlControllerPairingPersistenceRequired(_)
             | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }

--- a/prns-runtime/impls/embassy/src/manifold/driver/fixed_topology/tests.rs
+++ b/prns-runtime/impls/embassy/src/manifold/driver/fixed_topology/tests.rs
@@ -144,6 +144,7 @@ fn an_ifac_frame_crosses_the_seam_and_leaves_masked_through_the_peer() {
         | Journaled::RemoteControlTargetPairingControllerCommitted { .. }
         | Journaled::RemoteControlTargetPairingAuthorizationRequired { .. }
         | Journaled::RemoteControlTargetPairingAuthorizationPersisted { .. }
+        | Journaled::RemoteControlTargetPairingExpiredDuringAuthorization { .. }
         | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
         | Journaled::RemoteControlControllerPairingPersistenceRequired(_)
         | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }

--- a/prns-runtime/impls/embassy/src/manifold/driver/pooled_topology/tests.rs
+++ b/prns-runtime/impls/embassy/src/manifold/driver/pooled_topology/tests.rs
@@ -186,6 +186,7 @@ fn a_pooled_ifac_slot_added_at_runtime_opens_inbound_then_frees_on_remove() {
         | Journaled::RemoteControlTargetPairingControllerCommitted { .. }
         | Journaled::RemoteControlTargetPairingAuthorizationRequired { .. }
         | Journaled::RemoteControlTargetPairingAuthorizationPersisted { .. }
+        | Journaled::RemoteControlTargetPairingExpiredDuringAuthorization { .. }
         | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
         | Journaled::RemoteControlControllerPairingPersistenceRequired(_)
         | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }
@@ -328,6 +329,7 @@ fn a_pooled_slot_retagged_at_runtime_carries_traffic_under_the_new_id() {
         | Journaled::RemoteControlTargetPairingControllerCommitted { .. }
         | Journaled::RemoteControlTargetPairingAuthorizationRequired { .. }
         | Journaled::RemoteControlTargetPairingAuthorizationPersisted { .. }
+        | Journaled::RemoteControlTargetPairingExpiredDuringAuthorization { .. }
         | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
         | Journaled::RemoteControlControllerPairingPersistenceRequired(_)
         | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }

--- a/prns-runtime/impls/embassy/src/runtime/embedded_persistence.rs
+++ b/prns-runtime/impls/embassy/src/runtime/embedded_persistence.rs
@@ -497,6 +497,7 @@ where
             | Journaled::RemoteControlTargetPairingControllerCommitted { .. }
             | Journaled::RemoteControlTargetPairingAuthorizationRequired { .. }
             | Journaled::RemoteControlTargetPairingAuthorizationPersisted { .. }
+            | Journaled::RemoteControlTargetPairingExpiredDuringAuthorization { .. }
             | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
             | Journaled::RemoteControlControllerPairingPersistenceRequired(_)
             | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }

--- a/prns-runtime/impls/embassy/src/runtime/remote_control_pairing_persistence.rs
+++ b/prns-runtime/impls/embassy/src/runtime/remote_control_pairing_persistence.rs
@@ -229,6 +229,7 @@ impl RemoteControlPairingPersistenceRequired {
             | Journaled::RemoteControlTargetPairingConfirmationRequired(_)
             | Journaled::RemoteControlTargetPairingControllerCommitted { .. }
             | Journaled::RemoteControlTargetPairingAuthorizationPersisted { .. }
+            | Journaled::RemoteControlTargetPairingExpiredDuringAuthorization { .. }
             | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
             | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }
             | Journaled::RemoteControlControllerPairingExpired { .. }

--- a/prns-runtime/impls/tokio/src/manifold/driver/tests/announces.rs
+++ b/prns-runtime/impls/tokio/src/manifold/driver/tests/announces.rs
@@ -66,6 +66,7 @@ async fn a_commanded_announce_fans_to_every_interface_and_settles() {
         | Journaled::RemoteControlTargetPairingControllerCommitted { .. }
         | Journaled::RemoteControlTargetPairingAuthorizationRequired { .. }
         | Journaled::RemoteControlTargetPairingAuthorizationPersisted { .. }
+        | Journaled::RemoteControlTargetPairingExpiredDuringAuthorization { .. }
         | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
         | Journaled::RemoteControlControllerPairingPersistenceRequired(_)
         | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }

--- a/prns-runtime/impls/tokio/src/manifold/driver/tests/routes.rs
+++ b/prns-runtime/impls/tokio/src/manifold/driver/tests/routes.rs
@@ -47,6 +47,7 @@ async fn routing_control_drops_a_live_route_and_journals_the_explicit_removal() 
         | Journaled::RemoteControlTargetPairingControllerCommitted { .. }
         | Journaled::RemoteControlTargetPairingAuthorizationRequired { .. }
         | Journaled::RemoteControlTargetPairingAuthorizationPersisted { .. }
+        | Journaled::RemoteControlTargetPairingExpiredDuringAuthorization { .. }
         | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
         | Journaled::RemoteControlControllerPairingPersistenceRequired(_)
         | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }
@@ -189,6 +190,7 @@ async fn the_manifold_culls_an_expired_route_at_its_deadline() {
         | Journaled::RemoteControlTargetPairingControllerCommitted { .. }
         | Journaled::RemoteControlTargetPairingAuthorizationRequired { .. }
         | Journaled::RemoteControlTargetPairingAuthorizationPersisted { .. }
+        | Journaled::RemoteControlTargetPairingExpiredDuringAuthorization { .. }
         | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
         | Journaled::RemoteControlControllerPairingPersistenceRequired(_)
         | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }

--- a/prns-runtime/impls/tokio/src/manifold/driver/tests/transport.rs
+++ b/prns-runtime/impls/tokio/src/manifold/driver/tests/transport.rs
@@ -68,6 +68,7 @@ async fn a_loopback_frame_crosses_the_seam_and_the_rebroadcast_leaves_through_th
         | Journaled::RemoteControlTargetPairingControllerCommitted { .. }
         | Journaled::RemoteControlTargetPairingAuthorizationRequired { .. }
         | Journaled::RemoteControlTargetPairingAuthorizationPersisted { .. }
+        | Journaled::RemoteControlTargetPairingExpiredDuringAuthorization { .. }
         | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
         | Journaled::RemoteControlControllerPairingPersistenceRequired(_)
         | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }
@@ -434,6 +435,7 @@ async fn a_delivery_answers_with_a_proof_directive_on_the_arrival_lane() {
         | Journaled::RemoteControlTargetPairingControllerCommitted { .. }
         | Journaled::RemoteControlTargetPairingAuthorizationRequired { .. }
         | Journaled::RemoteControlTargetPairingAuthorizationPersisted { .. }
+        | Journaled::RemoteControlTargetPairingExpiredDuringAuthorization { .. }
         | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
         | Journaled::RemoteControlControllerPairingPersistenceRequired(_)
         | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }

--- a/prns-runtime/impls/tokio/src/runtime/remote_control_pairing_persistence.rs
+++ b/prns-runtime/impls/tokio/src/runtime/remote_control_pairing_persistence.rs
@@ -144,6 +144,7 @@ impl RemoteControlPairingPersistenceSender {
             | Journaled::RemoteControlTargetPairingConfirmationRequired(_)
             | Journaled::RemoteControlTargetPairingControllerCommitted { .. }
             | Journaled::RemoteControlTargetPairingAuthorizationPersisted { .. }
+            | Journaled::RemoteControlTargetPairingExpiredDuringAuthorization { .. }
             | Journaled::RemoteControlControllerPairingConfirmationRequired(_)
             | Journaled::RemoteControlControllerPairingAuthorizationPersisted { .. }
             | Journaled::RemoteControlControllerPairingExpired { .. }

--- a/prns-runtime/impls/tokio/src/runtime/tracing_events.rs
+++ b/prns-runtime/impls/tokio/src/runtime/tracing_events.rs
@@ -23,6 +23,7 @@ fn emit_message(message: &Message<'_>) {
         | Message::RemoteControlTargetPairingControllerCommitted { .. }
         | Message::RemoteControlTargetPairingAuthorizationRequired { .. }
         | Message::RemoteControlTargetPairingAuthorizationPersisted { .. }
+        | Message::RemoteControlTargetPairingExpiredDuringAuthorization { .. }
         | Message::RemoteControlControllerPairingConfirmationRequired(_)
         | Message::RemoteControlControllerPairingPersistenceRequired(_)
         | Message::RemoteControlControllerPairingAuthorizationPersisted { .. }

--- a/prns-wasm/examples/browser-playground/outcomes.ts
+++ b/prns-wasm/examples/browser-playground/outcomes.ts
@@ -151,6 +151,7 @@ export function describeInterfaceCloseFailure(
     HostOperationFailed: ({ operation, detail }) => `${operation}: ${detail}`,
     CloseFailed: ({ causes }) =>
       causes.map(describeCleanupFailure).join("; "),
+    RuntimeRejected: ({ operation, detail }) => `${operation}: ${detail}`,
   });
 }
 

--- a/prns-wasm/scripts/stage-event-smoke.mjs
+++ b/prns-wasm/scripts/stage-event-smoke.mjs
@@ -1,11 +1,19 @@
 import { copyFile, mkdir } from "node:fs/promises";
 
+const generatedCasework = new URL(
+  "../../prns-js/dist/casework.js",
+  import.meta.url,
+);
+const smokeCasework = new URL(
+  "../smoke/dist/prns-js/src/casework.js",
+  import.meta.url,
+);
 const sdkDirectory = new URL(
   "../smoke/dist/prns-wasm/examples/browser-playground/sdk/",
   import.meta.url,
 );
 await mkdir(sdkDirectory, { recursive: true });
-await copyFile(
-  new URL("../smoke/dist/prns-js/src/casework.js", import.meta.url),
-  new URL("index.js", sdkDirectory),
-);
+await Promise.all([
+  copyFile(generatedCasework, smokeCasework),
+  copyFile(generatedCasework, new URL("index.js", sdkDirectory)),
+]);

--- a/prns-wasm/smoke/auto-wifi-smoke.ts
+++ b/prns-wasm/smoke/auto-wifi-smoke.ts
@@ -112,7 +112,30 @@ class MockRuntime extends MockRuntimeBase {
   }
 
   snapshot(): unknown {
-    return { type: "snapshot" };
+    const removed = new Set(
+      this.removed.map((entry) => Array.from(entry.interfaceId).join(",")),
+    );
+    return {
+      type: "snapshot",
+      revision: BigInt(
+        this.registered.length + this.removed.length + this.ingested.length,
+      ),
+      ingestedPackets: this.ingested.length,
+      ingestedCommands: 0,
+      routes: 0,
+      scheduledAnnounces: 0,
+      interfaces: this.registered
+        .map((options, index) => ({
+          id: interfaceId(new Uint8Array([0, 0, 0, 0, 0, 0, 0, index + 1])),
+          kind: options.kind,
+          bitrateBps: options.bitrateBps,
+          hardwareMtu: options.hardwareMtu,
+          routes: 0,
+          links: 0,
+          transportedLinks: 0,
+        }))
+        .filter(({ id }) => !removed.has(Array.from(id).join(","))),
+    };
   }
 }
 

--- a/prns-wasm/smoke/casework-smoke.ts
+++ b/prns-wasm/smoke/casework-smoke.ts
@@ -75,7 +75,7 @@ const { MakeTag } = from<Creation>();
 const missing = MakeTag("Missing");
 assert(missing.tag === "Missing", "from constructs data-less union members");
 
-const into = match_into<number>().from<Creation>(ready, {
+const into = match_into<number>().from(ready as Creation, {
   Ready: ({ value }) => value,
   Missing: () => 0,
 });

--- a/prns-wasm/smoke/event-smoke.ts
+++ b/prns-wasm/smoke/event-smoke.ts
@@ -125,6 +125,7 @@ class MockRuntime extends MockRuntimeBase {
   snapshot(): unknown {
     return {
       type: "snapshot",
+      revision: 0n,
       ingestedPackets: 0,
       ingestedCommands: 0,
       routes: 0,

--- a/prns-wasm/smoke/mock_runtime.ts
+++ b/prns-wasm/smoke/mock_runtime.ts
@@ -324,6 +324,20 @@ export class MockRuntimeBase implements PrnsRuntimeBinding {
     return unexpectedRuntimeCall("sendResourceSegment");
   }
 
+  configureBrowserWork(
+    _execution: Parameters<PrnsRuntimeBinding["configureBrowserWork"]>[0],
+  ): ReturnType<PrnsRuntimeBinding["configureBrowserWork"]> {}
+
+  takeBrowserWork(): ReturnType<PrnsRuntimeBinding["takeBrowserWork"]> {
+    return undefined;
+  }
+
+  completeBrowserWork(
+    _options: Parameters<PrnsRuntimeBinding["completeBrowserWork"]>[0],
+  ): ReturnType<PrnsRuntimeBinding["completeBrowserWork"]> {
+    return unexpectedRuntimeCall("completeBrowserWork");
+  }
+
   setLinkResourceStrategy(
     _options: Parameters<
       PrnsRuntimeBinding["setLinkResourceStrategy"]
@@ -396,6 +410,12 @@ export class MockRuntimeBase implements PrnsRuntimeBinding {
 
   snapshot(): ReturnType<PrnsRuntimeBinding["snapshot"]> {
     return unexpectedRuntimeCall("snapshot");
+  }
+
+  projectionSnapshot(
+    _request: Parameters<PrnsRuntimeBinding["projectionSnapshot"]>[0],
+  ): ReturnType<PrnsRuntimeBinding["projectionSnapshot"]> {
+    return unexpectedRuntimeCall("projectionSnapshot");
   }
 }
 

--- a/prns-wasm/smoke/smoke.ts
+++ b/prns-wasm/smoke/smoke.ts
@@ -371,7 +371,7 @@ function describeInterface(snapshot: InterfaceSnapshot): string {
 }
 
 function describeEvent(event: PrnsEvent): string {
-  return match_into<string>().from<PrnsEvent>(event, {
+  return match_into<string>().from(event, {
     AnnounceHeard: ({ destination, hops, sourceInterface }) =>
       `announce destination=${hex(destination)} hops=${hops} interface=${hex(sourceInterface)}`,
     SingleDelivery: ({ destination, plaintext, sourceInterface }) =>

--- a/prns-wasm/smoke/websocket-smoke.ts
+++ b/prns-wasm/smoke/websocket-smoke.ts
@@ -55,11 +55,14 @@ class MockRuntime extends MockRuntimeBase {
   readonly removed: RuntimeRemoveInterfaceInput[] = [];
   readonly ingests: RuntimeIngestOptions[] = [];
   readonly destinations: RuntimeRegisterSingleDestinationOptions[] = [];
+  readonly events: unknown[] = [];
   outbound: unknown[] = [];
+  outboundDrains = 0;
   routeSnapshots: unknown[] = [];
   destinationIdentities: unknown[] = [];
   registerFailure: Error | undefined;
   #revision = 0;
+  #commandId = 0n;
 
   constructor(identity: IdentitySecretKey) {
     super();
@@ -100,7 +103,15 @@ class MockRuntime extends MockRuntimeBase {
   }
 
   announce(_options: RuntimeAnnounceOptions): bigint {
-    return 1n;
+    const id = ++this.#commandId;
+    this.events.push({
+      type: "commandSettled",
+      id,
+      result: "succeeded",
+      kind: "Announced",
+    });
+    this.#revision += 1;
+    return id;
   }
 
   sendSinglePacket(
@@ -121,10 +132,11 @@ class MockRuntime extends MockRuntimeBase {
   }
 
   drainEvents(): unknown[] {
-    return [];
+    return this.events.splice(0);
   }
 
   drainOutbound(): unknown[] {
+    this.outboundDrains += 1;
     const outbound = this.outbound;
     this.outbound = [];
     return outbound;
@@ -350,6 +362,17 @@ async function main(): Promise<void> {
       target: { type: "interface", interfaceId: session.interfaceId },
       bytes: packetFrame(new Uint8Array([9, 8, 7])),
     });
+    const idleDrains = runtime.outboundDrains;
+    await wait(40);
+    assert(
+      runtime.outboundDrains === idleDrains,
+      "idle runtime output is not polled",
+    );
+    assert(
+      Number(socket.sent.length) === 0,
+      "output waits for a runtime activity boundary",
+    );
+    await advanceRuntime(prns);
     await waitFor(() => socket.sent.length === 1, "outbound frame was sent");
     assertBytes(socket.sent[0], [9, 8, 7], "outbound bytes are exact");
     assert(socket.sentPayloads[0] instanceof Uint8Array, "outbound avoids a buffer copy");
@@ -360,6 +383,7 @@ async function main(): Promise<void> {
       target: { type: "interface", interfaceId: session.interfaceId },
       bytes: packetFrame(new Uint8Array([7, 8, 9])),
     });
+    await advanceRuntime(prns);
     await wait(40);
     assert(socket.sent.length === 1, "buffer pressure pauses outbound frames");
     socket.bufferedAmount = 0;
@@ -396,6 +420,7 @@ async function main(): Promise<void> {
       target: { type: "interface", interfaceId: silentAuto.interfaceId },
       bytes: packetFrame(VALID_PACKET),
     });
+    await advanceRuntime(prns);
     await wait(40);
     assert(
       silentAutoSocket.sent.length === 0,
@@ -422,6 +447,7 @@ async function main(): Promise<void> {
       target: { type: "interface", interfaceId: silentAuto.interfaceId },
       bytes: packetFrame(VALID_PACKET),
     });
+    await advanceRuntime(prns);
     await waitFor(
       () => silentAutoSocket.sent.length === 2,
       "outbound resumes after late KISS evidence",
@@ -449,6 +475,7 @@ async function main(): Promise<void> {
       target: { type: "interface", interfaceId: kissAuto.interfaceId },
       bytes: packetFrame(VALID_PACKET),
     });
+    await advanceRuntime(prns);
     await wait(40);
     assert(
       kissAutoSocket.sent.length === 0,
@@ -548,6 +575,7 @@ async function main(): Promise<void> {
       },
       bytes: packetFrame(new Uint8Array([12, 13])),
     });
+    await advanceRuntime(prns);
     await waitFor(
       () => fanoutSocketA.sent.length === 1 && fanoutSocketB.sent.length === 1,
       "broadcast reaches every WebSocket session",
@@ -560,6 +588,7 @@ async function main(): Promise<void> {
       target: { type: "interface", interfaceId: fanoutB.interfaceId },
       bytes: packetFrame(new Uint8Array([14])),
     });
+    await advanceRuntime(prns);
     await wait(40);
     for (let index = 0; index < 65; index += 1) {
       runtime.outbound.push({
@@ -572,6 +601,7 @@ async function main(): Promise<void> {
         bytes: packetFrame(new Uint8Array([index])),
       });
     }
+    await advanceRuntime(prns);
     await waitFor(() => fanoutSocketA.sent.length === 66, "fast fanout keeps draining");
     fanoutSocketB.bufferedAmount = 0;
     await waitFor(
@@ -644,6 +674,7 @@ async function main(): Promise<void> {
       },
       bytes: packetFrame(new Uint8Array([23])),
     });
+    await advanceRuntime(prns);
     await wait(40);
     assert(
       stableRendezvousSocket.sent.length === 1,
@@ -895,6 +926,16 @@ function fixedIdentityStore(): IdentityStore {
 
 function fixedEntropy(length: number) {
   return Tag("Filled", entropyBytes(new Uint8Array(length).fill(42)));
+}
+
+async function advanceRuntime(prns: Prns): Promise<void> {
+  // The event-driven runtime sleeps until a command or ingress advances it.
+  // Queuing fixture output alone must not wake or poll its outbound consumers.
+  const outcome = await prns.announce(destinationHash(new Uint8Array(16).fill(1)));
+  assert(
+    outcome.tag === "Succeeded" && outcome.data.tag === "Announced",
+    "the public command advances and settles the mock runtime",
+  );
 }
 
 function sendBytes(data: string | ArrayBufferLike | Blob | ArrayBufferView): Uint8Array {

--- a/prns-wasm/src/event_projection.rs
+++ b/prns-wasm/src/event_projection.rs
@@ -98,6 +98,12 @@ pub(crate) fn capture_journaled(journaled: Journaled<'_>) -> CapturedJournal {
                 format!("{attempt_id:?}"),
             )
         }
+        Journaled::RemoteControlTargetPairingExpiredDuringAuthorization { attempt_id } => {
+            remote_control_diagnostic(
+                "RemoteControlTargetPairingExpiredDuringAuthorization",
+                format!("{attempt_id:?}"),
+            )
+        }
         Journaled::RemoteControlControllerPairingConfirmationRequired(attempt) => {
             remote_control_diagnostic(
                 "RemoteControlControllerPairingConfirmationRequired",


### PR DESCRIPTION
Expose a runtime event when target authorization finishes after the pairing deadline and must be rolled back. Include the attempt ID and project it through the native Host and WASM event paths. The event reports the expired attempt, not rollback completion; existing rollback behavior and the wire format are unchanged. Exhaustive Rust event matches need the new variant.

The Prns app and the board's pairing screen need to leave the saving state when this happens, rather than waiting indefinitely for success.

Depends on #206 for browser smoke fixtures, not protocol behavior. The diff against trunk is cumulative until that PR lands; #210 is independent. [Review only this event change](https://github.com/evelant/Prns/compare/57a079ab29164ad3ae5ec65e5cf6047912cdab0e...prns-app-target-pairing-expiry-event).

Rebased onto trunk `c4fd54dfd` through #206. Focused checks pass: 22 core target-pairing tests and three runtime event projection tests. The normal local publishing gate passes, including all 14 firmware profiles. The separate casework smoke limitation is disclosed in #206; physical-device qualification is separate.
