### PR TITLE
Allow pairing attempts near the end of an invitation window

### DIFF
--- a/prns-core/src/remote_control/pairing/target_pairing/kani_proofs.rs
+++ b/prns-core/src/remote_control/pairing/target_pairing/kani_proofs.rs
@@ -33,3 +33,41 @@ fn target_attempt_deadlines_are_strictly_future_and_pairing_bounded() {
     assert!(attempt_window.expires_at() > started_at);
     assert!(attempt_window.expires_at() <= pairing_expires_at);
 }
+
+#[kani::proof]
+fn unexpired_pairing_windows_always_admit_a_bounded_attempt_timeout() {
+    let opened_at = InstantMillis(kani::any());
+    let pairing_expires_at = InstantMillis(kani::any());
+    let started_at = InstantMillis(kani::any());
+    let timeout_millis: u32 = kani::any();
+    kani::assume(opened_at < pairing_expires_at);
+    kani::assume(started_at < pairing_expires_at);
+    kani::assume(timeout_millis > 0);
+    kani::assume(u64::from(timeout_millis) <= MAX_REMOTE_CONTROL_PAIRING_ATTEMPT_TIMEOUT.0);
+
+    let Ok(pairing_window) = RemoteControlPairingWindow::new(opened_at, pairing_expires_at) else {
+        return;
+    };
+    let Ok(configured) =
+        RemoteControlPairingAttemptTimeout::try_from(DurationMillis(u64::from(timeout_millis)))
+    else {
+        return;
+    };
+    let actual =
+        super::state::attempt_timeout_for_remaining_window(configured, started_at, &pairing_window);
+    assert!(actual.duration().0 > 0);
+    assert!(actual.duration() <= configured.duration());
+    assert_eq!(
+        actual.duration().0,
+        configured
+            .duration()
+            .0
+            .min(pairing_expires_at.0 - started_at.0),
+    );
+    let window = RemoteControlTargetPairingAttemptWindow::new(started_at, actual, &pairing_window);
+    assert!(window.is_ok());
+    if let Ok(window) = window {
+        assert!(window.expires_at() > started_at);
+        assert!(window.expires_at() <= pairing_expires_at);
+    }
+}

--- a/prns-core/src/remote_control/pairing/target_pairing/state.rs
+++ b/prns-core/src/remote_control/pairing/target_pairing/state.rs
@@ -1,12 +1,13 @@
 use crate::identity::IdentitySigner;
 use crate::remote_control::RemoteControlControllerGrant;
 use crate::routing::links::LinkId;
-use crate::units::InstantMillis;
+use crate::units::{DurationMillis, InstantMillis};
 
 use super::super::{
-    RemoteControlPairingAttemptId, RemoteControlPairingCompleted, RemoteControlPairingContext,
+    RemoteControlPairingAttemptId, RemoteControlPairingAttemptTimeout,
+    RemoteControlPairingCompleted, RemoteControlPairingContext,
     RemoteControlPairingInvitationProofInvalid, RemoteControlPairingPreparedOffer,
-    RemoteControlPairingSession, RemoteControlPairingTranscript,
+    RemoteControlPairingSession, RemoteControlPairingTranscript, RemoteControlPairingWindow,
 };
 use super::model::*;
 
@@ -141,7 +142,11 @@ impl RemoteControlTargetPairingState {
         if let Some(active) = self.active_attempt_id() {
             return BeginRemoteControlTargetPairingOutcome::Busy { active };
         }
-        let attempt_timeout = session.attempt_timeout();
+        let attempt_timeout = attempt_timeout_for_remaining_window(
+            session.attempt_timeout(),
+            started_at,
+            session.window(),
+        );
         let window = match RemoteControlTargetPairingAttemptWindow::new(
             started_at,
             attempt_timeout,
@@ -813,6 +818,19 @@ impl RemoteControlTargetPairingState {
             }
         }
     }
+}
+
+pub(super) fn attempt_timeout_for_remaining_window(
+    configured: RemoteControlPairingAttemptTimeout,
+    started_at: InstantMillis,
+    pairing_window: &RemoteControlPairingWindow,
+) -> RemoteControlPairingAttemptTimeout {
+    let remaining = pairing_window.expires_at().0.saturating_sub(started_at.0);
+    let bounded = DurationMillis(configured.duration().0.min(remaining));
+    // A still-open invitation may have less than the configured attempt duration left.
+    // For an elapsed window, retain the configured timeout so the strict constructor
+    // returns its existing PairingWindowElapsed error rather than admitting zero time.
+    RemoteControlPairingAttemptTimeout::try_from(bounded).unwrap_or(configured)
 }
 
 fn abort_active(

--- a/prns-core/src/remote_control/pairing/target_pairing/tests.rs
+++ b/prns-core/src/remote_control/pairing/target_pairing/tests.rs
@@ -62,6 +62,19 @@ impl TargetPairingFixture {
         RemoteControlPairingContext::new(self.session.endpoint(), self.link_id)
     }
 
+    fn with_window(opened_at: u64, expires_at: u64, timeout: u64) -> Self {
+        let mut fixture = Self::new();
+        fixture.session = RemoteControlPairingSession::new(
+            RemoteControlPairingIdentity::new(fixture.session.identity().identity_hash()),
+            RemoteControlPairingWindow::new(InstantMillis(opened_at), InstantMillis(expires_at))
+                .unwrap(),
+            permissions(),
+            RemoteControlPairingAttemptTimeout::try_from(DurationMillis(timeout)).unwrap(),
+            invitation_code().verifier(),
+        );
+        fixture
+    }
+
     fn permissions(&self) -> &RemoteControlPairingPermissions {
         self.session.permissions()
     }
@@ -158,12 +171,20 @@ fn prepare_offer(
     state: &mut RemoteControlTargetPairingState,
     fixture: &TargetPairingFixture,
 ) -> (RemoteControlPairingAttemptId, RemoteControlPairingOffer) {
+    prepare_offer_at(state, fixture, ATTEMPT_STARTED_AT)
+}
+
+fn prepare_offer_at(
+    state: &mut RemoteControlTargetPairingState,
+    fixture: &TargetPairingFixture,
+    started_at: InstantMillis,
+) -> (RemoteControlPairingAttemptId, RemoteControlPairingOffer) {
     let arrival = fixture.begin_arrival(0x60);
     match state.begin(
         &fixture.target_signer,
         &fixture.session,
         &arrival,
-        ATTEMPT_STARTED_AT,
+        started_at,
     ) {
         BeginRemoteControlTargetPairingOutcome::OfferPrepared {
             attempt_id,
@@ -411,6 +432,155 @@ fn attempt_windows_are_positive_bounded_by_the_pairing_window_and_overflow_safe(
             }
         ),
     );
+}
+
+#[test]
+fn begin_signs_the_timeout_that_fits_the_remaining_pairing_window() {
+    let cases = [
+        // A 120-second invitation with a configured 60-second attempt.
+        (1_000, 121_000, 1_000, 60_000, 61_000),
+        (1_000, 121_000, 61_000, 60_000, 121_000),
+        (1_000, 121_000, 76_000, 45_000, 121_000),
+        (1_000, 121_000, 120_999, 1, 121_000),
+        // Bound before adding, so a still-open near-MAX window cannot overflow.
+        (
+            u64::MAX - 120_000,
+            u64::MAX,
+            u64::MAX - 45_000,
+            45_000,
+            u64::MAX,
+        ),
+        (u64::MAX - 120_000, u64::MAX, u64::MAX - 1, 1, u64::MAX),
+    ];
+    for (opened_at, expires_at, started_at, expected_timeout, expected_expiry) in cases {
+        let fixture = TargetPairingFixture::with_window(opened_at, expires_at, 60_000);
+        let mut state = RemoteControlTargetPairingState::default();
+        let (attempt_id, offer) = prepare_offer_at(&mut state, &fixture, InstantMillis(started_at));
+        let transcript = offer.verify(fixture.context(), &fixture.begin).unwrap();
+        let window = attempt_view(&state).window();
+
+        assert_eq!(
+            offer.attempt_timeout().duration(),
+            DurationMillis(expected_timeout)
+        );
+        assert_eq!(transcript.attempt_timeout(), offer.attempt_timeout());
+        assert_eq!(window.attempt_timeout(), offer.attempt_timeout());
+        assert_eq!(window.expires_at(), InstantMillis(expected_expiry));
+        assert_eq!(window.started_at(), InstantMillis(started_at));
+        assert_eq!(attempt_id, RemoteControlPairingAttemptId::from(&transcript));
+        assert_eq!(
+            fixture.session.attempt_timeout().duration(),
+            DurationMillis(60_000)
+        );
+        assert!(window.expires_at() > window.started_at());
+        assert!(window.expires_at() <= fixture.session.window().expires_at());
+    }
+}
+
+#[test]
+fn begin_still_refuses_elapsed_pairing_windows_without_an_offer() {
+    for (opened_at, expires_at, started_at) in [
+        (1_000, 121_000, 121_000),
+        (1_000, 121_000, 121_001),
+        (u64::MAX - 120_000, u64::MAX, u64::MAX),
+    ] {
+        let fixture = TargetPairingFixture::with_window(opened_at, expires_at, 60_000);
+        let mut state = RemoteControlTargetPairingState::default();
+        assert_eq!(
+            state.begin(
+                &fixture.target_signer,
+                &fixture.session,
+                &fixture.begin_arrival(0x60),
+                InstantMillis(started_at),
+            ),
+            BeginRemoteControlTargetPairingOutcome::PairingUnavailable {
+                reason: RemoteControlTargetPairingAttemptWindowError::PairingWindowElapsed {
+                    started_at: InstantMillis(started_at),
+                    pairing_expires_at: InstantMillis(expires_at),
+                },
+            },
+        );
+        assert_eq!(state.view(), RemoteControlTargetPairingView::Idle);
+    }
+}
+
+#[test]
+fn late_attempt_confirmation_expires_at_the_original_pairing_deadline() {
+    let fixture = TargetPairingFixture::with_window(1_000, 121_000, 60_000);
+    let mut state = RemoteControlTargetPairingState::default();
+    let (attempt_id, _) = prepare_offer_at(&mut state, &fixture, InstantMillis(76_000));
+    assert!(matches!(
+        state.offer_dispatched(attempt_id),
+        DispatchRemoteControlTargetPairingOfferOutcome::AwaitingConfirmation { .. }
+    ));
+    assert_eq!(
+        state.expire(InstantMillis(120_999)),
+        ExpireRemoteControlTargetPairingOutcome::NotDue {
+            expires_at: InstantMillis(121_000)
+        },
+    );
+    assert_eq!(
+        state.approve(attempt_id, InstantMillis(121_000)),
+        ApproveRemoteControlTargetPairingOutcome::Expired {
+            expired: RemoteControlTargetPairingAborted::AwaitingBoth {
+                attempt_id,
+                context: fixture.context(),
+            },
+        },
+    );
+    assert_eq!(state.view(), RemoteControlTargetPairingView::Idle);
+}
+
+#[test]
+fn late_attempt_authorization_cannot_extend_the_pairing_deadline() {
+    for persisted_at in [120_999, 121_000, 121_001] {
+        let fixture = TargetPairingFixture::with_window(1_000, 121_000, 60_000);
+        let mut state = RemoteControlTargetPairingState::default();
+        let now = InstantMillis(76_000);
+        let (attempt_id, offer) = prepare_offer_at(&mut state, &fixture, now);
+        let transcript = offer.verify(fixture.context(), &fixture.begin).unwrap();
+        state.offer_dispatched(attempt_id);
+        assert_eq!(
+            state.approve(attempt_id, now),
+            ApproveRemoteControlTargetPairingOutcome::AwaitingControllerCommit { attempt_id },
+        );
+        // Commit the actual shortened transcript, not the configured 60-second offer.
+        let arrival = RemoteControlTargetPairingCommitArrival::new(
+            RemoteControlPairingCommit::new(&transcript),
+            responder(fixture.link_id, 0x61),
+            fixture.begin.controller().identity_hash(),
+        );
+        let CommitRemoteControlTargetPairingOutcome::AuthorizationOwed { grant, .. } =
+            state.commit(arrival, now)
+        else {
+            panic!("the signed shortened offer can be committed")
+        };
+        let result = state.authorization_persisted(
+            attempt_id,
+            &fixture.target_signer,
+            InstantMillis(persisted_at),
+        );
+        if persisted_at < 121_000 {
+            assert!(matches!(
+                result,
+                PersistRemoteControlTargetPairingAuthorizationOutcome::CompletionOwed { .. }
+            ));
+            assert_eq!(
+                attempt_view(&state).window().expires_at(),
+                InstantMillis(121_000)
+            );
+        } else {
+            assert_eq!(
+                result,
+                PersistRemoteControlTargetPairingAuthorizationOutcome::AuthorizationPersistedAfterDeadline {
+                    attempt_id,
+                    context: fixture.context(),
+                    grant,
+                },
+            );
+            assert_eq!(state.view(), RemoteControlTargetPairingView::Idle);
+        }
+    }
 }
 
 #[test]

--- a/validation/manifest.toml
+++ b/validation/manifest.toml
@@ -1868,3 +1868,9 @@ name = "target_attempt_deadlines_are_strictly_future_and_pairing_bounded"
 source = "prns-core/src/remote_control/pairing/target_pairing/kani_proofs.rs"
 group = "remote-control"
 tiers = ["release", "scheduled"]
+
+[[kani]]
+name = "unexpired_pairing_windows_always_admit_a_bounded_attempt_timeout"
+source = "prns-core/src/remote_control/pairing/target_pairing/kani_proofs.rs"
+group = "remote-control"
+tiers = ["release", "scheduled"]


### PR DESCRIPTION
Cap a new pairing attempt to the invitation's remaining lifetime and sign that same timeout in the offer. Confirmation and authorization still cannot extend the original invitation deadline.

The Prns app can discover and submit an invitation shortly before expiry. It should get the time remaining rather than being rejected for having less than a full attempt window.

This branch already includes trunk `79050535f`; no history rewrite was needed. All 22 focused target-pairing tests and the validation registry pass on this head. The included Kani property has not been executed locally. Earlier full-matrix and firmware-size results belong to their recorded builds, not this refresh.
