### PR TITLE
Preserve split-resource identity after a segment completes

### DIFF
--- a/prns-core/src/routing/links/resources/send.rs
+++ b/prns-core/src/routing/links/resources/send.rs
@@ -670,6 +670,12 @@ impl<S: StorageLayout> EngineState<S> {
         let state = *self.outgoing_resources.state(index);
         if state.segment_index == 1 && state.total_segments > 1 {
             self.outgoing_assemblies.begin(reservation.link_id, hash);
+        } else if state.segment_index > 1 {
+            // The predecessor may have proved before this build was reserved, so a live
+            // continuation needs the same chain identity as a promoted staged build.
+            if let Some(original) = self.outgoing_assemblies.original_hash(&reservation.link_id) {
+                self.outgoing_resources.state_mut(index).original_hash = original;
+            }
         }
         let ActiveLinkLookup::Active(link) = self.links.active_view(&reservation.link_id) else {
             self.outgoing_resources.remove(&reservation.link_id, &hash);
@@ -2901,6 +2907,127 @@ mod tests {
                 OutgoingResourceStatus::StagedSealed,
             ],
         );
+    }
+
+    #[test]
+    fn owning_split_continuation_after_predecessor_proof_keeps_the_original_hash() {
+        let mut engine = heap_sender_with_active_link();
+        let mut original_hash = None;
+        let segments = [
+            b"first split segment".as_slice(),
+            b"second split segment".as_slice(),
+        ];
+        let total_data_bytes = segments.iter().map(|data| data.len() as u64).sum();
+        for (ordinal, data) in segments.into_iter().enumerate() {
+            let segment_index = ordinal as u64 + 1;
+            let command_id = CommandId(70 + segment_index);
+            let now = 1_500 + ordinal as u64 * 2_000;
+            let resource = ResourceSend {
+                id: command_id,
+                link_id: link_id(),
+                body: ResourceBody {
+                    data,
+                    compressed_candidate: None,
+                    metadata: ResourceMetadata::None,
+                },
+                correlation: ResourceCorrelation::Unsolicited,
+            };
+            let mut emitted = None;
+            engine.request_resource_build(
+                &resource,
+                ResourceSegment {
+                    index: segment_index,
+                    total_segments: 2,
+                    total_data_bytes,
+                },
+                &mut |reaction| {
+                    if let EngineReaction::Directive(Directive::Fulfill(OwedWork::ResourceBuild(
+                        owed,
+                    ))) = reaction
+                    {
+                        emitted = Some(owed);
+                    } else {
+                        panic!("a valid request emits only its typed build directive");
+                    }
+                },
+            );
+            let owed = emitted.expect("each segment delegates its build");
+            let shape = owed.shape();
+            let reservation = owed.reservation();
+            assert_eq!(reservation.lane, TrackLane::Live);
+            let mut transfer = std::vec![0; shape.transfer_bytes()];
+            let mut names = std::vec![0; shape.part_count() * MAP_HASH_LEN];
+            let outcome = owed.execute(
+                &[0xA5; 16],
+                || [0xA5; RESOURCE_NONCE_LEN],
+                BuildRegions {
+                    transfer: &mut transfer,
+                    hashmap: &mut names,
+                },
+            );
+            let mut frames = std::vec::Vec::new();
+            engine.resume_resource_build(
+                ResourceBuildCompleted {
+                    reservation,
+                    transfer: ResourceBuildTransfer::borrowed(&transfer),
+                    names: &names,
+                    request_data: data,
+                    outcome,
+                },
+                InstantMillis(now),
+                &mut |bytes: &mut [u8]| bytes.fill(0xA5),
+                &mut |reaction| {
+                    if let EngineReaction::Directive(Directive::EmitFrame { fill, .. }) = reaction {
+                        frames.push(filled_frame(fill).expect("the advertisement fits"));
+                    }
+                },
+            );
+            assert_eq!(frames.len(), 1);
+            let (_, payload) = WirePacketHeader::parse(&frames[0]).unwrap();
+            let mut sealed = payload.to_vec();
+            let opened = link_key().open_in_place(&mut sealed).unwrap();
+            let advertisement = ResourceAdvertisement::parse(opened).unwrap();
+            let original = *original_hash.get_or_insert(advertisement.hash);
+            assert_eq!(advertisement.segment_index, segment_index);
+            if segment_index > 1 {
+                assert_ne!(advertisement.hash, original);
+            }
+            assert_eq!(
+                advertisement.original_hash, original,
+                "a continuation advertises the first segment hash"
+            );
+
+            feed(
+                &mut engine,
+                &request_frame(&advertisement.hash, None, advertisement.hashmap),
+                now + 100,
+            );
+            let index = engine
+                .outgoing_resources
+                .lookup(&link_id(), &advertisement.hash)
+                .unwrap();
+            let proof = engine.outgoing_resources.state(index).expected_proof;
+            let proved = feed(
+                &mut engine,
+                &proof_frame(&advertisement.hash, &proof),
+                now + 200,
+            );
+            assert!(matches!(
+                proved.settlements.as_slice(),
+                [(id, Settlement::SendResource(Ok(())))] if *id == command_id
+            ));
+            assert!(engine.outgoing_resources.is_empty());
+            if segment_index == 1 {
+                assert_eq!(
+                    engine.outgoing_assemblies.original_hash(&link_id()),
+                    Some(original)
+                );
+            }
+        }
+        assert!(engine
+            .outgoing_assemblies
+            .original_hash(&link_id())
+            .is_none());
     }
 
     #[cfg(feature = "resource-work-offload")]


### PR DESCRIPTION
A split resource can lose its chain identity when one segment completes before
the next segment's offloaded build is reserved. That continuation takes the live
lane instead of the staged lane, but advertises its own hash as the original
resource hash. The receiver cannot match it to the existing assembly, so the
sender can exhaust its advertisement retries. For request responses, that
failure also closes the link.

Copy the existing assembly's original hash when a live continuation build lands,
matching the inline and staged paths. No retry, timeout, queue or wire-format
changes are needed.

This surfaced while preparing the app's upstream branches (#197): the
large-response TCP check also fails on current trunk, independently of USB or
Bluetooth. The app needs reliable large responses and a sound foundation for
future Resource support; this does not add large-message support to the app.

The regression proves segment one before reserving segment two, checks the
continuation's decrypted advertisement, and settles both segments. It fails
before the correction and passes afterward. On Linux arm64, 1,887 core tests,
25 integration tests and 50 consecutive runs of the original split-response
test pass without diagnostics. Three existing profiling tests and one manual
interop server remain ignored. Strict host core Clippy, an embedded-target core
check and the canonical unsafe inventory also pass.

All fourteen configured firmware profiles pass; T-Echo S140 v7 retains 472 bytes
of flash headroom. No memory layout or capacity changes are included.

The initial macOS Bluetooth CI job hits the existing USB test-fixture compilation
error addressed by #199; this change does not touch that code.
