### PR TITLE
Handle BLE notifications on Android 10–12

### DIFF
--- a/personal-hopspot/mobile/android/app/build.gradle.kts
+++ b/personal-hopspot/mobile/android/app/build.gradle.kts
@@ -124,6 +124,7 @@ tasks.register("verifyExperimentalWifiDirectDisabled")
 dependencies {
     implementation(libs.usb.serial)
     testImplementation(libs.junit)
+    testImplementation(libs.mockito.core)
 }
 
 afterEvaluate {

--- a/personal-hopspot/mobile/android/app/src/main/java/org/personal/hopspot/BleLink.kt
+++ b/personal-hopspot/mobile/android/app/src/main/java/org/personal/hopspot/BleLink.kt
@@ -1043,7 +1043,7 @@ class BleLink(private val context: Context) {
     }
 
     private fun clientCallback(connId: Int, address: String): BluetoothGattCallback =
-        object : BluetoothGattCallback() {
+        object : BleNotificationCallback() {
             override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
                 if (!running || !radioActive) {
                     runCatching { gatt.disconnect() }
@@ -1308,7 +1308,7 @@ class BleLink(private val context: Context) {
                 }
             }
 
-            override fun onCharacteristicChanged(
+            override fun onNotification(
                 gatt: BluetoothGatt,
                 characteristic: BluetoothGattCharacteristic,
                 value: ByteArray,

--- a/personal-hopspot/mobile/android/app/src/main/java/org/personal/hopspot/BleNotificationCallback.kt
+++ b/personal-hopspot/mobile/android/app/src/main/java/org/personal/hopspot/BleNotificationCallback.kt
@@ -1,0 +1,32 @@
+package org.personal.hopspot
+
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
+import android.bluetooth.BluetoothGattCharacteristic
+
+/** Delivers both pre-API-33 and current notifications through one transport handler. */
+internal abstract class BleNotificationCallback : BluetoothGattCallback() {
+    protected abstract fun onNotification(
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+        value: ByteArray,
+    )
+
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
+    final override fun onCharacteristicChanged(
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+    ) {
+        onNotification(gatt, characteristic, characteristic.value ?: ByteArray(0))
+    }
+
+    final override fun onCharacteristicChanged(
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+        value: ByteArray,
+    ) {
+        // Do not call the superclass: its modern implementation forwards to the
+        // legacy overload, which would deliver this notification a second time.
+        onNotification(gatt, characteristic, value)
+    }
+}

--- a/personal-hopspot/mobile/android/app/src/test/java/org/personal/hopspot/BleNotificationCallbackTest.kt
+++ b/personal-hopspot/mobile/android/app/src/test/java/org/personal/hopspot/BleNotificationCallbackTest.kt
@@ -1,0 +1,82 @@
+package org.personal.hopspot
+
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCharacteristic
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.mockito.Mockito.CALLS_REAL_METHODS
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+@Suppress("DEPRECATION")
+class BleNotificationCallbackTest {
+    private class RecordingCallback : BleNotificationCallback() {
+        var calls = 0
+        var receivedGatt: BluetoothGatt? = null
+        var receivedCharacteristic: BluetoothGattCharacteristic? = null
+        var receivedValue: ByteArray? = null
+
+        override fun onNotification(
+            gatt: BluetoothGatt,
+            characteristic: BluetoothGattCharacteristic,
+            value: ByteArray,
+        ) {
+            calls++
+            receivedGatt = gatt
+            receivedCharacteristic = characteristic
+            receivedValue = value
+        }
+    }
+
+    // Bypass the Android SDK stub constructor, but execute every callback and
+    // recording method normally. No device or native library is loaded.
+    private fun callback(): RecordingCallback =
+        mock(RecordingCallback::class.java, CALLS_REAL_METHODS)
+
+    @Test
+    fun legacyNotificationReachesTheTransportHandlerOnce() {
+        val gatt = mock(BluetoothGatt::class.java)
+        val characteristic = mock(BluetoothGattCharacteristic::class.java)
+        val payload = byteArrayOf(0, 1, 0x7f, 0xff.toByte())
+        `when`(characteristic.value).thenReturn(payload)
+        val callback = callback()
+
+        callback.onCharacteristicChanged(gatt, characteristic)
+
+        assertEquals(1, callback.calls)
+        assertSame(gatt, callback.receivedGatt)
+        assertSame(characteristic, callback.receivedCharacteristic)
+        assertArrayEquals(payload, callback.receivedValue)
+    }
+
+    @Test
+    fun missingLegacyValueIsDeliveredAsEmpty() {
+        val callback = callback()
+
+        callback.onCharacteristicChanged(
+            mock(BluetoothGatt::class.java),
+            mock(BluetoothGattCharacteristic::class.java),
+        )
+
+        assertEquals(1, callback.calls)
+        assertArrayEquals(byteArrayOf(), callback.receivedValue)
+    }
+
+    @Test
+    fun modernNotificationUsesItsSuppliedValueExactlyOnce() {
+        val callback = callback()
+        val gatt = mock(BluetoothGatt::class.java)
+        val characteristic = mock(BluetoothGattCharacteristic::class.java)
+        `when`(characteristic.value).thenReturn(byteArrayOf(9))
+        val payload = byteArrayOf(3, 4)
+
+        callback.onCharacteristicChanged(gatt, characteristic, payload)
+
+        assertEquals(1, callback.calls)
+        assertSame(gatt, callback.receivedGatt)
+        assertSame(characteristic, callback.receivedCharacteristic)
+        assertArrayEquals(payload, callback.receivedValue)
+    }
+}

--- a/personal-hopspot/mobile/android/gradle/libs.versions.toml
+++ b/personal-hopspot/mobile/android/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ activityCompose = "1.9.2"
 composeBom = "2024.09.00"
 usbSerial = "3.7.0"
 junit = "4.13.2"
+mockito = "5.14.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -15,6 +16,7 @@ androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
 usb-serial = { group = "com.github.mik3y", name = "usb-serial-for-android", version.ref = "usbSerial" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Handle both Android notification callback overloads through one transport handler. Personal Hopspot currently overrides only the Android 13 overload, so older devices never deliver notifications to Rust. Preserve the modern callback's supplied payload and deliver each notification once.

This surfaced during Prns app (#197) development on Android 10. The app has its own adapter; this brings the same compatibility fix to Personal Hopspot without changing the BLE protocol or radio recovery.

Rebased on current trunk. All three notification unit tests pass: legacy data, missing legacy data and modern single delivery. The normal local pre-push checks also pass, including all 14 firmware profiles within their unchanged limits. Current GitHub CI is reported separately. The earlier Android service smoke is historical, not a fresh result for this head; no new physical-device qualification is claimed.
