### PR TITLE
Refresh all affected wake schedules when a link closes

### DIFF
--- a/prns-core/src/engine/command_execution.rs
+++ b/prns-core/src/engine/command_execution.rs
@@ -1171,8 +1171,11 @@ impl<S: StorageLayout> EngineState<S> {
                     Err(_) => Settlement::CloseLink(Err(CloseLinkFailure::WriteFailed)),
                 };
                 settle(sink, id, settlement);
+                wake_schedule_changes.receipt_timeouts = self.receipt_timeouts_wake();
                 wake_schedule_changes.link_deadlines = self.link_deadlines_wake();
                 wake_schedule_changes.resource_deadlines = self.resource_deadlines_wake();
+                wake_schedule_changes.channel_timeouts = self.channel_timeouts_wake();
+                wake_schedule_changes.remote_control_pairing = self.remote_control_pairing_wake();
             }
             CommandOutcome::CloseLinkRejected { id, rejection } => {
                 settle(

--- a/prns-core/src/engine/commands/remote_control_controller_pairing.rs
+++ b/prns-core/src/engine/commands/remote_control_controller_pairing.rs
@@ -1758,6 +1758,52 @@ mod tests {
     }
 
     #[test]
+    fn a_close_link_command_refreshes_the_controller_pairing_schedule() {
+        let mut engine = engine_with_active_link();
+        configure_controller(&mut engine);
+        let (begun, begin_delta) = execute(
+            &mut engine,
+            PrnsCommand::BeginRemoteControlControllerPairing(BeginRemoteControlControllerPairing {
+                context: context(),
+                invitation_code: invitation_code(),
+                pairing_expires_at: PAIRING_EXPIRES_AT,
+            }),
+            STARTED_AT,
+        );
+        assert!(matches!(
+            begun,
+            Settlement::BeginRemoteControlControllerPairing(Ok(_))
+        ));
+        assert_eq!(
+            begin_delta.remote_control_pairing,
+            WakeSchedule::At(PAIRING_EXPIRES_AT),
+        );
+        let interfaces = [routable_descriptor(lane())];
+        let mut cached = engine.wake_schedules(AttachedInterfaces::new(&interfaces));
+        // No request is dispatched: this tests pairing-state cleanup separately
+        // from the request-receipt schedule owned by the same Link.
+        let (closed, close_delta) = execute(
+            &mut engine,
+            PrnsCommand::CloseLink(crate::engine::CloseLink {
+                link_id: context().link_id(),
+            }),
+            OFFERED_AT,
+        );
+        assert_eq!(closed, Settlement::CloseLink(Ok(())));
+        assert_eq!(
+            engine.remote_control_controller_pairing.view(),
+            RemoteControlControllerPairingView::Idle,
+        );
+        assert!(engine.links.is_empty());
+        cached.merge(close_delta);
+        assert_eq!(cached.remote_control_pairing, WakeSchedule::Idle);
+        assert_eq!(
+            cached.remote_control_pairing,
+            engine.remote_control_pairing_wake(),
+        );
+    }
+
+    #[test]
     fn retiring_the_exchange_link_aborts_and_journals_controller_pairing() {
         let mut engine = EngineState::<TestStorageLayout>::default();
         let controller = configure_controller(&mut engine);

--- a/prns-core/src/routing/links/establish/tests.rs
+++ b/prns-core/src/routing/links/establish/tests.rs
@@ -4016,6 +4016,97 @@ fn a_close_link_command_settles_and_closes_the_peer() {
 }
 
 #[test]
+fn a_close_link_command_refreshes_pending_request_and_channel_schedules() {
+    use crate::engine::{
+        CloseLink, SendRequest, SendRequestData, SendRequestFailure, SendToChannel,
+        SendToChannelBody, SendToChannelFailure,
+    };
+    use crate::routing::links::channel::MessageType;
+    use crate::routing::request_handlers::RequestPathHash;
+
+    let (mut initiator, _, link_id) = established_pair();
+    let interfaces = arrival_interfaces();
+    for (id, command) in [
+        (
+            CommandId(20),
+            PrnsCommand::SendRequest(SendRequest {
+                link_id,
+                path_hash: RequestPathHash::of("/status"),
+                data: SendRequestData::new(),
+                response_timeout: Default::default(),
+                maximum_response_bytes: Default::default(),
+            }),
+        ),
+        (
+            CommandId(21),
+            PrnsCommand::SendToChannel(SendToChannel {
+                link_id,
+                message_type: MessageType(1),
+                body: SendToChannelBody::from_slice(b"pending").unwrap(),
+            }),
+        ),
+    ] {
+        let mut sent = 0;
+        initiator.ingest_command_into(
+            IssuedCommand { id, command },
+            AttachedInterfaces::new(&interfaces),
+            InstantMillis(2_000),
+            &mut |bytes: &mut [u8]| bytes.fill(0xEA),
+            &mut |reaction| match reaction {
+                EngineReaction::Directive(Directive::EmitFrame { fill, .. }) => {
+                    assert!(filled_frame(fill).is_some());
+                    sent += 1;
+                }
+                EngineReaction::Journaled(Journaled::CommandSettled { .. }) => {
+                    panic!("the unanswered send must remain pending");
+                }
+                _ => {}
+            },
+        );
+        assert_eq!(sent, 1);
+    }
+    let mut cached = initiator.wake_schedules(AttachedInterfaces::new(&interfaces));
+    assert!(matches!(cached.receipt_timeouts, WakeSchedule::At(_)));
+    assert!(matches!(cached.channel_timeouts, WakeSchedule::At(_)));
+
+    let mut settled = std::vec::Vec::new();
+    let delta = initiator.ingest_command_into(
+        IssuedCommand {
+            id: CommandId(22),
+            command: PrnsCommand::CloseLink(CloseLink { link_id }),
+        },
+        AttachedInterfaces::new(&interfaces),
+        InstantMillis(2_001),
+        &mut |bytes: &mut [u8]| bytes.fill(0xEB),
+        &mut |reaction| {
+            if let EngineReaction::Journaled(Journaled::CommandSettled { id, settlement }) =
+                reaction
+            {
+                settled.push((id, settlement));
+            }
+        },
+    );
+    assert!(initiator.links.is_empty());
+    assert!(settled.contains(&(
+        CommandId(20),
+        Settlement::SendRequest(Err(SendRequestFailure::LinkClosed)),
+    )));
+    assert!(settled.contains(&(
+        CommandId(21),
+        Settlement::SendToChannel(Err(SendToChannelFailure::LinkClosed)),
+    )));
+    assert!(settled.contains(&(CommandId(22), Settlement::CloseLink(Ok(())))));
+    assert_eq!(settled.len(), 3, "each pending operation settles once");
+
+    cached.merge(delta);
+    assert_eq!(cached.receipt_timeouts, WakeSchedule::Idle);
+    assert_eq!(cached.channel_timeouts, WakeSchedule::Idle);
+    let truth = initiator.wake_schedules(AttachedInterfaces::new(&interfaces));
+    assert_eq!(cached.receipt_timeouts, truth.receipt_timeouts);
+    assert_eq!(cached.channel_timeouts, truth.channel_timeouts);
+}
+
+#[test]
 fn a_valid_peer_close_commits_final_route_evidence_before_removal() {
     use crate::engine::CloseLink;
 


### PR DESCRIPTION
Closing a Link can settle requests, close channels and abort pairing. Return fresh receipt, channel and pairing wake schedules with the command's delta, so the runtime does not retain deadlines for removed state.

The Prns app closes Links when a remote check is cancelled or the node stops. Correct wake bookkeeping lets that cleanup finish without waiting on obsolete work. Regressions start with real pending work, compare the delta with the engine's authoritative schedules, and preserve deadlines for work on other Links.

This branch already includes trunk `79050535f`; no history rewrite was needed. Earlier focused, no-std and firmware validation remains historical. No fresh firmware margin or physical-device result is claimed for this refresh.
